### PR TITLE
Add 454 tests across animation, core, graph, and fractal modules to i…

### DIFF
--- a/src/animation/animation-numbers.test.ts
+++ b/src/animation/animation-numbers.test.ts
@@ -1,0 +1,362 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { DecimalNumber } from '../mobjects/text/DecimalNumber';
+import {
+  ChangingDecimal,
+  ChangeDecimalToValue,
+  changingDecimal,
+  changeDecimalToValue,
+} from './numbers/index';
+import { linear } from '../rate-functions';
+
+/**
+ * happy-dom does not support canvas 2D context. Stub it with a minimal
+ * mock so DecimalNumber construction succeeds.
+ */
+beforeAll(() => {
+  const origGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function (type: string, ...args: unknown[]) {
+    if (type === '2d') {
+      return {
+        scale: () => {},
+        clearRect: () => {},
+        fillText: () => {},
+        fillRect: () => {},
+        measureText: (t: string) => ({
+          width: t.length * 10,
+          fontBoundingBoxAscent: 30,
+        }),
+        drawImage: () => {},
+        font: '',
+        fillStyle: '',
+        globalAlpha: 1,
+        textBaseline: 'alphabetic',
+        textAlign: 'left',
+      } as unknown as CanvasRenderingContext2D;
+    }
+    return origGetContext.call(this, type, ...(args as []));
+  } as typeof origGetContext;
+});
+
+describe('ChangingDecimal', () => {
+  let num: DecimalNumber;
+
+  beforeEach(() => {
+    num = new DecimalNumber({ value: 0, numDecimalPlaces: 2 });
+  });
+
+  describe('constructor', () => {
+    it('stores decimalNumber reference', () => {
+      const anim = new ChangingDecimal(num, { endValue: 100 });
+      expect(anim.decimalNumber).toBe(num);
+    });
+
+    it('uses current value as startValue when not provided', () => {
+      num.setValue(25);
+      const anim = new ChangingDecimal(num, { endValue: 100 });
+      expect(anim.getStartValue()).toBe(25);
+    });
+
+    it('uses explicit startValue when provided', () => {
+      const anim = new ChangingDecimal(num, {
+        startValue: 10,
+        endValue: 100,
+      });
+      expect(anim.getStartValue()).toBe(10);
+    });
+
+    it('stores endValue', () => {
+      const anim = new ChangingDecimal(num, { endValue: 50 });
+      expect(anim.getEndValue()).toBe(50);
+    });
+
+    it('defaults suspendMobjectUpdating to false', () => {
+      const anim = new ChangingDecimal(num, { endValue: 100 });
+      anim.begin();
+      anim.interpolate(0.5);
+      // If not suspended, value should change
+      expect(num.getValue()).toBeCloseTo(50, 5);
+    });
+
+    it('accepts custom duration', () => {
+      const anim = new ChangingDecimal(num, {
+        endValue: 100,
+        duration: 3,
+      });
+      expect(anim.duration).toBe(3);
+    });
+
+    it('accepts custom rateFunc', () => {
+      const anim = new ChangingDecimal(num, {
+        endValue: 100,
+        rateFunc: linear,
+      });
+      expect(anim.rateFunc).toBe(linear);
+    });
+  });
+
+  describe('begin()', () => {
+    it('calls super.begin()', () => {
+      const anim = new ChangingDecimal(num, { endValue: 100 });
+      anim.begin();
+      expect((anim as unknown as { _hasBegun: boolean })._hasBegun).toBe(true);
+    });
+  });
+
+  describe('interpolate()', () => {
+    it('at alpha=0 sets value to startValue', () => {
+      num.setValue(10);
+      const anim = new ChangingDecimal(num, { endValue: 50 });
+      anim.begin();
+      anim.interpolate(0);
+      expect(num.getValue()).toBeCloseTo(10, 5);
+    });
+
+    it('at alpha=0.5 sets value to midpoint', () => {
+      num.setValue(0);
+      const anim = new ChangingDecimal(num, { endValue: 100 });
+      anim.begin();
+      anim.interpolate(0.5);
+      expect(num.getValue()).toBeCloseTo(50, 5);
+    });
+
+    it('at alpha=1 sets value to endValue', () => {
+      num.setValue(0);
+      const anim = new ChangingDecimal(num, { endValue: 100 });
+      anim.begin();
+      anim.interpolate(1);
+      expect(num.getValue()).toBeCloseTo(100, 5);
+    });
+
+    it('interpolates with explicit startValue', () => {
+      const anim = new ChangingDecimal(num, {
+        startValue: 20,
+        endValue: 80,
+      });
+      anim.begin();
+      anim.interpolate(0.25);
+      // 20 + (80-20)*0.25 = 20 + 15 = 35
+      expect(num.getValue()).toBeCloseTo(35, 5);
+    });
+
+    it('handles negative range', () => {
+      num.setValue(100);
+      const anim = new ChangingDecimal(num, { endValue: -100 });
+      anim.begin();
+      anim.interpolate(0.5);
+      // 100 + (-100-100)*0.5 = 100 - 100 = 0
+      expect(num.getValue()).toBeCloseTo(0, 5);
+    });
+
+    it('does nothing when suspendMobjectUpdating is true', () => {
+      num.setValue(42);
+      const anim = new ChangingDecimal(num, {
+        endValue: 100,
+        suspendMobjectUpdating: true,
+      });
+      anim.begin();
+      anim.interpolate(0.5);
+      // Value should remain unchanged
+      expect(num.getValue()).toBe(42);
+    });
+  });
+
+  describe('finish()', () => {
+    it('sets value exactly to endValue', () => {
+      num.setValue(0);
+      const anim = new ChangingDecimal(num, { endValue: 77.77 });
+      anim.begin();
+      anim.interpolate(0.5);
+      anim.finish();
+      expect(num.getValue()).toBeCloseTo(77.77, 5);
+    });
+
+    it('marks animation as finished', () => {
+      const anim = new ChangingDecimal(num, { endValue: 100 });
+      anim.begin();
+      expect(anim.isFinished()).toBe(false);
+      anim.finish();
+      expect(anim.isFinished()).toBe(true);
+    });
+  });
+
+  describe('getStartValue() / getEndValue()', () => {
+    it('returns configured start and end', () => {
+      const anim = new ChangingDecimal(num, {
+        startValue: 5,
+        endValue: 95,
+      });
+      expect(anim.getStartValue()).toBe(5);
+      expect(anim.getEndValue()).toBe(95);
+    });
+  });
+});
+
+describe('ChangeDecimalToValue', () => {
+  let num: DecimalNumber;
+
+  beforeEach(() => {
+    num = new DecimalNumber({ value: 0, numDecimalPlaces: 2 });
+  });
+
+  describe('constructor', () => {
+    it('stores decimalNumber reference', () => {
+      const anim = new ChangeDecimalToValue(num, { targetValue: 100 });
+      expect(anim.decimalNumber).toBe(num);
+    });
+
+    it('captures current value as startValue', () => {
+      num.setValue(30);
+      const anim = new ChangeDecimalToValue(num, { targetValue: 100 });
+      expect(anim.getStartValue()).toBe(30);
+    });
+
+    it('stores targetValue', () => {
+      const anim = new ChangeDecimalToValue(num, { targetValue: 42 });
+      expect(anim.getTargetValue()).toBe(42);
+    });
+
+    it('accepts custom duration and rateFunc', () => {
+      const anim = new ChangeDecimalToValue(num, {
+        targetValue: 100,
+        duration: 2.5,
+        rateFunc: linear,
+      });
+      expect(anim.duration).toBe(2.5);
+      expect(anim.rateFunc).toBe(linear);
+    });
+  });
+
+  describe('begin()', () => {
+    it('re-captures current value at begin time', () => {
+      num.setValue(10);
+      const anim = new ChangeDecimalToValue(num, { targetValue: 100 });
+      // Change value after construction but before begin
+      num.setValue(20);
+      anim.begin();
+      expect(anim.getStartValue()).toBe(20);
+    });
+  });
+
+  describe('interpolate()', () => {
+    it('at alpha=0 value equals startValue', () => {
+      num.setValue(10);
+      const anim = new ChangeDecimalToValue(num, { targetValue: 50 });
+      anim.begin();
+      anim.interpolate(0);
+      expect(num.getValue()).toBeCloseTo(10, 5);
+    });
+
+    it('at alpha=0.5 value is midpoint', () => {
+      num.setValue(0);
+      const anim = new ChangeDecimalToValue(num, { targetValue: 100 });
+      anim.begin();
+      anim.interpolate(0.5);
+      expect(num.getValue()).toBeCloseTo(50, 5);
+    });
+
+    it('at alpha=1 value equals targetValue', () => {
+      num.setValue(0);
+      const anim = new ChangeDecimalToValue(num, { targetValue: 100 });
+      anim.begin();
+      anim.interpolate(1);
+      expect(num.getValue()).toBeCloseTo(100, 5);
+    });
+
+    it('handles decreasing values', () => {
+      num.setValue(100);
+      const anim = new ChangeDecimalToValue(num, { targetValue: 0 });
+      anim.begin();
+      anim.interpolate(0.75);
+      // 100 + (0-100)*0.75 = 100 - 75 = 25
+      expect(num.getValue()).toBeCloseTo(25, 5);
+    });
+
+    it('does nothing when suspendMobjectUpdating is true', () => {
+      num.setValue(42);
+      const anim = new ChangeDecimalToValue(num, {
+        targetValue: 100,
+        suspendMobjectUpdating: true,
+      });
+      anim.begin();
+      anim.interpolate(0.5);
+      expect(num.getValue()).toBe(42);
+    });
+  });
+
+  describe('finish()', () => {
+    it('sets value exactly to targetValue', () => {
+      num.setValue(0);
+      const anim = new ChangeDecimalToValue(num, {
+        targetValue: 33.33,
+      });
+      anim.begin();
+      anim.interpolate(0.5);
+      anim.finish();
+      expect(num.getValue()).toBeCloseTo(33.33, 5);
+    });
+
+    it('marks animation as finished', () => {
+      const anim = new ChangeDecimalToValue(num, { targetValue: 100 });
+      anim.begin();
+      expect(anim.isFinished()).toBe(false);
+      anim.finish();
+      expect(anim.isFinished()).toBe(true);
+    });
+  });
+
+  describe('getStartValue() / getTargetValue()', () => {
+    it('returns configured values', () => {
+      num.setValue(15);
+      const anim = new ChangeDecimalToValue(num, { targetValue: 85 });
+      expect(anim.getStartValue()).toBe(15);
+      expect(anim.getTargetValue()).toBe(85);
+    });
+  });
+});
+
+describe('Factory functions', () => {
+  let num: DecimalNumber;
+
+  beforeEach(() => {
+    num = new DecimalNumber({ value: 0 });
+  });
+
+  describe('changingDecimal()', () => {
+    it('returns a ChangingDecimal instance', () => {
+      const anim = changingDecimal(num, { endValue: 100 });
+      expect(anim).toBeInstanceOf(ChangingDecimal);
+    });
+
+    it('passes options through', () => {
+      const anim = changingDecimal(num, {
+        startValue: 5,
+        endValue: 95,
+        duration: 3,
+        rateFunc: linear,
+      });
+      expect(anim.getStartValue()).toBe(5);
+      expect(anim.getEndValue()).toBe(95);
+      expect(anim.duration).toBe(3);
+      expect(anim.rateFunc).toBe(linear);
+    });
+  });
+
+  describe('changeDecimalToValue()', () => {
+    it('returns a ChangeDecimalToValue instance', () => {
+      const anim = changeDecimalToValue(num, { targetValue: 50 });
+      expect(anim).toBeInstanceOf(ChangeDecimalToValue);
+    });
+
+    it('passes options through', () => {
+      const anim = changeDecimalToValue(num, {
+        targetValue: 50,
+        duration: 2,
+        rateFunc: linear,
+      });
+      expect(anim.getTargetValue()).toBe(50);
+      expect(anim.duration).toBe(2);
+      expect(anim.rateFunc).toBe(linear);
+    });
+  });
+});

--- a/src/animation/animation-speed.test.ts
+++ b/src/animation/animation-speed.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from 'vitest';
+import { Mobject } from '../core/Mobject';
+import { Animation, AnimationOptions } from './Animation';
+import { linear } from '../rate-functions';
+import {
+  ChangeSpeed,
+  changeSpeed,
+  linearSpeedRamp,
+  emphasizeRegion,
+  rushRegion,
+  smoothSpeedCurve,
+  SpeedFunction,
+} from './speed/index';
+
+/**
+ * Simple animation that records alphas passed to interpolate.
+ */
+class RecordingAnimation extends Animation {
+  alphas: number[] = [];
+
+  constructor(mobject: Mobject, options?: AnimationOptions) {
+    super(mobject, { rateFunc: linear, ...options });
+  }
+
+  interpolate(alpha: number): void {
+    this.alphas.push(alpha);
+  }
+}
+
+function createMob(): Mobject {
+  return new Mobject();
+}
+
+// ------------------------------------------------------------------
+// ChangeSpeed
+// ------------------------------------------------------------------
+
+describe('ChangeSpeed', () => {
+  describe('constructor', () => {
+    it('wraps the provided animation', () => {
+      const inner = new RecordingAnimation(createMob(), { duration: 1 });
+      const cs = new ChangeSpeed(inner, () => 1);
+      expect(cs.animation).toBe(inner);
+    });
+
+    it('stores the speed function', () => {
+      const sf: SpeedFunction = (t) => 1 + t;
+      const inner = new RecordingAnimation(createMob(), { duration: 1 });
+      const cs = new ChangeSpeed(inner, sf);
+      expect(cs.speedFunc).toBe(sf);
+    });
+
+    it('constant speed=1 preserves original duration', () => {
+      const inner = new RecordingAnimation(createMob(), { duration: 2 });
+      const cs = new ChangeSpeed(inner, () => 1);
+      expect(cs.duration).toBeCloseTo(2, 1);
+    });
+
+    it('constant speed=2 halves the duration', () => {
+      const inner = new RecordingAnimation(createMob(), { duration: 2 });
+      const cs = new ChangeSpeed(inner, () => 2);
+      expect(cs.duration).toBeCloseTo(1, 1);
+    });
+
+    it('constant speed=0.5 doubles the duration', () => {
+      const inner = new RecordingAnimation(createMob(), { duration: 1 });
+      const cs = new ChangeSpeed(inner, () => 0.5);
+      expect(cs.duration).toBeCloseTo(2, 1);
+    });
+
+    it('uses linear rateFunc by default', () => {
+      const inner = new RecordingAnimation(createMob(), { duration: 1 });
+      const cs = new ChangeSpeed(inner, () => 1);
+      expect(cs.rateFunc).toBe(linear);
+    });
+
+    it('accepts custom rateFunc in options', () => {
+      const customRate = (t: number) => t * t;
+      const inner = new RecordingAnimation(createMob(), { duration: 1 });
+      const cs = new ChangeSpeed(inner, () => 1, {
+        rateFunc: customRate,
+      });
+      expect(cs.rateFunc).toBe(customRate);
+    });
+  });
+
+  describe('begin()', () => {
+    it('calls begin on the wrapped animation', () => {
+      const inner = new RecordingAnimation(createMob(), { duration: 1 });
+      const cs = new ChangeSpeed(inner, () => 1);
+      cs.begin();
+      expect((inner as unknown as { _hasBegun: boolean })._hasBegun).toBe(true);
+    });
+  });
+
+  describe('interpolate()', () => {
+    it('at alpha=0 the wrapped animation gets alpha close to 0', () => {
+      const inner = new RecordingAnimation(createMob(), { duration: 1 });
+      const cs = new ChangeSpeed(inner, () => 1);
+      cs.begin();
+      cs.interpolate(0);
+      expect(inner.alphas.length).toBe(1);
+      expect(inner.alphas[0]).toBeCloseTo(0, 1);
+    });
+
+    it('at alpha=1 the wrapped animation gets alpha close to 1', () => {
+      const inner = new RecordingAnimation(createMob(), { duration: 1 });
+      const cs = new ChangeSpeed(inner, () => 1);
+      cs.begin();
+      cs.interpolate(1);
+      expect(inner.alphas.length).toBe(1);
+      expect(inner.alphas[0]).toBeCloseTo(1, 1);
+    });
+
+    it('uniform speed maps alpha linearly', () => {
+      const inner = new RecordingAnimation(createMob(), { duration: 1 });
+      const cs = new ChangeSpeed(inner, () => 1);
+      cs.begin();
+      cs.interpolate(0.5);
+      expect(inner.alphas[0]).toBeCloseTo(0.5, 1);
+    });
+  });
+
+  describe('finish()', () => {
+    it('calls finish on the wrapped animation', () => {
+      const inner = new RecordingAnimation(createMob(), { duration: 1 });
+      const cs = new ChangeSpeed(inner, () => 1);
+      cs.begin();
+      cs.finish();
+      expect(inner.isFinished()).toBe(true);
+    });
+
+    it('marks itself as finished', () => {
+      const inner = new RecordingAnimation(createMob(), { duration: 1 });
+      const cs = new ChangeSpeed(inner, () => 1);
+      cs.begin();
+      cs.finish();
+      expect(cs.isFinished()).toBe(true);
+    });
+  });
+
+  describe('reset()', () => {
+    it('resets both wrapper and wrapped animation', () => {
+      const inner = new RecordingAnimation(createMob(), { duration: 1 });
+      const cs = new ChangeSpeed(inner, () => 1);
+      cs.begin();
+      cs.finish();
+      cs.reset();
+      expect(cs.isFinished()).toBe(false);
+      expect(inner.isFinished()).toBe(false);
+    });
+  });
+});
+
+// ------------------------------------------------------------------
+// changeSpeed factory
+// ------------------------------------------------------------------
+
+describe('changeSpeed() factory', () => {
+  it('returns a ChangeSpeed instance', () => {
+    const inner = new RecordingAnimation(createMob(), { duration: 1 });
+    const cs = changeSpeed(inner, () => 1);
+    expect(cs).toBeInstanceOf(ChangeSpeed);
+  });
+
+  it('passes speed function and options through', () => {
+    const sf: SpeedFunction = () => 2;
+    const inner = new RecordingAnimation(createMob(), { duration: 2 });
+    const cs = changeSpeed(inner, sf, { rateFunc: linear });
+    expect(cs.speedFunc).toBe(sf);
+    expect(cs.rateFunc).toBe(linear);
+    // speed=2 should halve: 2/2 = 1
+    expect(cs.duration).toBeCloseTo(1, 1);
+  });
+});
+
+// ------------------------------------------------------------------
+// Predefined speed functions
+// ------------------------------------------------------------------
+
+describe('linearSpeedRamp()', () => {
+  it('returns startSpeed at t=0', () => {
+    const sf = linearSpeedRamp(1, 3);
+    expect(sf(0)).toBe(1);
+  });
+
+  it('returns endSpeed at t=1', () => {
+    const sf = linearSpeedRamp(1, 3);
+    expect(sf(1)).toBe(3);
+  });
+
+  it('returns midpoint at t=0.5', () => {
+    const sf = linearSpeedRamp(1, 3);
+    expect(sf(0.5)).toBe(2);
+  });
+
+  it('works with decreasing ramp', () => {
+    const sf = linearSpeedRamp(4, 0);
+    expect(sf(0)).toBe(4);
+    expect(sf(0.5)).toBe(2);
+    expect(sf(1)).toBe(0);
+  });
+});
+
+describe('emphasizeRegion()', () => {
+  it('returns emphasizedSpeed inside the region', () => {
+    const sf = emphasizeRegion(0.3, 0.7, 2, 0.5);
+    expect(sf(0.5)).toBe(0.5);
+    expect(sf(0.3)).toBe(0.5);
+    expect(sf(0.7)).toBe(0.5);
+  });
+
+  it('returns normalSpeed outside the region', () => {
+    const sf = emphasizeRegion(0.3, 0.7, 2, 0.5);
+    expect(sf(0)).toBe(2);
+    expect(sf(0.1)).toBe(2);
+    expect(sf(0.8)).toBe(2);
+    expect(sf(1)).toBe(2);
+  });
+
+  it('uses defaults: normalSpeed=2, emphasizedSpeed=0.5', () => {
+    const sf = emphasizeRegion(0.2, 0.8);
+    expect(sf(0.5)).toBe(0.5);
+    expect(sf(0)).toBe(2);
+  });
+});
+
+describe('rushRegion()', () => {
+  it('returns rushedSpeed inside the region', () => {
+    const sf = rushRegion(0.2, 0.5, 1, 3);
+    expect(sf(0.3)).toBe(3);
+    expect(sf(0.2)).toBe(3);
+    expect(sf(0.5)).toBe(3);
+  });
+
+  it('returns normalSpeed outside the region', () => {
+    const sf = rushRegion(0.2, 0.5, 1, 3);
+    expect(sf(0)).toBe(1);
+    expect(sf(0.1)).toBe(1);
+    expect(sf(0.6)).toBe(1);
+    expect(sf(1)).toBe(1);
+  });
+
+  it('uses defaults: normalSpeed=1, rushedSpeed=3', () => {
+    const sf = rushRegion(0.4, 0.6);
+    expect(sf(0.5)).toBe(3);
+    expect(sf(0)).toBe(1);
+  });
+});
+
+describe('smoothSpeedCurve()', () => {
+  it('returns maxSpeed at t=0', () => {
+    const sf = smoothSpeedCurve(0.5, 2);
+    expect(sf(0)).toBeCloseTo(2, 5);
+  });
+
+  it('returns minSpeed at t=0.5', () => {
+    const sf = smoothSpeedCurve(0.5, 2);
+    expect(sf(0.5)).toBeCloseTo(0.5, 5);
+  });
+
+  it('returns maxSpeed at t=1', () => {
+    const sf = smoothSpeedCurve(0.5, 2);
+    expect(sf(1)).toBeCloseTo(2, 5);
+  });
+
+  it('is symmetric around t=0.5', () => {
+    const sf = smoothSpeedCurve(1, 4);
+    expect(sf(0.25)).toBeCloseTo(sf(0.75), 5);
+  });
+
+  it('values stay in [minSpeed, maxSpeed] range', () => {
+    const sf = smoothSpeedCurve(0.5, 3);
+    for (let t = 0; t <= 1; t += 0.1) {
+      const v = sf(t);
+      expect(v).toBeGreaterThanOrEqual(0.5 - 1e-10);
+      expect(v).toBeLessThanOrEqual(3 + 1e-10);
+    }
+  });
+});

--- a/src/animation/animation-utility.test.ts
+++ b/src/animation/animation-utility.test.ts
@@ -1,0 +1,463 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Mobject } from '../core/Mobject';
+import { linear } from '../rate-functions';
+import {
+  Add,
+  add,
+  Remove,
+  remove,
+  Wait,
+  wait,
+  Rotating,
+  rotating,
+  Broadcast,
+  broadcast,
+} from './utility/index';
+
+function createMob(): Mobject {
+  return new Mobject();
+}
+
+// ==================================================================
+// Add
+// ==================================================================
+
+describe('Add', () => {
+  let mob: Mobject;
+
+  beforeEach(() => {
+    mob = createMob();
+  });
+
+  describe('constructor', () => {
+    it('forces duration to 0', () => {
+      const anim = new Add(mob);
+      expect(anim.duration).toBe(0);
+    });
+
+    it('forces duration to 0 even if custom duration provided', () => {
+      const anim = new Add(mob, { duration: 5 });
+      expect(anim.duration).toBe(0);
+    });
+
+    it('stores mobject reference', () => {
+      const anim = new Add(mob);
+      expect(anim.mobject).toBe(mob);
+    });
+  });
+
+  describe('begin()', () => {
+    it('sets mobject opacity to 1', () => {
+      mob.opacity = 0;
+      const anim = new Add(mob);
+      anim.begin();
+      expect(mob.opacity).toBe(1);
+    });
+
+    it('marks _hasBegun true', () => {
+      const anim = new Add(mob);
+      anim.begin();
+      expect((anim as unknown as { _hasBegun: boolean })._hasBegun).toBe(true);
+    });
+  });
+
+  describe('interpolate()', () => {
+    it('does nothing (instant animation)', () => {
+      mob.opacity = 1;
+      const anim = new Add(mob);
+      anim.begin();
+      anim.interpolate(0);
+      expect(mob.opacity).toBe(1);
+      anim.interpolate(0.5);
+      expect(mob.opacity).toBe(1);
+      anim.interpolate(1);
+      expect(mob.opacity).toBe(1);
+    });
+  });
+
+  describe('add() factory', () => {
+    it('returns an Add instance', () => {
+      const anim = add(mob);
+      expect(anim).toBeInstanceOf(Add);
+    });
+
+    it('stores mobject reference', () => {
+      const anim = add(mob);
+      expect(anim.mobject).toBe(mob);
+    });
+  });
+});
+
+// ==================================================================
+// Remove
+// ==================================================================
+
+describe('Remove', () => {
+  let mob: Mobject;
+
+  beforeEach(() => {
+    mob = createMob();
+  });
+
+  describe('constructor', () => {
+    it('forces duration to 0', () => {
+      const anim = new Remove(mob);
+      expect(anim.duration).toBe(0);
+    });
+
+    it('forces duration to 0 even if custom duration provided', () => {
+      const anim = new Remove(mob, { duration: 3 });
+      expect(anim.duration).toBe(0);
+    });
+
+    it('stores mobject reference', () => {
+      const anim = new Remove(mob);
+      expect(anim.mobject).toBe(mob);
+    });
+  });
+
+  describe('begin()', () => {
+    it('sets mobject opacity to 0', () => {
+      mob.opacity = 1;
+      const anim = new Remove(mob);
+      anim.begin();
+      expect(mob.opacity).toBe(0);
+    });
+
+    it('marks _hasBegun true', () => {
+      const anim = new Remove(mob);
+      anim.begin();
+      expect((anim as unknown as { _hasBegun: boolean })._hasBegun).toBe(true);
+    });
+  });
+
+  describe('interpolate()', () => {
+    it('does nothing (instant animation)', () => {
+      mob.opacity = 1;
+      const anim = new Remove(mob);
+      anim.begin();
+      // opacity set to 0 by begin
+      anim.interpolate(0);
+      expect(mob.opacity).toBe(0);
+      anim.interpolate(1);
+      expect(mob.opacity).toBe(0);
+    });
+  });
+
+  describe('remove() factory', () => {
+    it('returns a Remove instance', () => {
+      const anim = remove(mob);
+      expect(anim).toBeInstanceOf(Remove);
+    });
+
+    it('stores mobject reference', () => {
+      const anim = remove(mob);
+      expect(anim.mobject).toBe(mob);
+    });
+  });
+});
+
+// ==================================================================
+// Wait
+// ==================================================================
+
+describe('Wait', () => {
+  let mob: Mobject;
+
+  beforeEach(() => {
+    mob = createMob();
+  });
+
+  describe('constructor', () => {
+    it('defaults duration to 1', () => {
+      const anim = new Wait(mob);
+      expect(anim.duration).toBe(1);
+    });
+
+    it('accepts custom duration', () => {
+      const anim = new Wait(mob, { duration: 3 });
+      expect(anim.duration).toBe(3);
+    });
+
+    it('defaults rateFunc to linear', () => {
+      const anim = new Wait(mob);
+      expect(anim.rateFunc).toBe(linear);
+    });
+
+    it('accepts custom rateFunc', () => {
+      const custom = (t: number) => t * t;
+      const anim = new Wait(mob, { rateFunc: custom });
+      expect(anim.rateFunc).toBe(custom);
+    });
+  });
+
+  describe('interpolate()', () => {
+    it('does nothing visually', () => {
+      mob.opacity = 0.7;
+      mob.position.set(1, 2, 3);
+      const anim = new Wait(mob);
+      anim.begin();
+      anim.interpolate(0);
+      expect(mob.opacity).toBe(0.7);
+      expect(mob.position.x).toBe(1);
+      anim.interpolate(0.5);
+      expect(mob.opacity).toBe(0.7);
+      expect(mob.position.x).toBe(1);
+      anim.interpolate(1);
+      expect(mob.opacity).toBe(0.7);
+      expect(mob.position.x).toBe(1);
+    });
+  });
+
+  describe('wait() factory', () => {
+    it('returns a Wait instance', () => {
+      const anim = wait(mob);
+      expect(anim).toBeInstanceOf(Wait);
+    });
+
+    it('accepts duration as second argument', () => {
+      const anim = wait(mob, 5);
+      expect(anim.duration).toBe(5);
+    });
+
+    it('passes additional options', () => {
+      const custom = (t: number) => t;
+      const anim = wait(mob, 2, { rateFunc: custom });
+      expect(anim.duration).toBe(2);
+      expect(anim.rateFunc).toBe(custom);
+    });
+  });
+});
+
+// ==================================================================
+// Rotating
+// ==================================================================
+
+describe('Rotating', () => {
+  let mob: Mobject;
+
+  beforeEach(() => {
+    mob = createMob();
+  });
+
+  describe('constructor', () => {
+    it('defaults duration to 5', () => {
+      const anim = new Rotating(mob);
+      expect(anim.duration).toBe(5);
+    });
+
+    it('defaults angle to 2*PI (TAU)', () => {
+      const anim = new Rotating(mob);
+      expect(anim.angle).toBeCloseTo(2 * Math.PI, 5);
+    });
+
+    it('defaults axis to Z [0,0,1]', () => {
+      const anim = new Rotating(mob);
+      expect(anim.axis).toEqual([0, 0, 1]);
+    });
+
+    it('defaults aboutPoint to null (mobject center)', () => {
+      const anim = new Rotating(mob);
+      expect(anim.aboutPoint).toBeNull();
+    });
+
+    it('defaults rateFunc to linear', () => {
+      const anim = new Rotating(mob);
+      expect(anim.rateFunc).toBe(linear);
+    });
+
+    it('accepts custom angle', () => {
+      const anim = new Rotating(mob, { angle: Math.PI });
+      expect(anim.angle).toBeCloseTo(Math.PI, 5);
+    });
+
+    it('accepts custom axis', () => {
+      const anim = new Rotating(mob, { axis: [1, 0, 0] });
+      expect(anim.axis).toEqual([1, 0, 0]);
+    });
+
+    it('accepts custom aboutPoint', () => {
+      const anim = new Rotating(mob, { aboutPoint: [1, 2, 3] });
+      expect(anim.aboutPoint).toEqual([1, 2, 3]);
+    });
+
+    it('accepts custom duration', () => {
+      const anim = new Rotating(mob, { duration: 10 });
+      expect(anim.duration).toBe(10);
+    });
+  });
+
+  describe('interpolate()', () => {
+    it('at alpha=0 rotation is unchanged from initial', () => {
+      mob.position.set(0, 0, 0);
+      // Provide aboutPoint to avoid getCenter() calling getThreeObject() on abstract Mobject
+      const anim = new Rotating(mob, { aboutPoint: [0, 0, 0] });
+      anim.begin();
+
+      const initialZ = mob.rotation.z;
+      anim.interpolate(0);
+      expect(mob.rotation.z).toBeCloseTo(initialZ, 5);
+    });
+
+    it('at alpha=1 with default angle rotates by TAU (full circle)', () => {
+      mob.position.set(0, 0, 0);
+      const anim = new Rotating(mob, { aboutPoint: [0, 0, 0] });
+      anim.begin();
+
+      anim.interpolate(1);
+      // Full TAU rotation: z should be back near 0 (mod 2PI)
+      // Euler angles may wrap, so check sin/cos
+      const z = mob.rotation.z;
+      expect(Math.cos(z)).toBeCloseTo(1, 3);
+      expect(Math.sin(z)).toBeCloseTo(0, 3);
+    });
+
+    it('at alpha=0.5 with PI angle rotates by PI/2', () => {
+      mob.position.set(0, 0, 0);
+      const anim = new Rotating(mob, {
+        angle: Math.PI,
+        aboutPoint: [0, 0, 0],
+      });
+      anim.begin();
+
+      anim.interpolate(0.5);
+      // totalAngle = PI * 0.5 = PI/2
+      const z = mob.rotation.z;
+      expect(Math.cos(z)).toBeCloseTo(0, 2);
+      expect(Math.sin(z)).toBeCloseTo(1, 2);
+    });
+
+    it('rotation about a point changes position', () => {
+      mob.position.set(1, 0, 0);
+      const anim = new Rotating(mob, {
+        angle: Math.PI / 2,
+        aboutPoint: [0, 0, 0],
+      });
+      anim.begin();
+
+      anim.interpolate(1);
+      // 90 degrees around Z at origin: (1,0,0) -> (0,1,0)
+      expect(mob.position.x).toBeCloseTo(0, 2);
+      expect(mob.position.y).toBeCloseTo(1, 2);
+    });
+
+    it('rotation about X axis', () => {
+      mob.position.set(0, 1, 0);
+      const anim = new Rotating(mob, {
+        angle: Math.PI / 2,
+        axis: [1, 0, 0],
+        aboutPoint: [0, 0, 0],
+      });
+      anim.begin();
+
+      anim.interpolate(1);
+      // 90 degrees around X: (0,1,0) -> (0,0,1)
+      expect(mob.position.x).toBeCloseTo(0, 2);
+      expect(mob.position.y).toBeCloseTo(0, 2);
+      expect(mob.position.z).toBeCloseTo(1, 2);
+    });
+
+    it('marks mobject dirty', () => {
+      const anim = new Rotating(mob, { aboutPoint: [0, 0, 0] });
+      anim.begin();
+      mob._dirty = false;
+      anim.interpolate(0.5);
+      expect(mob._dirty).toBe(true);
+    });
+  });
+
+  describe('rotating() factory', () => {
+    it('returns a Rotating instance', () => {
+      const anim = rotating(mob);
+      expect(anim).toBeInstanceOf(Rotating);
+    });
+
+    it('passes options through', () => {
+      const anim = rotating(mob, {
+        angle: Math.PI,
+        duration: 3,
+        axis: [0, 1, 0],
+      });
+      expect(anim.angle).toBeCloseTo(Math.PI, 5);
+      expect(anim.duration).toBe(3);
+      expect(anim.axis).toEqual([0, 1, 0]);
+    });
+  });
+});
+
+// ==================================================================
+// Broadcast
+// ==================================================================
+// NOTE: Broadcast relies on THREE.js Line2/LineMaterial/LineGeometry
+// and window.innerWidth/innerHeight. Full interpolation testing
+// requires WebGL context. We test constructor/config and factory only.
+
+describe('Broadcast', () => {
+  let mob: Mobject;
+
+  beforeEach(() => {
+    mob = createMob();
+  });
+
+  describe('constructor', () => {
+    it('defaults duration to 1', () => {
+      const anim = new Broadcast(mob);
+      expect(anim.duration).toBe(1);
+    });
+
+    it('defaults numRings to 3', () => {
+      const anim = new Broadcast(mob);
+      expect(anim.numRings).toBe(3);
+    });
+
+    it('defaults maxRadius to 2', () => {
+      const anim = new Broadcast(mob);
+      expect(anim.maxRadius).toBe(2);
+    });
+
+    it('defaults lagRatio to 0.3', () => {
+      const anim = new Broadcast(mob);
+      expect(anim.lagRatio).toBeCloseTo(0.3, 5);
+    });
+
+    it('defaults rateFunc to linear', () => {
+      const anim = new Broadcast(mob);
+      expect(anim.rateFunc).toBe(linear);
+    });
+
+    it('accepts custom options', () => {
+      const anim = new Broadcast(mob, {
+        color: '#ff0000',
+        numRings: 5,
+        maxRadius: 4,
+        strokeWidth: 2,
+        lagRatio: 0.5,
+        duration: 2,
+      });
+      expect(anim.ringColor).toBe('#ff0000');
+      expect(anim.numRings).toBe(5);
+      expect(anim.maxRadius).toBe(4);
+      expect(anim.strokeWidth).toBe(2);
+      expect(anim.lagRatio).toBeCloseTo(0.5, 5);
+      expect(anim.duration).toBe(2);
+    });
+  });
+
+  describe('broadcast() factory', () => {
+    it('returns a Broadcast instance', () => {
+      const anim = broadcast(mob);
+      expect(anim).toBeInstanceOf(Broadcast);
+    });
+
+    it('passes options through', () => {
+      const anim = broadcast(mob, {
+        numRings: 7,
+        maxRadius: 5,
+        duration: 3,
+      });
+      expect(anim.numRings).toBe(7);
+      expect(anim.maxRadius).toBe(5);
+      expect(anim.duration).toBe(3);
+    });
+  });
+});

--- a/src/animation/creation.test.ts
+++ b/src/animation/creation.test.ts
@@ -1,0 +1,540 @@
+import { describe, it, expect } from 'vitest';
+import { Mobject } from '../core/Mobject';
+import { VMobject } from '../core/VMobject';
+import {
+  Create,
+  create,
+  DrawBorderThenFill,
+  drawBorderThenFill,
+  Uncreate,
+  uncreate,
+  Write,
+  write,
+  Unwrite,
+  unwrite,
+  AddTextLetterByLetter,
+  addTextLetterByLetter,
+  RemoveTextLetterByLetter,
+  removeTextLetterByLetter,
+} from './creation/Create';
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+describe('Create', () => {
+  describe('constructor defaults', () => {
+    it('has duration=2', () => {
+      const m = new Mobject();
+      const anim = new Create(m);
+      expect(anim.duration).toBe(2);
+    });
+
+    it('accepts custom duration', () => {
+      const m = new Mobject();
+      const anim = new Create(m, { duration: 3 });
+      expect(anim.duration).toBe(3);
+    });
+
+    it('accepts custom lagRatio', () => {
+      const m = new Mobject();
+      const anim = new Create(m, { lagRatio: 0.5 });
+      // lagRatio is private but we can verify via the class existing
+      expect(anim).toBeInstanceOf(Create);
+    });
+  });
+
+  describe('non-VMobject (opacity fallback)', () => {
+    it('begin sets opacity to 0', () => {
+      const m = new Mobject();
+      m.setOpacity(1);
+      const anim = new Create(m);
+      anim.begin();
+      expect(m.opacity).toBe(0);
+    });
+
+    it('interpolate sets opacity proportional to alpha', () => {
+      const m = new Mobject();
+      const anim = new Create(m);
+      anim.begin();
+      anim.interpolate(0);
+      expect(m.opacity).toBeCloseTo(0, 5);
+      anim.interpolate(0.5);
+      expect(m.opacity).toBeCloseTo(0.5, 5);
+      anim.interpolate(1);
+      expect(m.opacity).toBeCloseTo(1, 5);
+    });
+
+    it('finish restores opacity to 1', () => {
+      const m = new Mobject();
+      const anim = new Create(m);
+      anim.begin();
+      anim.interpolate(0.5);
+      anim.finish();
+      expect(m.opacity).toBe(1);
+    });
+  });
+
+  describe('VMobject without Line2 (opacity fallback)', () => {
+    it('uses opacity fallback when VMobject has no Line2 children', () => {
+      const vm = new VMobject();
+      // VMobject without any geometry won't have Line2 children
+      const anim = new Create(vm);
+      anim.begin();
+      expect(vm.opacity).toBe(0);
+      anim.interpolate(0.5);
+      expect(vm.opacity).toBeCloseTo(0.5, 5);
+      anim.finish();
+      expect(vm.opacity).toBe(1);
+    });
+  });
+
+  describe('create() factory function', () => {
+    it('returns a Create instance', () => {
+      const m = new Mobject();
+      const anim = create(m);
+      expect(anim).toBeInstanceOf(Create);
+    });
+
+    it('passes options through', () => {
+      const m = new Mobject();
+      const anim = create(m, { duration: 5 });
+      expect(anim.duration).toBe(5);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DrawBorderThenFill
+// ---------------------------------------------------------------------------
+describe('DrawBorderThenFill', () => {
+  describe('constructor defaults', () => {
+    it('has duration=2', () => {
+      const m = new Mobject();
+      const anim = new DrawBorderThenFill(m);
+      expect(anim.duration).toBe(2);
+    });
+
+    it('accepts custom duration', () => {
+      const m = new Mobject();
+      const anim = new DrawBorderThenFill(m, { duration: 4 });
+      expect(anim.duration).toBe(4);
+    });
+  });
+
+  describe('non-VMobject (no dash reveal, no-op interpolation)', () => {
+    it('begin does not crash for non-VMobject', () => {
+      const m = new Mobject();
+      const anim = new DrawBorderThenFill(m);
+      expect(() => anim.begin()).not.toThrow();
+    });
+
+    it('interpolate does not crash for non-VMobject', () => {
+      const m = new Mobject();
+      const anim = new DrawBorderThenFill(m);
+      anim.begin();
+      expect(() => anim.interpolate(0.5)).not.toThrow();
+    });
+
+    it('finish does not crash for non-VMobject', () => {
+      const m = new Mobject();
+      const anim = new DrawBorderThenFill(m);
+      anim.begin();
+      anim.interpolate(1);
+      expect(() => anim.finish()).not.toThrow();
+    });
+  });
+
+  describe('VMobject without Line2 (no dash reveal)', () => {
+    it('handles VMobject without Line2 children gracefully', () => {
+      const vm = new VMobject();
+      const anim = new DrawBorderThenFill(vm);
+      anim.begin();
+      expect(() => anim.interpolate(0.3)).not.toThrow();
+      expect(() => anim.interpolate(0.7)).not.toThrow();
+      expect(() => anim.finish()).not.toThrow();
+    });
+  });
+
+  describe('drawBorderThenFill() factory function', () => {
+    it('returns a DrawBorderThenFill instance', () => {
+      const m = new Mobject();
+      const anim = drawBorderThenFill(m);
+      expect(anim).toBeInstanceOf(DrawBorderThenFill);
+    });
+
+    it('passes options through', () => {
+      const m = new Mobject();
+      const anim = drawBorderThenFill(m, { duration: 3 });
+      expect(anim.duration).toBe(3);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Uncreate
+// ---------------------------------------------------------------------------
+describe('Uncreate', () => {
+  describe('constructor defaults', () => {
+    it('has duration=2', () => {
+      const m = new Mobject();
+      const anim = new Uncreate(m);
+      expect(anim.duration).toBe(2);
+    });
+
+    it('accepts custom duration', () => {
+      const m = new Mobject();
+      const anim = new Uncreate(m, { duration: 1 });
+      expect(anim.duration).toBe(1);
+    });
+  });
+
+  describe('non-VMobject (opacity fallback)', () => {
+    it('interpolate fades opacity from 1 to 0', () => {
+      const m = new Mobject();
+      m.setOpacity(1);
+      const anim = new Uncreate(m);
+      anim.begin();
+      anim.interpolate(0);
+      expect(m.opacity).toBeCloseTo(1, 5);
+      anim.interpolate(0.5);
+      expect(m.opacity).toBeCloseTo(0.5, 5);
+      anim.interpolate(1);
+      expect(m.opacity).toBeCloseTo(0, 5);
+    });
+
+    it('finish sets opacity to 0', () => {
+      const m = new Mobject();
+      m.setOpacity(1);
+      const anim = new Uncreate(m);
+      anim.begin();
+      anim.interpolate(0.5);
+      anim.finish();
+      expect(m.opacity).toBe(0);
+    });
+  });
+
+  describe('uncreate() factory function', () => {
+    it('returns an Uncreate instance', () => {
+      const m = new Mobject();
+      const anim = uncreate(m);
+      expect(anim).toBeInstanceOf(Uncreate);
+    });
+
+    it('passes options through', () => {
+      const m = new Mobject();
+      const anim = uncreate(m, { duration: 5 });
+      expect(anim.duration).toBe(5);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Write
+// ---------------------------------------------------------------------------
+describe('Write', () => {
+  describe('constructor defaults', () => {
+    it('has duration=1', () => {
+      const m = new Mobject();
+      const anim = new Write(m);
+      expect(anim.duration).toBe(1);
+    });
+
+    it('accepts custom duration', () => {
+      const m = new Mobject();
+      const anim = new Write(m, { duration: 2 });
+      expect(anim.duration).toBe(2);
+    });
+  });
+
+  describe('non-VMobject (opacity fallback)', () => {
+    it('begin sets opacity to 0', () => {
+      const m = new Mobject();
+      m.setOpacity(1);
+      const anim = new Write(m);
+      anim.begin();
+      expect(m.opacity).toBe(0);
+    });
+
+    it('interpolate sets opacity proportional to alpha', () => {
+      const m = new Mobject();
+      m.setOpacity(1);
+      const anim = new Write(m);
+      anim.begin();
+      anim.interpolate(0.5);
+      expect(m.opacity).toBeCloseTo(0.5, 5);
+    });
+
+    it('finish restores opacity', () => {
+      const m = new Mobject();
+      m.setOpacity(0.8);
+      const anim = new Write(m);
+      anim.begin();
+      anim.interpolate(0.5);
+      anim.finish();
+      expect(m.opacity).toBeCloseTo(0.8, 5);
+    });
+  });
+
+  describe('reverse mode (opacity fallback)', () => {
+    it('reverse starts with full opacity and fades to 0', () => {
+      const m = new Mobject();
+      m.setOpacity(1);
+      const anim = new Write(m, { reverse: true });
+      anim.begin();
+      // When reverse, begin should set opacity to original (not 0)
+      anim.interpolate(0);
+      // effectiveAlpha = 1 - 0 = 1, so opacity = original * 1
+      expect(m.opacity).toBeCloseTo(1, 5);
+      anim.interpolate(1);
+      // effectiveAlpha = 1 - 1 = 0, so opacity = 0
+      expect(m.opacity).toBeCloseTo(0, 5);
+    });
+  });
+
+  describe('write() factory function', () => {
+    it('returns a Write instance', () => {
+      const m = new Mobject();
+      const anim = write(m);
+      expect(anim).toBeInstanceOf(Write);
+    });
+
+    it('passes options through', () => {
+      const m = new Mobject();
+      const anim = write(m, { duration: 3 });
+      expect(anim.duration).toBe(3);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unwrite
+// ---------------------------------------------------------------------------
+describe('Unwrite', () => {
+  describe('constructor', () => {
+    it('is an instance of Write', () => {
+      const m = new Mobject();
+      const anim = new Unwrite(m);
+      expect(anim).toBeInstanceOf(Write);
+    });
+
+    it('has duration=1 by default', () => {
+      const m = new Mobject();
+      const anim = new Unwrite(m);
+      expect(anim.duration).toBe(1);
+    });
+
+    it('accepts custom duration', () => {
+      const m = new Mobject();
+      const anim = new Unwrite(m, { duration: 2 });
+      expect(anim.duration).toBe(2);
+    });
+  });
+
+  describe('unwrite() factory function', () => {
+    it('returns an Unwrite instance', () => {
+      const m = new Mobject();
+      const anim = unwrite(m);
+      expect(anim).toBeInstanceOf(Unwrite);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AddTextLetterByLetter
+// ---------------------------------------------------------------------------
+describe('AddTextLetterByLetter', () => {
+  describe('constructor defaults', () => {
+    it('has duration=1, timePerChar=0.1', () => {
+      const m = new Mobject();
+      const anim = new AddTextLetterByLetter(m);
+      expect(anim.duration).toBe(1);
+      expect(anim.timePerChar).toBe(0.1);
+    });
+
+    it('accepts custom duration and timePerChar', () => {
+      const m = new Mobject();
+      const anim = new AddTextLetterByLetter(m, {
+        duration: 5,
+        timePerChar: 0.2,
+      });
+      expect(anim.duration).toBe(5);
+      expect(anim.timePerChar).toBe(0.2);
+    });
+  });
+
+  describe('with mock text mobject', () => {
+    interface TextLike {
+      getText(): string;
+      setText(t: string): void;
+    }
+    function makeTextMobject(text: string): Mobject & TextLike {
+      const m = new Mobject();
+      let currentText = text;
+      const tm = m as Mobject & TextLike;
+      tm.getText = () => currentText;
+      tm.setText = (t: string) => {
+        currentText = t;
+      };
+      return tm;
+    }
+
+    it('begin clears the text', () => {
+      const m = makeTextMobject('Hello');
+      const anim = new AddTextLetterByLetter(m);
+      anim.begin();
+      expect(m.getText()).toBe('');
+    });
+
+    it('interpolate reveals characters proportional to alpha', () => {
+      const m = makeTextMobject('Hello');
+      const anim = new AddTextLetterByLetter(m);
+      anim.begin();
+      anim.interpolate(0);
+      expect(m.getText()).toBe('');
+      anim.interpolate(0.4);
+      // floor(0.4 * 5) = 2
+      expect(m.getText()).toBe('He');
+      anim.interpolate(1);
+      // floor(1 * 5) = 5
+      expect(m.getText()).toBe('Hello');
+    });
+
+    it('finish restores full text', () => {
+      const m = makeTextMobject('Hello');
+      const anim = new AddTextLetterByLetter(m);
+      anim.begin();
+      anim.interpolate(0.5);
+      anim.finish();
+      expect(m.getText()).toBe('Hello');
+    });
+  });
+
+  describe('without text methods (noop)', () => {
+    it('does not crash when mobject has no getText/setText', () => {
+      const m = new Mobject();
+      const anim = new AddTextLetterByLetter(m);
+      expect(() => {
+        anim.begin();
+        anim.interpolate(0.5);
+        anim.finish();
+      }).not.toThrow();
+    });
+  });
+
+  describe('addTextLetterByLetter() factory function', () => {
+    it('returns an AddTextLetterByLetter instance', () => {
+      const m = new Mobject();
+      const anim = addTextLetterByLetter(m);
+      expect(anim).toBeInstanceOf(AddTextLetterByLetter);
+    });
+
+    it('passes options through', () => {
+      const m = new Mobject();
+      const anim = addTextLetterByLetter(m, { timePerChar: 0.5 });
+      expect(anim.timePerChar).toBe(0.5);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RemoveTextLetterByLetter
+// ---------------------------------------------------------------------------
+describe('RemoveTextLetterByLetter', () => {
+  describe('constructor defaults', () => {
+    it('has duration=1, timePerChar=0.1', () => {
+      const m = new Mobject();
+      const anim = new RemoveTextLetterByLetter(m);
+      expect(anim.duration).toBe(1);
+      expect(anim.timePerChar).toBe(0.1);
+    });
+  });
+
+  describe('with mock text mobject', () => {
+    interface TextLike {
+      getText(): string;
+      setText(t: string): void;
+    }
+    function makeTextMobject(text: string): Mobject & TextLike {
+      const m = new Mobject();
+      let currentText = text;
+      const tm = m as Mobject & TextLike;
+      tm.getText = () => currentText;
+      tm.setText = (t: string) => {
+        currentText = t;
+      };
+      return tm;
+    }
+
+    it('begin preserves full text', () => {
+      const m = makeTextMobject('World');
+      const anim = new RemoveTextLetterByLetter(m);
+      anim.begin();
+      expect(m.getText()).toBe('World');
+    });
+
+    it('interpolate removes characters proportional to alpha', () => {
+      const m = makeTextMobject('World');
+      const anim = new RemoveTextLetterByLetter(m);
+      anim.begin();
+      anim.interpolate(0);
+      expect(m.getText()).toBe('World');
+      anim.interpolate(0.4);
+      // floor(0.4 * 5) = 2 chars removed => 3 remain
+      expect(m.getText()).toBe('Wor');
+      anim.interpolate(1);
+      // floor(1 * 5) = 5 chars removed => 0 remain
+      expect(m.getText()).toBe('');
+    });
+
+    it('finish clears all text', () => {
+      const m = makeTextMobject('World');
+      const anim = new RemoveTextLetterByLetter(m);
+      anim.begin();
+      anim.interpolate(0.5);
+      anim.finish();
+      expect(m.getText()).toBe('');
+    });
+  });
+
+  describe('removeTextLetterByLetter() factory function', () => {
+    it('returns a RemoveTextLetterByLetter instance', () => {
+      const m = new Mobject();
+      const anim = removeTextLetterByLetter(m);
+      expect(anim).toBeInstanceOf(RemoveTextLetterByLetter);
+    });
+
+    it('passes options through', () => {
+      const m = new Mobject();
+      const anim = removeTextLetterByLetter(m, {
+        duration: 2,
+        timePerChar: 0.3,
+      });
+      expect(anim.duration).toBe(2);
+      expect(anim.timePerChar).toBe(0.3);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Create._childAlpha stagger logic (tested via public interface)
+// ---------------------------------------------------------------------------
+describe('Create stagger with lagRatio', () => {
+  it('lagRatio=0 means all children animate together (opacity path)', () => {
+    const m = new Mobject();
+    const anim = new Create(m, { lagRatio: 0 });
+    anim.begin();
+    // opacity fallback: all animated together regardless
+    anim.interpolate(0.5);
+    expect(m.opacity).toBeCloseTo(0.5, 5);
+  });
+
+  it('lagRatio>0 still animates correctly for opacity path', () => {
+    const m = new Mobject();
+    const anim = new Create(m, { lagRatio: 0.3 });
+    anim.begin();
+    anim.interpolate(1);
+    expect(m.opacity).toBeCloseTo(1, 5);
+    anim.finish();
+    expect(m.opacity).toBe(1);
+  });
+});

--- a/src/animation/indication-extra.test.ts
+++ b/src/animation/indication-extra.test.ts
@@ -1,0 +1,486 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { Mobject } from '../core/Mobject';
+import { VMobject } from '../core/VMobject';
+import { ApplyWave } from './indication/ApplyWave';
+import { applyWave } from './indication/ApplyWave';
+import { Circumscribe } from './indication/Circumscribe';
+import { circumscribe } from './indication/Circumscribe';
+import { Flash } from './indication/Flash';
+import { flash } from './indication/Flash';
+import { linear, smooth } from '../rate-functions';
+import { YELLOW, DEFAULT_STROKE_WIDTH } from '../constants';
+
+/** Concrete Mobject for tests that call getCenter()/getThreeObject(). */
+class ConcreteMobject extends Mobject {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  protected _createThreeObject(): THREE.Object3D {
+    return new THREE.Group();
+  }
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  protected _createCopy(): Mobject {
+    return new ConcreteMobject();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ApplyWave
+// ---------------------------------------------------------------------------
+describe('ApplyWave', () => {
+  describe('constructor defaults', () => {
+    it('has direction=horizontal, amplitude=0.2, wavelength=1.5, speed=1, ripples=false', () => {
+      const m = new Mobject();
+      const anim = new ApplyWave(m);
+      expect(anim.direction).toBe('horizontal');
+      expect(anim.amplitude).toBe(0.2);
+      expect(anim.wavelength).toBe(1.5);
+      expect(anim.speed).toBe(1);
+      expect(anim.ripples).toBe(false);
+    });
+
+    it('has duration=1 and rateFunc=linear', () => {
+      const m = new Mobject();
+      const anim = new ApplyWave(m);
+      expect(anim.duration).toBe(1);
+      expect(anim.rateFunc).toBe(linear);
+    });
+  });
+
+  describe('custom options', () => {
+    it('uses custom direction', () => {
+      const m = new Mobject();
+      const anim = new ApplyWave(m, { direction: 'vertical' });
+      expect(anim.direction).toBe('vertical');
+    });
+
+    it('uses custom amplitude', () => {
+      const m = new Mobject();
+      const anim = new ApplyWave(m, { amplitude: 0.5 });
+      expect(anim.amplitude).toBe(0.5);
+    });
+
+    it('uses custom wavelength', () => {
+      const m = new Mobject();
+      const anim = new ApplyWave(m, { wavelength: 3 });
+      expect(anim.wavelength).toBe(3);
+    });
+
+    it('uses custom speed', () => {
+      const m = new Mobject();
+      const anim = new ApplyWave(m, { speed: 2 });
+      expect(anim.speed).toBe(2);
+    });
+
+    it('uses custom ripples', () => {
+      const m = new Mobject();
+      const anim = new ApplyWave(m, { ripples: true });
+      expect(anim.ripples).toBe(true);
+    });
+
+    it('uses custom duration', () => {
+      const m = new Mobject();
+      const anim = new ApplyWave(m, { duration: 3 });
+      expect(anim.duration).toBe(3);
+    });
+
+    it('uses custom rateFunc', () => {
+      const m = new Mobject();
+      const anim = new ApplyWave(m, { rateFunc: smooth });
+      expect(anim.rateFunc).toBe(smooth);
+    });
+  });
+
+  describe('non-VMobject position wave (horizontal)', () => {
+    it('begin stores original position', () => {
+      const m = new ConcreteMobject();
+      m.position.set(1, 2, 3);
+      const anim = new ApplyWave(m);
+      anim.begin();
+      anim.interpolate(0);
+      // envelope = sin(0) = 0, so no displacement
+      expect(m.position.y).toBeCloseTo(2, 5);
+    });
+
+    it('at alpha=0 position is unchanged (envelope=0)', () => {
+      const m = new ConcreteMobject();
+      m.position.set(0, 5, 0);
+      const anim = new ApplyWave(m);
+      anim.begin();
+      anim.interpolate(0);
+      expect(m.position.y).toBeCloseTo(5, 5);
+    });
+
+    it('at alpha=0.5 envelope is max (sin(PI/2)=1)', () => {
+      const m = new ConcreteMobject();
+      m.position.set(0, 0, 0);
+      const anim = new ApplyWave(m);
+      anim.begin();
+      anim.interpolate(0.5);
+      const envelope = Math.sin(0.5 * Math.PI); // = 1
+      const wave = Math.sin(0.5 * Math.PI * 2 * 1.5 * 1);
+      const expected = wave * 0.2 * envelope;
+      expect(m.position.y).toBeCloseTo(expected, 5);
+    });
+
+    it('at alpha=1 envelope is ~0 (sin(PI)~0)', () => {
+      const m = new ConcreteMobject();
+      m.position.set(0, 0, 0);
+      const anim = new ApplyWave(m);
+      anim.begin();
+      anim.interpolate(1);
+      // envelope = sin(PI) ~ 0
+      expect(m.position.y).toBeCloseTo(0, 4);
+    });
+  });
+
+  describe('non-VMobject position wave (vertical)', () => {
+    it('displaces x instead of y for vertical direction', () => {
+      const m = new ConcreteMobject();
+      m.position.set(0, 0, 0);
+      const anim = new ApplyWave(m, { direction: 'vertical' });
+      anim.begin();
+      anim.interpolate(0.5);
+      const envelope = Math.sin(0.5 * Math.PI);
+      const wave = Math.sin(0.5 * Math.PI * 2 * 1.5 * 1);
+      const expected = wave * 0.2 * envelope;
+      expect(m.position.x).toBeCloseTo(expected, 5);
+      expect(m.position.y).toBeCloseTo(0, 5);
+    });
+  });
+
+  describe('VMobject wave', () => {
+    function makeVMobject(): VMobject {
+      const vm = new VMobject();
+      // Set up a simple square shape
+      vm.setPoints([
+        [0, 0, 0],
+        [1, 0, 0],
+        [1, 0, 0],
+        [1, 0, 0],
+        [1, 0, 0],
+        [1, 1, 0],
+        [1, 1, 0],
+        [1, 1, 0],
+        [1, 1, 0],
+        [0, 1, 0],
+        [0, 1, 0],
+        [0, 1, 0],
+        [0, 1, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+      ]);
+      return vm;
+    }
+
+    it('begin stores original points', () => {
+      const vm = makeVMobject();
+      const originalPoints = vm.getPoints().map((p) => [...p]);
+      const anim = new ApplyWave(vm);
+      anim.begin();
+      // At alpha=0 envelope=0, points should be unchanged
+      anim.interpolate(0);
+      const currentPoints = vm.getPoints();
+      for (let i = 0; i < originalPoints.length; i++) {
+        expect(currentPoints[i][0]).toBeCloseTo(originalPoints[i][0], 4);
+        expect(currentPoints[i][1]).toBeCloseTo(originalPoints[i][1], 4);
+        expect(currentPoints[i][2]).toBeCloseTo(originalPoints[i][2], 4);
+      }
+    });
+
+    it('horizontal wave displaces y coordinates', () => {
+      const vm = makeVMobject();
+      const originalPoints = vm.getPoints().map((p) => [...p]);
+      // Use wavelength=1.0 to avoid sin hitting exact zeros at boundary points
+      const anim = new ApplyWave(vm, { direction: 'horizontal', wavelength: 1.0 });
+      anim.begin();
+      anim.interpolate(0.3);
+      const currentPoints = vm.getPoints();
+      // At least some y coordinates should differ (envelope is non-zero)
+      let anyDifferent = false;
+      for (let i = 0; i < originalPoints.length; i++) {
+        if (Math.abs(currentPoints[i][1] - originalPoints[i][1]) > 0.001) {
+          anyDifferent = true;
+          break;
+        }
+      }
+      expect(anyDifferent).toBe(true);
+      // x coordinates should remain unchanged for horizontal wave
+      for (let i = 0; i < originalPoints.length; i++) {
+        expect(currentPoints[i][0]).toBeCloseTo(originalPoints[i][0], 5);
+      }
+    });
+
+    it('vertical wave displaces x coordinates', () => {
+      const vm = makeVMobject();
+      const originalPoints = vm.getPoints().map((p) => [...p]);
+      // Use wavelength=1.0 to avoid sin hitting exact zeros at boundary points
+      const anim = new ApplyWave(vm, { direction: 'vertical', wavelength: 1.0 });
+      anim.begin();
+      anim.interpolate(0.3);
+      const currentPoints = vm.getPoints();
+      let anyDifferent = false;
+      for (let i = 0; i < originalPoints.length; i++) {
+        if (Math.abs(currentPoints[i][0] - originalPoints[i][0]) > 0.001) {
+          anyDifferent = true;
+          break;
+        }
+      }
+      expect(anyDifferent).toBe(true);
+      // y coordinates should remain unchanged for vertical wave
+      for (let i = 0; i < originalPoints.length; i++) {
+        expect(currentPoints[i][1]).toBeCloseTo(originalPoints[i][1], 5);
+      }
+    });
+
+    it('ripple mode displaces both x and y based on radial distance', () => {
+      const vm = makeVMobject();
+      const originalPoints = vm.getPoints().map((p) => [...p]);
+      const anim = new ApplyWave(vm, { ripples: true });
+      anim.begin();
+      anim.interpolate(0.5);
+      const currentPoints = vm.getPoints();
+      // z coordinates should remain unchanged
+      for (let i = 0; i < originalPoints.length; i++) {
+        expect(currentPoints[i][2]).toBeCloseTo(originalPoints[i][2], 5);
+      }
+    });
+
+    it('finish restores original points', () => {
+      const vm = makeVMobject();
+      const originalPoints = vm.getPoints().map((p) => [...p]);
+      const anim = new ApplyWave(vm);
+      anim.begin();
+      anim.interpolate(0.5);
+      anim.finish();
+      const restoredPoints = vm.getPoints();
+      for (let i = 0; i < originalPoints.length; i++) {
+        expect(restoredPoints[i][0]).toBeCloseTo(originalPoints[i][0], 5);
+        expect(restoredPoints[i][1]).toBeCloseTo(originalPoints[i][1], 5);
+        expect(restoredPoints[i][2]).toBeCloseTo(originalPoints[i][2], 5);
+      }
+    });
+  });
+
+  describe('finish restores non-VMobject position', () => {
+    it('restores original position after animation', () => {
+      const m = new ConcreteMobject();
+      m.position.set(3, 7, 2);
+      const anim = new ApplyWave(m);
+      anim.begin();
+      anim.interpolate(0.5);
+      anim.finish();
+      expect(m.position.x).toBeCloseTo(3, 5);
+      expect(m.position.y).toBeCloseTo(7, 5);
+      expect(m.position.z).toBeCloseTo(2, 5);
+    });
+  });
+
+  describe('custom amplitude affects displacement magnitude', () => {
+    it('larger amplitude produces larger displacement', () => {
+      const m1 = new ConcreteMobject();
+      m1.position.set(0, 0, 0);
+      const anim1 = new ApplyWave(m1, { amplitude: 0.2 });
+      anim1.begin();
+      anim1.interpolate(0.25);
+      const y1 = m1.position.y;
+
+      const m2 = new ConcreteMobject();
+      m2.position.set(0, 0, 0);
+      const anim2 = new ApplyWave(m2, { amplitude: 1.0 });
+      anim2.begin();
+      anim2.interpolate(0.25);
+      const y2 = m2.position.y;
+
+      // The ratio of displacements should match the ratio of amplitudes
+      if (Math.abs(y1) > 0.0001) {
+        expect(Math.abs(y2 / y1)).toBeCloseTo(1.0 / 0.2, 1);
+      }
+    });
+  });
+
+  describe('applyWave() factory function', () => {
+    it('returns an ApplyWave instance', () => {
+      const m = new Mobject();
+      const anim = applyWave(m);
+      expect(anim).toBeInstanceOf(ApplyWave);
+    });
+
+    it('passes options through', () => {
+      const m = new Mobject();
+      const anim = applyWave(m, { amplitude: 0.8, direction: 'vertical' });
+      expect(anim.amplitude).toBe(0.8);
+      expect(anim.direction).toBe('vertical');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Circumscribe
+// ---------------------------------------------------------------------------
+describe('Circumscribe', () => {
+  describe('constructor defaults', () => {
+    it('has shape=rectangle, color=YELLOW, buff=0.2', () => {
+      const m = new Mobject();
+      const anim = new Circumscribe(m);
+      expect(anim.shapeType).toBe('rectangle');
+      expect(anim.shapeColor).toBe(YELLOW);
+      expect(anim.buff).toBe(0.2);
+    });
+
+    it('has strokeWidth=DEFAULT_STROKE_WIDTH, timeWidth=0.3, fadeOut=true', () => {
+      const m = new Mobject();
+      const anim = new Circumscribe(m);
+      expect(anim.strokeWidth).toBe(DEFAULT_STROKE_WIDTH);
+      expect(anim.timeWidth).toBe(0.3);
+      expect(anim.fadeOut).toBe(true);
+    });
+
+    it('has duration=1', () => {
+      const m = new Mobject();
+      const anim = new Circumscribe(m);
+      expect(anim.duration).toBe(1);
+    });
+  });
+
+  describe('custom options', () => {
+    it('uses custom shape', () => {
+      const m = new Mobject();
+      const anim = new Circumscribe(m, { shape: 'circle' });
+      expect(anim.shapeType).toBe('circle');
+    });
+
+    it('uses custom color', () => {
+      const m = new Mobject();
+      const anim = new Circumscribe(m, { color: '#ff0000' });
+      expect(anim.shapeColor).toBe('#ff0000');
+    });
+
+    it('uses custom buff', () => {
+      const m = new Mobject();
+      const anim = new Circumscribe(m, { buff: 0.5 });
+      expect(anim.buff).toBe(0.5);
+    });
+
+    it('uses custom strokeWidth', () => {
+      const m = new Mobject();
+      const anim = new Circumscribe(m, { strokeWidth: 8 });
+      expect(anim.strokeWidth).toBe(8);
+    });
+
+    it('uses custom timeWidth', () => {
+      const m = new Mobject();
+      const anim = new Circumscribe(m, { timeWidth: 0.5 });
+      expect(anim.timeWidth).toBe(0.5);
+    });
+
+    it('uses custom fadeOut', () => {
+      const m = new Mobject();
+      const anim = new Circumscribe(m, { fadeOut: false });
+      expect(anim.fadeOut).toBe(false);
+    });
+
+    it('uses custom duration', () => {
+      const m = new Mobject();
+      const anim = new Circumscribe(m, { duration: 2 });
+      expect(anim.duration).toBe(2);
+    });
+  });
+
+  describe('circumscribe() factory function', () => {
+    it('returns a Circumscribe instance', () => {
+      const m = new Mobject();
+      const anim = circumscribe(m);
+      expect(anim).toBeInstanceOf(Circumscribe);
+    });
+
+    it('passes options through', () => {
+      const m = new Mobject();
+      const anim = circumscribe(m, { shape: 'circle', buff: 0.8 });
+      expect(anim.shapeType).toBe('circle');
+      expect(anim.buff).toBe(0.8);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flash
+// ---------------------------------------------------------------------------
+describe('Flash', () => {
+  describe('constructor defaults', () => {
+    it('has color=YELLOW, numLines=8, flashRadius=1', () => {
+      const m = new Mobject();
+      const anim = new Flash(m);
+      expect(anim.flashColor).toBe(YELLOW);
+      expect(anim.numLines).toBe(8);
+      expect(anim.flashRadius).toBe(1);
+    });
+
+    it('has lineWidth=DEFAULT_STROKE_WIDTH, innerRadius=0', () => {
+      const m = new Mobject();
+      const anim = new Flash(m);
+      expect(anim.lineWidth).toBe(DEFAULT_STROKE_WIDTH);
+      expect(anim.innerRadius).toBe(0);
+    });
+
+    it('has duration=0.5', () => {
+      const m = new Mobject();
+      const anim = new Flash(m);
+      expect(anim.duration).toBe(0.5);
+    });
+  });
+
+  describe('custom options', () => {
+    it('uses custom color', () => {
+      const m = new Mobject();
+      const anim = new Flash(m, { color: '#00ff00' });
+      expect(anim.flashColor).toBe('#00ff00');
+    });
+
+    it('uses custom numLines', () => {
+      const m = new Mobject();
+      const anim = new Flash(m, { numLines: 12 });
+      expect(anim.numLines).toBe(12);
+    });
+
+    it('uses custom flashRadius', () => {
+      const m = new Mobject();
+      const anim = new Flash(m, { flashRadius: 2.5 });
+      expect(anim.flashRadius).toBe(2.5);
+    });
+
+    it('uses custom lineWidth', () => {
+      const m = new Mobject();
+      const anim = new Flash(m, { lineWidth: 6 });
+      expect(anim.lineWidth).toBe(6);
+    });
+
+    it('uses custom innerRadius', () => {
+      const m = new Mobject();
+      const anim = new Flash(m, { innerRadius: 0.3 });
+      expect(anim.innerRadius).toBe(0.3);
+    });
+
+    it('uses custom duration', () => {
+      const m = new Mobject();
+      const anim = new Flash(m, { duration: 2 });
+      expect(anim.duration).toBe(2);
+    });
+  });
+
+  describe('flash() factory function', () => {
+    it('returns a Flash instance', () => {
+      const m = new Mobject();
+      const anim = flash(m);
+      expect(anim).toBeInstanceOf(Flash);
+    });
+
+    it('passes options through', () => {
+      const m = new Mobject();
+      const anim = flash(m, { numLines: 16, flashRadius: 3 });
+      expect(anim.numLines).toBe(16);
+      expect(anim.flashRadius).toBe(3);
+    });
+  });
+});

--- a/src/animation/indication-pulse.test.ts
+++ b/src/animation/indication-pulse.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest';
+import { Mobject } from '../core/Mobject';
+import { FocusOn, Pulse } from './indication/FocusOn';
+import { focusOn, pulse } from './indication/FocusOn';
+import { linear, smooth } from '../rate-functions';
+import { GRAY, DEFAULT_STROKE_WIDTH } from '../constants';
+
+// ---------------------------------------------------------------------------
+// FocusOn
+// ---------------------------------------------------------------------------
+describe('FocusOn', () => {
+  describe('constructor defaults', () => {
+    it('has color=GRAY, startRadius=2, endRadius=0', () => {
+      const m = new Mobject();
+      const anim = new FocusOn(m);
+      expect(anim.focusColor).toBe(GRAY);
+      expect(anim.startRadius).toBe(2);
+      expect(anim.endRadius).toBe(0);
+    });
+
+    it('has numRings=5, strokeWidth=DEFAULT_STROKE_WIDTH, opacity=0.5', () => {
+      const m = new Mobject();
+      const anim = new FocusOn(m);
+      expect(anim.numRings).toBe(5);
+      expect(anim.strokeWidth).toBe(DEFAULT_STROKE_WIDTH);
+      expect(anim.ringOpacity).toBe(0.5);
+    });
+
+    it('has duration=0.5 and rateFunc=smooth', () => {
+      const m = new Mobject();
+      const anim = new FocusOn(m);
+      expect(anim.duration).toBe(0.5);
+      expect(anim.rateFunc).toBe(smooth);
+    });
+  });
+
+  describe('custom options', () => {
+    it('uses custom color', () => {
+      const m = new Mobject();
+      const anim = new FocusOn(m, { color: '#ff0000' });
+      expect(anim.focusColor).toBe('#ff0000');
+    });
+
+    it('uses custom startRadius', () => {
+      const m = new Mobject();
+      const anim = new FocusOn(m, { startRadius: 5 });
+      expect(anim.startRadius).toBe(5);
+    });
+
+    it('uses custom endRadius', () => {
+      const m = new Mobject();
+      const anim = new FocusOn(m, { endRadius: 0.5 });
+      expect(anim.endRadius).toBe(0.5);
+    });
+
+    it('uses custom numRings', () => {
+      const m = new Mobject();
+      const anim = new FocusOn(m, { numRings: 10 });
+      expect(anim.numRings).toBe(10);
+    });
+
+    it('uses custom strokeWidth', () => {
+      const m = new Mobject();
+      const anim = new FocusOn(m, { strokeWidth: 8 });
+      expect(anim.strokeWidth).toBe(8);
+    });
+
+    it('uses custom opacity', () => {
+      const m = new Mobject();
+      const anim = new FocusOn(m, { opacity: 0.8 });
+      expect(anim.ringOpacity).toBe(0.8);
+    });
+
+    it('uses custom duration', () => {
+      const m = new Mobject();
+      const anim = new FocusOn(m, { duration: 3 });
+      expect(anim.duration).toBe(3);
+    });
+
+    it('uses custom rateFunc', () => {
+      const m = new Mobject();
+      const anim = new FocusOn(m, { rateFunc: linear });
+      expect(anim.rateFunc).toBe(linear);
+    });
+  });
+
+  describe('focusOn() factory function', () => {
+    it('returns a FocusOn instance', () => {
+      const m = new Mobject();
+      const anim = focusOn(m);
+      expect(anim).toBeInstanceOf(FocusOn);
+    });
+
+    it('passes options through', () => {
+      const m = new Mobject();
+      const anim = focusOn(m, { startRadius: 4, numRings: 8 });
+      expect(anim.startRadius).toBe(4);
+      expect(anim.numRings).toBe(8);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pulse
+// ---------------------------------------------------------------------------
+describe('Pulse', () => {
+  describe('constructor defaults', () => {
+    it('has scaleFactor=1.2, nPulses=1', () => {
+      const m = new Mobject();
+      const anim = new Pulse(m);
+      expect(anim.scaleFactor).toBe(1.2);
+      expect(anim.nPulses).toBe(1);
+    });
+
+    it('has duration=0.5 and rateFunc=smooth', () => {
+      const m = new Mobject();
+      const anim = new Pulse(m);
+      expect(anim.duration).toBe(0.5);
+      expect(anim.rateFunc).toBe(smooth);
+    });
+  });
+
+  describe('begin()', () => {
+    it('stores original scale', () => {
+      const m = new Mobject();
+      m.scaleVector.set(2, 3, 4);
+      const anim = new Pulse(m);
+      anim.begin();
+      anim.interpolate(0);
+      expect(m.scaleVector.x).toBeCloseTo(2, 5);
+      expect(m.scaleVector.y).toBeCloseTo(3, 5);
+      expect(m.scaleVector.z).toBeCloseTo(4, 5);
+    });
+  });
+
+  describe('interpolate()', () => {
+    it('at alpha=0 scale is original (sin(0)=0)', () => {
+      const m = new Mobject();
+      m.scaleVector.set(1, 1, 1);
+      const anim = new Pulse(m);
+      anim.begin();
+      anim.interpolate(0);
+      expect(m.scaleVector.x).toBeCloseTo(1, 5);
+      expect(m.scaleVector.y).toBeCloseTo(1, 5);
+      expect(m.scaleVector.z).toBeCloseTo(1, 5);
+    });
+
+    it('at alpha=0.25 scale peaks (sin(PI/2)=1)', () => {
+      const m = new Mobject();
+      const anim = new Pulse(m);
+      anim.begin();
+      anim.interpolate(0.25);
+      expect(m.scaleVector.x).toBeCloseTo(1.2, 5);
+      expect(m.scaleVector.y).toBeCloseTo(1.2, 5);
+      expect(m.scaleVector.z).toBeCloseTo(1.2, 5);
+    });
+
+    it('at alpha=0.5 scale is original (sin(PI)~0)', () => {
+      const m = new Mobject();
+      const anim = new Pulse(m);
+      anim.begin();
+      anim.interpolate(0.5);
+      expect(m.scaleVector.x).toBeCloseTo(1, 4);
+      expect(m.scaleVector.y).toBeCloseTo(1, 4);
+      expect(m.scaleVector.z).toBeCloseTo(1, 4);
+    });
+
+    it('at alpha=0.75 scale peaks again (abs(sin(3PI/2))=1)', () => {
+      const m = new Mobject();
+      const anim = new Pulse(m);
+      anim.begin();
+      anim.interpolate(0.75);
+      expect(m.scaleVector.x).toBeCloseTo(1.2, 5);
+      expect(m.scaleVector.y).toBeCloseTo(1.2, 5);
+      expect(m.scaleVector.z).toBeCloseTo(1.2, 5);
+    });
+
+    it('at alpha=1 scale is original (sin(2PI)~0)', () => {
+      const m = new Mobject();
+      const anim = new Pulse(m);
+      anim.begin();
+      anim.interpolate(1);
+      expect(m.scaleVector.x).toBeCloseTo(1, 4);
+      expect(m.scaleVector.y).toBeCloseTo(1, 4);
+      expect(m.scaleVector.z).toBeCloseTo(1, 4);
+    });
+
+    it('works with non-unit initial scale', () => {
+      const m = new Mobject();
+      m.scaleVector.set(3, 3, 3);
+      const anim = new Pulse(m);
+      anim.begin();
+      anim.interpolate(0.25);
+      expect(m.scaleVector.x).toBeCloseTo(3.6, 5);
+      expect(m.scaleVector.y).toBeCloseTo(3.6, 5);
+      expect(m.scaleVector.z).toBeCloseTo(3.6, 5);
+    });
+
+    it('custom nPulses produces more oscillations', () => {
+      const m = new Mobject();
+      const anim = new Pulse(m, { nPulses: 2 });
+      anim.begin();
+      anim.interpolate(0.125);
+      expect(m.scaleVector.x).toBeCloseTo(1.2, 5);
+    });
+
+    it('custom scaleFactor changes peak scale', () => {
+      const m = new Mobject();
+      const anim = new Pulse(m, { scaleFactor: 2.0 });
+      anim.begin();
+      anim.interpolate(0.25);
+      expect(m.scaleVector.x).toBeCloseTo(2.0, 5);
+      expect(m.scaleVector.y).toBeCloseTo(2.0, 5);
+    });
+  });
+
+  describe('finish()', () => {
+    it('restores original scale', () => {
+      const m = new Mobject();
+      m.scaleVector.set(5, 5, 5);
+      const anim = new Pulse(m);
+      anim.begin();
+      anim.interpolate(0.25);
+      expect(m.scaleVector.x).toBeCloseTo(6.0, 5);
+      anim.finish();
+      expect(m.scaleVector.x).toBeCloseTo(5, 5);
+      expect(m.scaleVector.y).toBeCloseTo(5, 5);
+      expect(m.scaleVector.z).toBeCloseTo(5, 5);
+    });
+  });
+
+  describe('pulse() factory function', () => {
+    it('returns a Pulse instance', () => {
+      const m = new Mobject();
+      const anim = pulse(m);
+      expect(anim).toBeInstanceOf(Pulse);
+    });
+
+    it('passes options through', () => {
+      const m = new Mobject();
+      const anim = pulse(m, { scaleFactor: 1.5, nPulses: 3 });
+      expect(anim.scaleFactor).toBe(1.5);
+      expect(anim.nPulses).toBe(3);
+    });
+  });
+});

--- a/src/core/core-camera.test.ts
+++ b/src/core/core-camera.test.ts
@@ -1,0 +1,461 @@
+import { describe, it, expect } from 'vitest';
+import { Camera2D } from './Camera';
+import { Camera2DFrame } from './Camera2DFrame';
+import { CameraFrame, CameraAnimateProxy } from './CameraFrame';
+import { Mobject } from './Mobject';
+import { VMobject } from './VMobject';
+import { linear } from '../rate-functions';
+
+describe('Camera2DFrame', () => {
+  function makeCam(fw = 14, fh = 8) {
+    return new Camera2D({ frameWidth: fw, frameHeight: fh });
+  }
+
+  it('constructs with invisible visual properties and dummy points', () => {
+    const frame = new Camera2DFrame(makeCam());
+    expect(frame.opacity).toBe(0);
+    expect(frame.fillOpacity).toBe(0);
+    expect(frame.strokeWidth).toBe(0);
+    expect(frame.numPoints).toBeGreaterThan(0);
+  });
+
+  it('primary frame initializes position from camera center', () => {
+    const frame = new Camera2DFrame(new Camera2D(), true);
+    expect(frame.position.x).toBeCloseTo(0);
+    expect(frame.position.y).toBeCloseTo(0);
+  });
+
+  it('non-primary frame does not sync position from camera', () => {
+    const frame = new Camera2DFrame(new Camera2D({ position: [3, 5, 10] }), false);
+    expect(frame.position.x).toBe(0);
+    expect(frame.position.y).toBe(0);
+  });
+
+  it('getCenter returns current position', () => {
+    const frame = new Camera2DFrame(makeCam());
+    frame.position.set(2, 3, 0);
+    const c = frame.getCenter();
+    expect(c[0]).toBeCloseTo(2);
+    expect(c[1]).toBeCloseTo(3);
+    expect(c[2]).toBeCloseTo(0);
+  });
+
+  it('moveTo with array sets position and syncs camera', () => {
+    const cam = makeCam();
+    const frame = new Camera2DFrame(cam, true);
+    const result = frame.moveTo([5, 7, 0]);
+    expect(result).toBe(frame);
+    expect(frame.position.x).toBeCloseTo(5);
+    expect(frame.position.y).toBeCloseTo(7);
+    expect(cam.position.x).toBeCloseTo(5);
+    expect(cam.position.y).toBeCloseTo(7);
+  });
+
+  it('moveTo with Mobject centers on the mobject', () => {
+    const frame = new Camera2DFrame(makeCam(), true);
+    const mob = new VMobject();
+    mob.moveTo([4, 6, 0]);
+    frame.moveTo(mob);
+    expect(frame.position.x).toBeCloseTo(4);
+    expect(frame.position.y).toBeCloseTo(6);
+  });
+
+  it('scale on primary frame syncs frameWidth/Height to camera', () => {
+    const cam = makeCam(14, 8);
+    const frame = new Camera2DFrame(cam, true);
+    frame.scale(2);
+    expect(cam.frameWidth).toBeCloseTo(28);
+    expect(cam.frameHeight).toBeCloseTo(16);
+  });
+
+  it('scale on non-primary frame does not sync to camera', () => {
+    const cam = makeCam(14, 8);
+    const frame = new Camera2DFrame(cam, false);
+    frame.scale(2);
+    expect(cam.frameWidth).toBeCloseTo(14);
+    expect(cam.frameHeight).toBeCloseTo(8);
+  });
+
+  it('copy returns a non-primary clone with matching state', () => {
+    const cam = makeCam();
+    const frame = new Camera2DFrame(cam, true);
+    frame.moveTo([3, 4, 0]);
+    frame.scale(1.5);
+    const copy = frame.copy() as Camera2DFrame;
+    expect(copy.position.x).toBeCloseTo(3);
+    expect(copy.position.y).toBeCloseTo(4);
+    expect(copy.scaleVector.x).toBeCloseTo(1.5);
+    expect(copy.opacity).toBe(0);
+    expect(copy.fillOpacity).toBe(0);
+    expect(copy.strokeWidth).toBe(0);
+    expect(copy.numPoints).toBe(frame.numPoints);
+    // Non-primary: further changes do not affect camera
+    copy.moveTo([10, 10, 0]);
+    expect(cam.position.x).toBeCloseTo(3);
+    expect(cam.position.y).toBeCloseTo(4);
+  });
+
+  it('generateTarget creates a modifiable copy', () => {
+    const frame = new Camera2DFrame(makeCam(), true);
+    const target = frame.generateTarget();
+    expect(target).not.toBe(frame);
+    expect(frame.targetCopy).toBe(target);
+  });
+
+  it('saveState stores a copy that can be used later', () => {
+    const frame = new Camera2DFrame(makeCam(), true);
+    frame.moveTo([1, 2, 0]);
+    frame.saveState();
+    expect(frame.savedState).toBeDefined();
+    expect(frame.savedState!.position.x).toBeCloseTo(1);
+    expect(frame.savedState!.position.y).toBeCloseTo(2);
+  });
+
+  it('_markDirty on primary frame syncs camera position', () => {
+    const cam = makeCam();
+    const frame = new Camera2DFrame(cam, true);
+    frame.position.set(9, 8, 0);
+    frame._markDirty();
+    expect(cam.position.x).toBeCloseTo(9);
+    expect(cam.position.y).toBeCloseTo(8);
+  });
+
+  it('shift on primary frame updates camera', () => {
+    const cam = makeCam();
+    const frame = new Camera2DFrame(cam, true);
+    frame.shift([2, 3, 0]);
+    expect(cam.position.x).toBeCloseTo(2);
+    expect(cam.position.y).toBeCloseTo(3);
+  });
+});
+
+describe('CameraFrame', () => {
+  it('constructs with default Euler angles', () => {
+    const frame = new CameraFrame();
+    const [theta, phi, gamma] = frame.getEulerAngles();
+    expect(theta).toBeCloseTo(-Math.PI / 2);
+    expect(phi).toBeCloseTo(Math.PI / 4);
+    expect(gamma).toBe(0);
+  });
+
+  it('constructs with custom options', () => {
+    const frame = new CameraFrame(16 / 9, {
+      theta: 1.0,
+      phi: 0.5,
+      gamma: 0.2,
+      distance: 20,
+      fov: 60,
+    });
+    expect(frame.getTheta()).toBeCloseTo(1.0);
+    expect(frame.getPhi()).toBeCloseTo(0.5);
+    expect(frame.getGamma()).toBeCloseTo(0.2);
+    expect(frame.getDistance()).toBe(20);
+    expect(frame.getFieldOfView()).toBe(60);
+  });
+
+  it('getCamera3D and getThreeCamera return valid cameras', () => {
+    const frame = new CameraFrame();
+    expect(frame.getCamera3D()).toBeDefined();
+    expect(frame.getCamera3D().getCamera).toBeDefined();
+    expect(frame.getThreeCamera().isPerspectiveCamera).toBe(true);
+  });
+
+  it('setTheta/setPhi/setGamma update and return this', () => {
+    const frame = new CameraFrame();
+    expect(frame.setTheta(1.5)).toBe(frame);
+    expect(frame.getTheta()).toBeCloseTo(1.5);
+    expect(frame.setPhi(0.8)).toBe(frame);
+    expect(frame.getPhi()).toBeCloseTo(0.8);
+    expect(frame.setGamma(0.3)).toBe(frame);
+    expect(frame.getGamma()).toBeCloseTo(0.3);
+  });
+
+  it('incrementTheta/Phi/Gamma add deltas', () => {
+    const frame = new CameraFrame();
+    const t0 = frame.getTheta();
+    const p0 = frame.getPhi();
+    frame.incrementTheta(0.5);
+    frame.incrementPhi(0.3);
+    frame.incrementGamma(0.1);
+    expect(frame.getTheta()).toBeCloseTo(t0 + 0.5);
+    expect(frame.getPhi()).toBeCloseTo(p0 + 0.3);
+    expect(frame.getGamma()).toBeCloseTo(0.1);
+  });
+
+  it('setEulerAngles sets multiple angles, leaves others unchanged', () => {
+    const frame = new CameraFrame(16 / 9, { theta: 1.0, phi: 0.5 });
+    frame.setEulerAngles({ gamma: 0.7 });
+    expect(frame.getTheta()).toBeCloseTo(1.0);
+    expect(frame.getPhi()).toBeCloseTo(0.5);
+    expect(frame.getGamma()).toBeCloseTo(0.7);
+  });
+
+  it('setDistance clamps to minimum 0.1', () => {
+    const frame = new CameraFrame();
+    frame.setDistance(0.01);
+    expect(frame.getDistance()).toBeCloseTo(0.1);
+    frame.setDistance(-5);
+    expect(frame.getDistance()).toBeCloseTo(0.1);
+  });
+
+  it('setDistance updates and returns this', () => {
+    const frame = new CameraFrame();
+    expect(frame.setDistance(15)).toBe(frame);
+    expect(frame.getDistance()).toBe(15);
+  });
+
+  it('setFieldOfView updates fov', () => {
+    const frame = new CameraFrame();
+    frame.setFieldOfView(90);
+    expect(frame.getFieldOfView()).toBe(90);
+  });
+
+  it('getCenter and moveTo control look-at center', () => {
+    const frame = new CameraFrame(16 / 9, { lookAt: [1, 2, 3] });
+    expect(frame.getCenter()).toEqual([1, 2, 3]);
+    expect(frame.moveTo([5, 6, 7])).toBe(frame);
+    const c = frame.getCenter();
+    expect(c[0]).toBeCloseTo(5);
+    expect(c[1]).toBeCloseTo(6);
+    expect(c[2]).toBeCloseTo(7);
+  });
+
+  it('setAspectRatio returns this', () => {
+    expect(new CameraFrame().setAspectRatio(4 / 3)).toBeInstanceOf(CameraFrame);
+  });
+
+  it('mobjectStub is a Mobject instance', () => {
+    expect(new CameraFrame().mobjectStub).toBeInstanceOf(Mobject);
+  });
+
+  it('camera position reflects spherical coordinates', () => {
+    const frame = new CameraFrame(16 / 9, {
+      theta: -Math.PI / 2,
+      phi: Math.PI / 2,
+      distance: 10,
+    });
+    const cam = frame.getThreeCamera();
+    expect(cam.position.x).toBeCloseTo(0, 4);
+    expect(cam.position.y).toBeCloseTo(0, 4);
+    expect(cam.position.z).toBeCloseTo(-10, 4);
+  });
+
+  it('camera position updates when theta changes', () => {
+    const frame = new CameraFrame(16 / 9, {
+      theta: 0,
+      phi: Math.PI / 2,
+      distance: 10,
+    });
+    const cam = frame.getThreeCamera();
+    expect(cam.position.x).toBeCloseTo(10, 4);
+    expect(cam.position.z).toBeCloseTo(0, 4);
+    frame.setTheta(Math.PI / 2);
+    expect(cam.position.x).toBeCloseTo(0, 4);
+    expect(cam.position.z).toBeCloseTo(10, 4);
+  });
+
+  it('gamma applies roll to the camera up vector', () => {
+    const frame = new CameraFrame(16 / 9, {
+      theta: -Math.PI / 2,
+      phi: Math.PI / 4,
+      gamma: Math.PI / 4,
+      distance: 10,
+    });
+    const up = frame.getThreeCamera().up;
+    expect(up.x === 0 && up.y === 1 && up.z === 0).toBe(false);
+  });
+
+  it('gamma=0 leaves up vector as world Y', () => {
+    const frame = new CameraFrame(16 / 9, {
+      theta: -Math.PI / 2,
+      phi: Math.PI / 4,
+      gamma: 0,
+      distance: 10,
+    });
+    const up = frame.getThreeCamera().up;
+    expect(up.x).toBeCloseTo(0);
+    expect(up.y).toBeCloseTo(1);
+    expect(up.z).toBeCloseTo(0);
+  });
+});
+
+describe('CameraFrame snapshot/restore', () => {
+  it('_snapshot captures current state', () => {
+    const frame = new CameraFrame(16 / 9, {
+      theta: 1.0,
+      phi: 0.5,
+      gamma: 0.2,
+      distance: 15,
+      fov: 60,
+      lookAt: [1, 2, 3],
+    });
+    const s = frame._snapshot();
+    expect(s.theta).toBeCloseTo(1.0);
+    expect(s.phi).toBeCloseTo(0.5);
+    expect(s.gamma).toBeCloseTo(0.2);
+    expect(s.distance).toBe(15);
+    expect(s.fov).toBe(60);
+    expect(s.center).toEqual([1, 2, 3]);
+  });
+
+  it('_applyState restores a previously captured state', () => {
+    const frame = new CameraFrame();
+    const snap = frame._snapshot();
+    frame.setTheta(2.0);
+    frame.setPhi(1.0);
+    frame.setGamma(0.5);
+    frame.setDistance(25);
+    frame.setFieldOfView(90);
+    frame.moveTo([10, 20, 30]);
+    expect(frame.getTheta()).toBeCloseTo(2.0);
+    frame._applyState(snap);
+    expect(frame.getTheta()).toBeCloseTo(snap.theta);
+    expect(frame.getPhi()).toBeCloseTo(snap.phi);
+    expect(frame.getGamma()).toBeCloseTo(snap.gamma);
+    expect(frame.getDistance()).toBe(snap.distance);
+    expect(frame.getFieldOfView()).toBe(snap.fov);
+    expect(frame.getCenter()).toEqual(snap.center);
+  });
+});
+
+describe('CameraAnimateProxy', () => {
+  it('frame.animate returns a CameraAnimateProxy with defaults', () => {
+    const frame = new CameraFrame();
+    const proxy = frame.animate;
+    expect(proxy).toBeInstanceOf(CameraAnimateProxy);
+    expect(proxy.duration).toBe(1);
+    expect(proxy.getFrame()).toBe(frame);
+  });
+
+  it('animateTo passes custom duration and rateFunc', () => {
+    const frame = new CameraFrame();
+    const proxy = frame.animateTo({ duration: 3, rateFunc: linear });
+    expect(proxy.duration).toBe(3);
+    expect(proxy.rateFunc).toBe(linear);
+  });
+
+  it('builder methods are chainable', () => {
+    const frame = new CameraFrame();
+    const proxy = frame.animate;
+    const result = proxy
+      .incrementTheta(0.5)
+      .incrementPhi(0.3)
+      .incrementGamma(0.1)
+      .setDistance(20)
+      .setFieldOfView(60)
+      .moveTo([1, 2, 3])
+      .setEulerAngles({ theta: 1 });
+    expect(result).toBe(proxy);
+  });
+
+  it('withDuration and withRateFunc override animation params', () => {
+    const frame = new CameraFrame();
+    const proxy = frame.animate.withDuration(5).withRateFunc(linear);
+    expect(proxy.duration).toBe(5);
+    expect(proxy.rateFunc).toBe(linear);
+  });
+
+  it('interpolate(0) keeps start state', () => {
+    const frame = new CameraFrame(16 / 9, { theta: 0, phi: Math.PI / 4, distance: 10 });
+    const proxy = frame.animate.incrementTheta(Math.PI / 2);
+    proxy.begin();
+    proxy.interpolate(0);
+    expect(frame.getTheta()).toBeCloseTo(0);
+  });
+
+  it('interpolate(1) reaches target state', () => {
+    const frame = new CameraFrame(16 / 9, { theta: 0, phi: Math.PI / 4, distance: 10 });
+    const proxy = frame.animate.incrementTheta(Math.PI / 2);
+    proxy.begin();
+    proxy.interpolate(1);
+    expect(frame.getTheta()).toBeCloseTo(Math.PI / 2);
+  });
+
+  it('interpolate(0.5) gives midpoint', () => {
+    const frame = new CameraFrame(16 / 9, { theta: 0, distance: 10 });
+    const proxy = frame.animate.incrementTheta(Math.PI);
+    proxy.begin();
+    proxy.interpolate(0.5);
+    expect(frame.getTheta()).toBeCloseTo(Math.PI / 2);
+  });
+
+  it('absolute setEulerAngles interpolates to target', () => {
+    const frame = new CameraFrame(16 / 9, { theta: 0, phi: 0, gamma: 0 });
+    const proxy = frame.animate.setEulerAngles({ theta: Math.PI, phi: Math.PI / 2 });
+    proxy.begin();
+    proxy.interpolate(1);
+    expect(frame.getTheta()).toBeCloseTo(Math.PI);
+    expect(frame.getPhi()).toBeCloseTo(Math.PI / 2);
+    expect(frame.getGamma()).toBeCloseTo(0);
+  });
+
+  it('setDistance animates distance', () => {
+    const frame = new CameraFrame(16 / 9, { distance: 10 });
+    const proxy = frame.animate.setDistance(20);
+    proxy.begin();
+    proxy.interpolate(0.5);
+    expect(frame.getDistance()).toBeCloseTo(15);
+    proxy.interpolate(1);
+    expect(frame.getDistance()).toBeCloseTo(20);
+  });
+
+  it('setFieldOfView animates fov', () => {
+    const frame = new CameraFrame(16 / 9, { fov: 45 });
+    const proxy = frame.animate.setFieldOfView(90);
+    proxy.begin();
+    proxy.interpolate(0.5);
+    expect(frame.getFieldOfView()).toBeCloseTo(67.5);
+    proxy.interpolate(1);
+    expect(frame.getFieldOfView()).toBeCloseTo(90);
+  });
+
+  it('moveTo animates center', () => {
+    const frame = new CameraFrame(16 / 9, { lookAt: [0, 0, 0] });
+    const proxy = frame.animate.moveTo([10, 20, 30]);
+    proxy.begin();
+    proxy.interpolate(0.5);
+    expect(frame.getCenter()[0]).toBeCloseTo(5);
+    expect(frame.getCenter()[1]).toBeCloseTo(10);
+    expect(frame.getCenter()[2]).toBeCloseTo(15);
+    proxy.interpolate(1);
+    expect(frame.getCenter()[0]).toBeCloseTo(10);
+    expect(frame.getCenter()[1]).toBeCloseTo(20);
+    expect(frame.getCenter()[2]).toBeCloseTo(30);
+  });
+
+  it('finish applies final state', () => {
+    const frame = new CameraFrame(16 / 9, { theta: 0, phi: 0, distance: 10 });
+    const proxy = frame.animate.incrementPhi(1.0);
+    proxy.begin();
+    proxy.finish();
+    expect(frame.getPhi()).toBeCloseTo(1.0);
+  });
+
+  it('combined deltas accumulate', () => {
+    const frame = new CameraFrame(16 / 9, { theta: 0, phi: 0 });
+    const proxy = frame.animate.incrementTheta(0.5).incrementTheta(0.5);
+    proxy.begin();
+    proxy.interpolate(1);
+    expect(frame.getTheta()).toBeCloseTo(1.0);
+  });
+});
+
+describe('Camera2D frame interaction', () => {
+  it('camera.frame is lazily created, cached, and is a Camera2DFrame', () => {
+    const cam = new Camera2D();
+    const f1 = cam.frame;
+    expect(f1).toBeInstanceOf(Camera2DFrame);
+    expect(cam.frame).toBe(f1);
+  });
+
+  it('updateFrame with no frame is a no-op', () => {
+    new Camera2D().updateFrame(0.016); // should not throw
+  });
+
+  it('updateFrame with frame does not throw', () => {
+    const cam = new Camera2D();
+    const frame = cam.frame; // create the frame
+    expect(frame).toBeDefined();
+    cam.updateFrame(0.016);
+  });
+});

--- a/src/mobjects/fractals/fractals.test.ts
+++ b/src/mobjects/fractals/fractals.test.ts
@@ -1,0 +1,475 @@
+import { describe, it, expect } from 'vitest';
+import { MandelbrotSet } from './MandelbrotSet';
+import { NewtonFractal } from './NewtonFractal';
+
+// ==========================================================================
+// MandelbrotSet
+// ==========================================================================
+
+describe('MandelbrotSet', () => {
+  describe('construction with defaults', () => {
+    it('has correct default values', () => {
+      const m = new MandelbrotSet();
+      expect(m.getWidth()).toBe(8);
+      expect(m.getHeight()).toBe(6);
+      expect(m.getCenter()).toEqual([-0.5, 0, 0]);
+      expect(m.getZoom()).toBe(1);
+      expect(m.getMaxIterations()).toBe(100);
+      expect(m.getSaturation()).toBe(0.8);
+      expect(m.getLightness()).toBe(0.5);
+      expect(m.opacity).toBe(1);
+      expect(m.fillOpacity).toBe(1);
+    });
+  });
+
+  describe('construction with custom options', () => {
+    it('accepts all custom options', () => {
+      const m = new MandelbrotSet({
+        width: 10,
+        height: 8,
+        center: [-0.7, 0.3],
+        zoom: 50,
+        maxIterations: 500,
+        saturation: 0.6,
+        lightness: 0.4,
+        opacity: 0.5,
+      });
+      expect(m.getWidth()).toBe(10);
+      expect(m.getHeight()).toBe(8);
+      expect(m.getCenter()).toEqual([-0.7, 0.3, 0]);
+      expect(m.getZoom()).toBe(50);
+      expect(m.getMaxIterations()).toBe(500);
+      expect(m.getSaturation()).toBe(0.6);
+      expect(m.getLightness()).toBe(0.4);
+      expect(m.opacity).toBe(0.5);
+      expect(m.fillOpacity).toBe(0.5);
+    });
+  });
+
+  describe('setters return this for chaining', () => {
+    it('setCenter updates and returns this', () => {
+      const m = new MandelbrotSet();
+      expect(m.setCenter([1.5, -0.3])).toBe(m);
+      expect(m.getCenter()).toEqual([1.5, -0.3, 0]);
+    });
+
+    it('setZoom updates and returns this', () => {
+      const m = new MandelbrotSet();
+      expect(m.setZoom(200)).toBe(m);
+      expect(m.getZoom()).toBe(200);
+    });
+
+    it('setMaxIterations updates and returns this', () => {
+      const m = new MandelbrotSet();
+      expect(m.setMaxIterations(300)).toBe(m);
+      expect(m.getMaxIterations()).toBe(300);
+    });
+
+    it('setSaturation updates and returns this', () => {
+      const m = new MandelbrotSet();
+      expect(m.setSaturation(0.3)).toBe(m);
+      expect(m.getSaturation()).toBe(0.3);
+    });
+
+    it('setLightness updates and returns this', () => {
+      const m = new MandelbrotSet();
+      expect(m.setLightness(0.7)).toBe(m);
+      expect(m.getLightness()).toBe(0.7);
+    });
+
+    it('setWidth updates and returns this', () => {
+      const m = new MandelbrotSet();
+      expect(m.setWidth(12)).toBe(m);
+      expect(m.getWidth()).toBe(12);
+    });
+
+    it('setHeight updates and returns this', () => {
+      const m = new MandelbrotSet();
+      expect(m.setHeight(9)).toBe(m);
+      expect(m.getHeight()).toBe(9);
+    });
+  });
+
+  describe('validation and clamping', () => {
+    it('setMaxIterations rounds to integer', () => {
+      const m = new MandelbrotSet();
+      m.setMaxIterations(99.7);
+      expect(m.getMaxIterations()).toBe(100);
+    });
+
+    it('setMaxIterations enforces minimum of 1', () => {
+      const m = new MandelbrotSet();
+      m.setMaxIterations(0);
+      expect(m.getMaxIterations()).toBe(1);
+      m.setMaxIterations(-5);
+      expect(m.getMaxIterations()).toBe(1);
+    });
+
+    it('clamps saturation to [0, 1]', () => {
+      const m = new MandelbrotSet();
+      m.setSaturation(-0.5);
+      expect(m.getSaturation()).toBe(0);
+      m.setSaturation(1.5);
+      expect(m.getSaturation()).toBe(1);
+    });
+
+    it('clamps lightness to [0, 1]', () => {
+      const m = new MandelbrotSet();
+      m.setLightness(-0.1);
+      expect(m.getLightness()).toBe(0);
+      m.setLightness(2.0);
+      expect(m.getLightness()).toBe(1);
+    });
+  });
+
+  describe('array isolation', () => {
+    it('constructor copies the center array', () => {
+      const center: [number, number] = [1, 2];
+      const m = new MandelbrotSet({ center });
+      center[0] = 99;
+      expect(m.getCenter()).toEqual([1, 2, 0]);
+    });
+
+    it('setCenter copies the array', () => {
+      const m = new MandelbrotSet();
+      const center: [number, number] = [3, 4];
+      m.setCenter(center);
+      center[0] = 99;
+      expect(m.getCenter()).toEqual([3, 4, 0]);
+    });
+  });
+
+  describe('method chaining', () => {
+    it('supports chaining multiple setters', () => {
+      const m = new MandelbrotSet();
+      const result = m
+        .setCenter([-1, 0.5])
+        .setZoom(10)
+        .setMaxIterations(200)
+        .setSaturation(0.9)
+        .setLightness(0.6)
+        .setWidth(10)
+        .setHeight(8);
+      expect(result).toBe(m);
+      expect(m.getCenter()).toEqual([-1, 0.5, 0]);
+      expect(m.getZoom()).toBe(10);
+      expect(m.getMaxIterations()).toBe(200);
+    });
+  });
+
+  describe('copy', () => {
+    it('preserves all properties', () => {
+      const m = new MandelbrotSet({
+        width: 12,
+        height: 9,
+        center: [-0.7, 0.2],
+        zoom: 50,
+        maxIterations: 250,
+        saturation: 0.6,
+        lightness: 0.4,
+        opacity: 0.8,
+      });
+      const clone = m.copy();
+      expect(clone).toBeInstanceOf(MandelbrotSet);
+      expect(clone).not.toBe(m);
+      expect(clone.getWidth()).toBe(12);
+      expect(clone.getHeight()).toBe(9);
+      expect(clone.getCenter()).toEqual([-0.7, 0.2, 0]);
+      expect(clone.getZoom()).toBe(50);
+      expect(clone.getMaxIterations()).toBe(250);
+      expect(clone.getSaturation()).toBe(0.6);
+      expect(clone.getLightness()).toBe(0.4);
+      expect(clone.opacity).toBe(0.8);
+    });
+
+    it('copy is independent from original', () => {
+      const m = new MandelbrotSet({ center: [1, 2], zoom: 5 });
+      const clone = m.copy();
+      m.setCenter([99, 99]);
+      m.setZoom(999);
+      expect(clone.getCenter()).toEqual([1, 2, 0]);
+      expect(clone.getZoom()).toBe(5);
+    });
+  });
+});
+
+// ==========================================================================
+// NewtonFractal
+// ==========================================================================
+
+describe('NewtonFractal', () => {
+  describe('construction with defaults', () => {
+    it('has correct default values', () => {
+      const n = new NewtonFractal();
+      expect(n.getWidth()).toBe(8);
+      expect(n.getHeight()).toBe(6);
+      expect(n.getCenter()).toEqual([0, 0, 0]);
+      expect(n.getZoom()).toBe(1);
+      expect(n.getMaxIterations()).toBe(40);
+      expect(n.getCoefficients()).toEqual([-1, 0, 0, 1]);
+      expect(n.getTolerance()).toBe(1e-6);
+      expect(n.getSaturation()).toBe(0.85);
+      expect(n.getLightness()).toBe(0.5);
+      expect(n.opacity).toBe(1);
+      expect(n.fillOpacity).toBe(1);
+    });
+  });
+
+  describe('construction with custom options', () => {
+    it('accepts all custom options', () => {
+      const n = new NewtonFractal({
+        width: 16,
+        height: 12,
+        center: [0.5, -0.5],
+        zoom: 10,
+        maxIterations: 100,
+        coefficients: [-1, 0, 0, 0, 1],
+        tolerance: 1e-10,
+        saturation: 0.7,
+        lightness: 0.3,
+        opacity: 0.6,
+      });
+      expect(n.getWidth()).toBe(16);
+      expect(n.getHeight()).toBe(12);
+      expect(n.getCenter()).toEqual([0.5, -0.5, 0]);
+      expect(n.getZoom()).toBe(10);
+      expect(n.getMaxIterations()).toBe(100);
+      expect(n.getCoefficients()).toEqual([-1, 0, 0, 0, 1]);
+      expect(n.getTolerance()).toBe(1e-10);
+      expect(n.getSaturation()).toBe(0.7);
+      expect(n.getLightness()).toBe(0.3);
+      expect(n.opacity).toBe(0.6);
+      expect(n.fillOpacity).toBe(0.6);
+    });
+  });
+
+  describe('setters return this for chaining', () => {
+    it('setCenter updates and returns this', () => {
+      const n = new NewtonFractal();
+      expect(n.setCenter([2.0, -1.0])).toBe(n);
+      expect(n.getCenter()).toEqual([2.0, -1.0, 0]);
+    });
+
+    it('setZoom updates and returns this', () => {
+      const n = new NewtonFractal();
+      expect(n.setZoom(25)).toBe(n);
+      expect(n.getZoom()).toBe(25);
+    });
+
+    it('setMaxIterations updates and returns this', () => {
+      const n = new NewtonFractal();
+      expect(n.setMaxIterations(80)).toBe(n);
+      expect(n.getMaxIterations()).toBe(80);
+    });
+
+    it('setCoefficients updates and returns this', () => {
+      const n = new NewtonFractal();
+      expect(n.setCoefficients([-1, 0, 0, 0, 0, 1])).toBe(n);
+      expect(n.getCoefficients()).toEqual([-1, 0, 0, 0, 0, 1]);
+    });
+
+    it('setTolerance updates and returns this', () => {
+      const n = new NewtonFractal();
+      expect(n.setTolerance(1e-8)).toBe(n);
+      expect(n.getTolerance()).toBe(1e-8);
+    });
+
+    it('setSaturation updates and returns this', () => {
+      const n = new NewtonFractal();
+      expect(n.setSaturation(0.5)).toBe(n);
+      expect(n.getSaturation()).toBe(0.5);
+    });
+
+    it('setLightness updates and returns this', () => {
+      const n = new NewtonFractal();
+      expect(n.setLightness(0.8)).toBe(n);
+      expect(n.getLightness()).toBe(0.8);
+    });
+
+    it('setWidth updates and returns this', () => {
+      const n = new NewtonFractal();
+      expect(n.setWidth(20)).toBe(n);
+      expect(n.getWidth()).toBe(20);
+    });
+
+    it('setHeight updates and returns this', () => {
+      const n = new NewtonFractal();
+      expect(n.setHeight(15)).toBe(n);
+      expect(n.getHeight()).toBe(15);
+    });
+  });
+
+  describe('validation and clamping', () => {
+    it('setMaxIterations rounds to integer', () => {
+      const n = new NewtonFractal();
+      n.setMaxIterations(39.2);
+      expect(n.getMaxIterations()).toBe(39);
+    });
+
+    it('setMaxIterations enforces minimum of 1', () => {
+      const n = new NewtonFractal();
+      n.setMaxIterations(0);
+      expect(n.getMaxIterations()).toBe(1);
+      n.setMaxIterations(-10);
+      expect(n.getMaxIterations()).toBe(1);
+    });
+
+    it('clamps saturation to [0, 1]', () => {
+      const n = new NewtonFractal();
+      n.setSaturation(-0.2);
+      expect(n.getSaturation()).toBe(0);
+      n.setSaturation(1.5);
+      expect(n.getSaturation()).toBe(1);
+    });
+
+    it('clamps lightness to [0, 1]', () => {
+      const n = new NewtonFractal();
+      n.setLightness(-1);
+      expect(n.getLightness()).toBe(0);
+      n.setLightness(3);
+      expect(n.getLightness()).toBe(1);
+    });
+
+    it('enforces minimum tolerance of 1e-12', () => {
+      const n = new NewtonFractal();
+      n.setTolerance(1e-15);
+      expect(n.getTolerance()).toBe(1e-12);
+      n.setTolerance(0);
+      expect(n.getTolerance()).toBe(1e-12);
+      n.setTolerance(-1);
+      expect(n.getTolerance()).toBe(1e-12);
+    });
+  });
+
+  describe('array isolation', () => {
+    it('constructor copies the center array', () => {
+      const center: [number, number] = [1, 2];
+      const n = new NewtonFractal({ center });
+      center[0] = 99;
+      expect(n.getCenter()).toEqual([1, 2, 0]);
+    });
+
+    it('setCenter copies the array', () => {
+      const n = new NewtonFractal();
+      const center: [number, number] = [5, 6];
+      n.setCenter(center);
+      center[0] = 99;
+      expect(n.getCenter()).toEqual([5, 6, 0]);
+    });
+
+    it('constructor copies the coefficients array', () => {
+      const coeffs = [-1, 0, 0, 1];
+      const n = new NewtonFractal({ coefficients: coeffs });
+      coeffs[0] = 999;
+      expect(n.getCoefficients()).toEqual([-1, 0, 0, 1]);
+    });
+
+    it('setCoefficients copies the array', () => {
+      const n = new NewtonFractal();
+      const coeffs = [1, 0, -1, 0, 1];
+      n.setCoefficients(coeffs);
+      coeffs[0] = 999;
+      expect(n.getCoefficients()).toEqual([1, 0, -1, 0, 1]);
+    });
+
+    it('getCoefficients returns a copy', () => {
+      const n = new NewtonFractal({ coefficients: [-1, 0, 0, 1] });
+      const returned = n.getCoefficients();
+      returned[0] = 999;
+      expect(n.getCoefficients()).toEqual([-1, 0, 0, 1]);
+    });
+  });
+
+  describe('method chaining', () => {
+    it('supports chaining all setters', () => {
+      const n = new NewtonFractal();
+      const result = n
+        .setCenter([1, -1])
+        .setZoom(5)
+        .setMaxIterations(60)
+        .setCoefficients([-1, 0, 0, 0, 1])
+        .setTolerance(1e-8)
+        .setSaturation(0.7)
+        .setLightness(0.4)
+        .setWidth(10)
+        .setHeight(8);
+      expect(result).toBe(n);
+      expect(n.getCenter()).toEqual([1, -1, 0]);
+      expect(n.getZoom()).toBe(5);
+      expect(n.getMaxIterations()).toBe(60);
+      expect(n.getCoefficients()).toEqual([-1, 0, 0, 0, 1]);
+      expect(n.getTolerance()).toBe(1e-8);
+    });
+  });
+
+  describe('copy', () => {
+    it('preserves all properties', () => {
+      const n = new NewtonFractal({
+        width: 16,
+        height: 12,
+        center: [0.5, -0.5],
+        zoom: 10,
+        maxIterations: 80,
+        coefficients: [-1, 0, 0, 0, 1],
+        tolerance: 1e-8,
+        saturation: 0.7,
+        lightness: 0.3,
+        opacity: 0.9,
+      });
+      const clone = n.copy();
+      expect(clone).toBeInstanceOf(NewtonFractal);
+      expect(clone).not.toBe(n);
+      expect(clone.getWidth()).toBe(16);
+      expect(clone.getHeight()).toBe(12);
+      expect(clone.getCenter()).toEqual([0.5, -0.5, 0]);
+      expect(clone.getZoom()).toBe(10);
+      expect(clone.getMaxIterations()).toBe(80);
+      expect(clone.getCoefficients()).toEqual([-1, 0, 0, 0, 1]);
+      expect(clone.getTolerance()).toBe(1e-8);
+      expect(clone.getSaturation()).toBe(0.7);
+      expect(clone.getLightness()).toBe(0.3);
+      expect(clone.opacity).toBe(0.9);
+    });
+
+    it('copy is independent from original', () => {
+      const n = new NewtonFractal({
+        center: [1, 2],
+        zoom: 5,
+        coefficients: [-1, 0, 0, 1],
+      });
+      const clone = n.copy();
+      n.setCenter([99, 99]);
+      n.setZoom(999);
+      n.setCoefficients([1, 2, 3]);
+      expect(clone.getCenter()).toEqual([1, 2, 0]);
+      expect(clone.getZoom()).toBe(5);
+      expect(clone.getCoefficients()).toEqual([-1, 0, 0, 1]);
+    });
+  });
+
+  describe('polynomial representations', () => {
+    it('can represent various polynomials', () => {
+      // z^2 - 1
+      const n2 = new NewtonFractal({ coefficients: [-1, 0, 1] });
+      expect(n2.getCoefficients()).toEqual([-1, 0, 1]);
+
+      // z^5 - 1
+      const n5 = new NewtonFractal({ coefficients: [-1, 0, 0, 0, 0, 1] });
+      expect(n5.getCoefficients()).toHaveLength(6);
+
+      // linear: z + 1
+      const n1 = new NewtonFractal({ coefficients: [1, 1] });
+      expect(n1.getCoefficients()).toEqual([1, 1]);
+    });
+
+    it('supports up to 12-coefficient polynomials', () => {
+      const coeffs = new Array(12).fill(0);
+      coeffs[0] = -1;
+      coeffs[11] = 1;
+      const n = new NewtonFractal({ coefficients: coeffs });
+      expect(n.getCoefficients()).toHaveLength(12);
+      expect(n.getCoefficients()[0]).toBe(-1);
+      expect(n.getCoefficients()[11]).toBe(1);
+    });
+  });
+});

--- a/src/mobjects/graph/graph-helpers.test.ts
+++ b/src/mobjects/graph/graph-helpers.test.ts
@@ -1,0 +1,461 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Graph,
+  DiGraph,
+  GenericGraph,
+  completeGraph,
+  cycleGraph,
+  pathGraph,
+  starGraph,
+  binaryTree,
+  gridGraph,
+  bipartiteGraph,
+} from './index';
+
+describe('Layout algorithms', () => {
+  it('circular layout places vertices on a circle', () => {
+    const g = new Graph({
+      vertices: [0, 1, 2, 3],
+      layout: { type: 'circular', scale: 2, center: [0, 0, 0] },
+    });
+    const positions = g.getPositions();
+    expect(positions.size).toBe(4);
+    for (const [, pos] of positions) {
+      const dist = Math.sqrt(pos[0] ** 2 + pos[1] ** 2);
+      expect(dist).toBeCloseTo(2, 1);
+    }
+  });
+
+  it('circular layout with custom center offsets positions', () => {
+    const g = new Graph({
+      vertices: [0, 1],
+      layout: { type: 'circular', scale: 1, center: [5, 5, 0] },
+    });
+    for (const [, pos] of g.getPositions()) {
+      const dist = Math.sqrt((pos[0] - 5) ** 2 + (pos[1] - 5) ** 2);
+      expect(dist).toBeCloseTo(1, 1);
+    }
+  });
+
+  it('grid layout places vertices in a grid pattern', () => {
+    const g = new Graph({
+      vertices: [0, 1, 2, 3],
+      layout: { type: 'grid', scale: 2, center: [0, 0, 0] },
+    });
+    const pts = Array.from(g.getPositions().values());
+    const xs = new Set(pts.map((p) => Math.round(p[0] * 100)));
+    const ys = new Set(pts.map((p) => Math.round(p[1] * 100)));
+    expect(xs.size).toBe(2);
+    expect(ys.size).toBe(2);
+  });
+
+  it('custom layout uses provided positions', () => {
+    const positions = new Map<string | number, [number, number, number]>();
+    positions.set('a', [1, 2, 0]);
+    positions.set('b', [3, 4, 0]);
+    const g = new Graph({ vertices: ['a', 'b'], layout: { type: 'custom', positions } });
+    expect(g.getVertexPosition('a')).toEqual([1, 2, 0]);
+    expect(g.getVertexPosition('b')).toEqual([3, 4, 0]);
+  });
+
+  it('tree layout assigns positions hierarchically', () => {
+    const g = new Graph({
+      vertices: ['root', 'L', 'R'],
+      edges: [
+        ['root', 'L'],
+        ['root', 'R'],
+      ],
+      layout: { type: 'tree', root: 'root', scale: 2, center: [0, 0, 0] },
+    });
+    const positions = g.getPositions();
+    expect(positions.get('root')![1]).toBeGreaterThan(positions.get('L')![1]);
+    expect(positions.get('root')![1]).toBeGreaterThan(positions.get('R')![1]);
+    expect(positions.get('L')![1]).toBeCloseTo(positions.get('R')![1], 5);
+  });
+
+  it('tree layout defaults to first vertex as root', () => {
+    const g = new Graph({
+      vertices: [1, 2, 3],
+      edges: [
+        [1, 2],
+        [1, 3],
+      ],
+      layout: { type: 'tree', scale: 2 },
+    });
+    expect(g.getPositions().get(1)![1]).toBeGreaterThan(g.getPositions().get(2)![1]);
+  });
+
+  it('tree layout handles disconnected vertices', () => {
+    const g = new Graph({
+      vertices: [1, 2, 3, 99],
+      edges: [
+        [1, 2],
+        [1, 3],
+      ],
+      layout: { type: 'tree', root: 1, scale: 2 },
+    });
+    expect(g.getPositions().size).toBe(4);
+    expect(g.getPositions().get(99)).toBeDefined();
+  });
+
+  it('bipartite layout splits vertices into two columns', () => {
+    const left = ['L0', 'L1'];
+    const right = ['R0', 'R1'];
+    const g = new Graph({
+      vertices: [...left, ...right],
+      edges: [
+        ['L0', 'R0'],
+        ['L1', 'R1'],
+      ],
+      layout: { type: 'bipartite', partition: [left, right], scale: 2, center: [0, 0, 0] },
+    });
+    const positions = g.getPositions();
+    for (const v of left) expect(positions.get(v)![0]).toBeCloseTo(-2, 5);
+    for (const v of right) expect(positions.get(v)![0]).toBeCloseTo(2, 5);
+  });
+
+  it('bipartite layout defaults to half-half split', () => {
+    const g = new Graph({ vertices: [1, 2, 3, 4], layout: { type: 'bipartite', scale: 2 } });
+    const positions = g.getPositions();
+    expect(positions.get(1)![0]).toBeCloseTo(-2, 5);
+    expect(positions.get(2)![0]).toBeCloseTo(-2, 5);
+    expect(positions.get(3)![0]).toBeCloseTo(2, 5);
+    expect(positions.get(4)![0]).toBeCloseTo(2, 5);
+  });
+
+  it('shell layout places all vertices with 3-tuples', () => {
+    const g = new Graph({
+      vertices: [0, 1, 2, 3, 4, 5, 6, 7],
+      layout: { type: 'shell', scale: 2, center: [0, 0, 0] },
+    });
+    expect(g.getPositions().size).toBe(8);
+    for (const [, pos] of g.getPositions()) expect(pos).toHaveLength(3);
+  });
+
+  it('kamada_kawai layout places all vertices', () => {
+    const g = new Graph({
+      vertices: [1, 2, 3],
+      edges: [
+        [1, 2],
+        [2, 3],
+      ],
+      layout: { type: 'kamada_kawai', scale: 2, center: [0, 0, 0] },
+    });
+    expect(g.getPositions().size).toBe(3);
+  });
+
+  it('kamada_kawai with single vertex places at center', () => {
+    const g = new Graph({
+      vertices: [1],
+      layout: { type: 'kamada_kawai', scale: 2, center: [3, 4, 0] },
+    });
+    const pos = g.getVertexPosition(1)!;
+    expect(pos[0]).toBeCloseTo(3, 5);
+    expect(pos[1]).toBeCloseTo(4, 5);
+  });
+
+  it('random layout produces positions for all vertices', () => {
+    const g = new Graph({
+      vertices: [1, 2, 3, 4, 5],
+      layout: { type: 'random', scale: 3, center: [0, 0, 0] },
+    });
+    expect(g.getPositions().size).toBe(5);
+  });
+
+  it('spring layout produces positions for all vertices', () => {
+    const g = new Graph({
+      vertices: [1, 2, 3],
+      edges: [
+        [1, 2],
+        [2, 3],
+      ],
+      layout: { type: 'spring', scale: 2, iterations: 5 },
+    });
+    expect(g.getPositions().size).toBe(3);
+  });
+
+  it('layout string shorthand sets type', () => {
+    expect(new Graph({ vertices: [1, 2, 3], layout: 'circular' }).getPositions().size).toBe(3);
+  });
+
+  it('setLayout changes the layout', () => {
+    const g = new Graph({
+      vertices: [1, 2, 3, 4],
+      edges: [
+        [1, 2],
+        [2, 3],
+        [3, 4],
+      ],
+      layout: 'circular',
+    });
+    g.setLayout('grid');
+    expect(g.getPositions().size).toBe(4);
+  });
+
+  it('setLayout with config object', () => {
+    const g = new Graph({ vertices: [1, 2], layout: 'circular' });
+    g.setLayout({ type: 'grid', scale: 5 });
+    expect(g.getPositions().size).toBe(2);
+  });
+
+  it('setLayout returns this for chaining', () => {
+    expect(new Graph({ vertices: [1] }).setLayout('circular')).toBeInstanceOf(Graph);
+  });
+
+  it('getPositions returns a copy', () => {
+    const g = new Graph({ vertices: [1, 2] });
+    expect(g.getPositions()).not.toBe(g.getPositions());
+  });
+
+  it('empty vertices produces empty layout', () => {
+    expect(new Graph({ layout: 'circular' }).getPositions().size).toBe(0);
+  });
+});
+
+describe('Styling operations', () => {
+  it('setVertexColor returns this for chaining', () => {
+    expect(new Graph({ vertices: [1] }).setVertexColor(1, '#FF0000')).toBeInstanceOf(Graph);
+  });
+
+  it('setVertexColor on missing vertex is a no-op', () => {
+    expect(new Graph().setVertexColor(99, '#FF0000')).toBeInstanceOf(Graph);
+  });
+
+  it('setEdgeColor returns this for chaining', () => {
+    expect(
+      new Graph({ vertices: [1, 2], edges: [[1, 2]] }).setEdgeColor(1, 2, '#0F0'),
+    ).toBeInstanceOf(Graph);
+  });
+
+  it('setEdgeColor on missing edge is a no-op', () => {
+    expect(new Graph().setEdgeColor(1, 2, '#00FF00')).toBeInstanceOf(Graph);
+  });
+
+  it('highlightPath returns this for chaining', () => {
+    const g = new Graph({
+      vertices: [1, 2, 3],
+      edges: [
+        [1, 2],
+        [2, 3],
+      ],
+    });
+    expect(g.highlightPath([1, 2, 3])).toBe(g);
+  });
+
+  it('highlightPath works with custom colors', () => {
+    const g = new Graph({
+      vertices: [1, 2, 3],
+      edges: [
+        [1, 2],
+        [2, 3],
+      ],
+    });
+    expect(g.highlightPath([1, 2, 3], '#00FF00', '#0000FF')).toBe(g);
+  });
+
+  it('resetColors returns this for chaining', () => {
+    const g = new Graph({ vertices: [1, 2], edges: [[1, 2]] });
+    g.highlightPath([1, 2]);
+    expect(g.resetColors()).toBe(g);
+  });
+
+  it('resetColors with per-vertex config', () => {
+    const vcfg = new Map();
+    vcfg.set(1, { style: { color: '#FF0000' } });
+    const g = new Graph({ vertices: [1, 2], edges: [[1, 2]], vertexConfig: vcfg });
+    g.highlightPath([1, 2]);
+    expect(g.resetColors()).toBe(g);
+  });
+
+  it('resetColors with per-edge config', () => {
+    const ecfg = new Map();
+    ecfg.set('1--2', { style: { color: '#00FF00' } });
+    const g = new Graph({ vertices: [1, 2], edges: [[1, 2]], edgeConfig: ecfg });
+    g.highlightPath([1, 2]);
+    expect(g.resetColors()).toBe(g);
+  });
+});
+
+describe('completeGraph', () => {
+  it('creates K0 (empty)', () => {
+    expect(completeGraph(0).numVertices).toBe(0);
+    expect(completeGraph(0).numEdges).toBe(0);
+  });
+
+  it('creates K1 (single vertex, no edges)', () => {
+    expect(completeGraph(1).numVertices).toBe(1);
+    expect(completeGraph(1).numEdges).toBe(0);
+  });
+
+  it('creates K3 with 3 edges', () => {
+    expect(completeGraph(3).numEdges).toBe(3);
+  });
+
+  it('creates K4 with n*(n-1)/2 = 6 edges', () => {
+    expect(completeGraph(4).numEdges).toBe(6);
+  });
+
+  it('creates K5 with 10 edges', () => {
+    expect(completeGraph(5).numEdges).toBe(10);
+  });
+
+  it('returns a Graph instance', () => {
+    expect(completeGraph(3)).toBeInstanceOf(Graph);
+  });
+
+  it('accepts custom options', () => {
+    expect(completeGraph(3, { layout: 'grid' }).numVertices).toBe(3);
+  });
+});
+
+describe('cycleGraph', () => {
+  it('creates C3 with degree 2 for all vertices', () => {
+    const g = cycleGraph(3);
+    expect(g.numVertices).toBe(3);
+    expect(g.numEdges).toBe(3);
+    for (let i = 0; i < 3; i++) expect(g.getDegree(i)).toBe(2);
+  });
+
+  it('creates C4 (square)', () => {
+    expect(cycleGraph(4).numEdges).toBe(4);
+  });
+
+  it('creates C1 (self-loop)', () => {
+    expect(cycleGraph(1).numEdges).toBe(1);
+  });
+
+  it('returns a Graph instance', () => {
+    expect(cycleGraph(5)).toBeInstanceOf(Graph);
+  });
+});
+
+describe('pathGraph', () => {
+  it('creates P1 (single vertex, no edges)', () => {
+    expect(pathGraph(1).numEdges).toBe(0);
+  });
+
+  it('creates P3 with endpoint degree 1 and middle degree 2', () => {
+    const g = pathGraph(3);
+    expect(g.numEdges).toBe(2);
+    expect(g.getDegree(0)).toBe(1);
+    expect(g.getDegree(1)).toBe(2);
+    expect(g.getDegree(2)).toBe(1);
+  });
+
+  it('P5 has n-1 edges', () => {
+    expect(pathGraph(5).numEdges).toBe(4);
+  });
+
+  it('returns a Graph instance', () => {
+    expect(pathGraph(3)).toBeInstanceOf(Graph);
+  });
+});
+
+describe('starGraph', () => {
+  it('creates S3 (center + 3 outer)', () => {
+    const g = starGraph(3);
+    expect(g.numVertices).toBe(4);
+    expect(g.numEdges).toBe(3);
+    expect(g.getDegree(0)).toBe(3);
+  });
+
+  it('creates S1 (center + 1 outer)', () => {
+    expect(starGraph(1).numVertices).toBe(2);
+  });
+
+  it('outer vertices have degree 1', () => {
+    const g = starGraph(4);
+    for (let i = 1; i <= 4; i++) expect(g.getDegree(i)).toBe(1);
+  });
+
+  it('returns a Graph instance', () => {
+    expect(starGraph(3)).toBeInstanceOf(Graph);
+  });
+});
+
+describe('binaryTree', () => {
+  it('creates depth-0 tree (single root)', () => {
+    expect(binaryTree(0).numVertices).toBe(1);
+    expect(binaryTree(0).numEdges).toBe(0);
+  });
+
+  it('creates depth-1 tree (3 nodes, 2 edges)', () => {
+    expect(binaryTree(1).numVertices).toBe(3);
+    expect(binaryTree(1).numEdges).toBe(2);
+  });
+
+  it('creates depth-2 tree (7 nodes, 6 edges)', () => {
+    expect(binaryTree(2).numVertices).toBe(7);
+    expect(binaryTree(2).numEdges).toBe(6);
+  });
+
+  it('returns a DiGraph instance', () => {
+    expect(binaryTree(1)).toBeInstanceOf(DiGraph);
+    expect(binaryTree(1)).toBeInstanceOf(GenericGraph);
+  });
+
+  it('root has out-degree 2', () => {
+    expect(binaryTree(2).getOutDegree(0)).toBe(2);
+  });
+
+  it('leaf nodes have out-degree 0', () => {
+    const t = binaryTree(2);
+    for (const leaf of [3, 4, 5, 6]) expect(t.getOutDegree(leaf)).toBe(0);
+  });
+});
+
+describe('gridGraph', () => {
+  it('creates 2x2 grid (4 edges)', () => {
+    expect(gridGraph(2, 2).numVertices).toBe(4);
+    expect(gridGraph(2, 2).numEdges).toBe(4);
+  });
+
+  it('creates 3x3 grid (12 edges)', () => {
+    expect(gridGraph(3, 3).numEdges).toBe(12);
+  });
+
+  it('creates 1x1 grid (no edges)', () => {
+    expect(gridGraph(1, 1).numEdges).toBe(0);
+  });
+
+  it('creates 1xN path', () => {
+    expect(gridGraph(1, 4).numEdges).toBe(3);
+  });
+
+  it('vertex ids use row,col format', () => {
+    const g = gridGraph(2, 3);
+    expect(g.hasVertex('0,0')).toBe(true);
+    expect(g.hasVertex('1,2')).toBe(true);
+    expect(g.hasVertex('0,3')).toBe(false);
+  });
+
+  it('returns a Graph instance', () => {
+    expect(gridGraph(2, 2)).toBeInstanceOf(Graph);
+  });
+});
+
+describe('bipartiteGraph', () => {
+  it('creates complete bipartite K(2,3) with 6 edges', () => {
+    expect(bipartiteGraph(2, 3).numEdges).toBe(6);
+  });
+
+  it('creates K(1,1)', () => {
+    expect(bipartiteGraph(1, 1).numEdges).toBe(1);
+  });
+
+  it('vertices use L/R prefix', () => {
+    const g = bipartiteGraph(2, 2);
+    expect(g.hasVertex('L0')).toBe(true);
+    expect(g.hasVertex('R1')).toBe(true);
+  });
+
+  it('creates bipartite with custom edges', () => {
+    const g = bipartiteGraph(2, 2, [['L0', 'R1']]);
+    expect(g.numEdges).toBe(1);
+    expect(g.hasEdge('L0', 'R1')).toBe(true);
+  });
+
+  it('returns a Graph instance', () => {
+    expect(bipartiteGraph(2, 2)).toBeInstanceOf(Graph);
+  });
+});

--- a/src/mobjects/graph/graph.test.ts
+++ b/src/mobjects/graph/graph.test.ts
@@ -1,0 +1,510 @@
+import { describe, it, expect } from 'vitest';
+import { Graph, DiGraph, GenericGraph } from './index';
+
+// ============================================================================
+// Graph (undirected) construction
+// ============================================================================
+
+describe('Graph construction', () => {
+  it('constructs an empty graph with defaults', () => {
+    const g = new Graph();
+    expect(g.numVertices).toBe(0);
+    expect(g.numEdges).toBe(0);
+    expect(g.getVertices()).toEqual([]);
+    expect(g.getEdges()).toEqual([]);
+  });
+
+  it('constructs a graph with vertices only', () => {
+    const g = new Graph({ vertices: ['a', 'b', 'c'] });
+    expect(g.numVertices).toBe(3);
+    expect(g.numEdges).toBe(0);
+    expect(g.getVertices()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('constructs a graph with vertices and edges', () => {
+    const g = new Graph({
+      vertices: [1, 2, 3],
+      edges: [
+        [1, 2],
+        [2, 3],
+      ],
+    });
+    expect(g.numVertices).toBe(3);
+    expect(g.numEdges).toBe(2);
+  });
+
+  it('constructs with numeric vertex ids', () => {
+    const g = new Graph({ vertices: [10, 20, 30] });
+    expect(g.hasVertex(10)).toBe(true);
+    expect(g.hasVertex(20)).toBe(true);
+    expect(g.hasVertex(30)).toBe(true);
+    expect(g.hasVertex(40)).toBe(false);
+  });
+
+  it('is an instance of GenericGraph', () => {
+    expect(new Graph()).toBeInstanceOf(GenericGraph);
+  });
+});
+
+// ============================================================================
+// Vertex operations
+// ============================================================================
+
+describe('Vertex operations', () => {
+  it('addVertex adds a new vertex', () => {
+    const g = new Graph();
+    g.addVertex('x');
+    expect(g.hasVertex('x')).toBe(true);
+    expect(g.numVertices).toBe(1);
+  });
+
+  it('addVertex is idempotent for existing vertex', () => {
+    const g = new Graph({ vertices: ['a'] });
+    g.addVertex('a');
+    expect(g.numVertices).toBe(1);
+  });
+
+  it('addVertex returns this for chaining', () => {
+    const g = new Graph();
+    expect(g.addVertex('v')).toBe(g);
+  });
+
+  it('addVertex with config stores position', () => {
+    const g = new Graph();
+    g.addVertex('v', { position: [3, 4, 0] });
+    expect(g.hasVertex('v')).toBe(true);
+    const pos = g.getVertexPosition('v');
+    expect(pos).toBeDefined();
+    expect(pos![0]).toBeCloseTo(3, 5);
+    expect(pos![1]).toBeCloseTo(4, 5);
+  });
+
+  it('addVertices adds multiple vertices at once', () => {
+    const g = new Graph();
+    g.addVertices('a', 'b', 'c');
+    expect(g.numVertices).toBe(3);
+    expect(g.hasVertex('a')).toBe(true);
+    expect(g.hasVertex('b')).toBe(true);
+    expect(g.hasVertex('c')).toBe(true);
+  });
+
+  it('addVertices skips already existing vertices', () => {
+    const g = new Graph({ vertices: ['a'] });
+    g.addVertices('a', 'b');
+    expect(g.numVertices).toBe(2);
+  });
+
+  it('addVertices returns this for chaining', () => {
+    expect(new Graph().addVertices('x')).toBeInstanceOf(Graph);
+  });
+
+  it('removeVertex removes a vertex', () => {
+    const g = new Graph({ vertices: ['a', 'b', 'c'] });
+    g.removeVertex('b');
+    expect(g.hasVertex('b')).toBe(false);
+    expect(g.numVertices).toBe(2);
+  });
+
+  it('removeVertex also removes connected edges', () => {
+    const g = new Graph({
+      vertices: ['a', 'b', 'c'],
+      edges: [
+        ['a', 'b'],
+        ['b', 'c'],
+        ['a', 'c'],
+      ],
+    });
+    g.removeVertex('b');
+    expect(g.numEdges).toBe(1);
+    expect(g.hasEdge('a', 'c')).toBe(true);
+    expect(g.hasEdge('a', 'b')).toBe(false);
+  });
+
+  it('removeVertex on non-existent vertex is a no-op', () => {
+    const g = new Graph({ vertices: ['a'] });
+    g.removeVertex('z');
+    expect(g.numVertices).toBe(1);
+  });
+
+  it('removeVertex returns this for chaining', () => {
+    const g = new Graph({ vertices: ['a'] });
+    expect(g.removeVertex('a')).toBe(g);
+  });
+
+  it('getVertices returns a copy', () => {
+    const g = new Graph({ vertices: [1, 2, 3] });
+    const v = g.getVertices();
+    v.push(99);
+    expect(g.numVertices).toBe(3);
+  });
+
+  it('getVertexPosition returns position or undefined', () => {
+    const g = new Graph({ vertices: [1], layout: 'circular' });
+    expect(g.getVertexPosition(1)).toBeDefined();
+    expect(g.getVertexPosition(999)).toBeUndefined();
+  });
+
+  it('setVertexPosition updates position', () => {
+    const g = new Graph({
+      vertices: [1, 2],
+      edges: [[1, 2]],
+      layout: 'circular',
+    });
+    g.setVertexPosition(1, [5, 5, 0]);
+    expect(g.getVertexPosition(1)).toEqual([5, 5, 0]);
+  });
+
+  it('setVertexPosition on non-existent vertex is a no-op', () => {
+    const g = new Graph();
+    expect(g.setVertexPosition(999, [1, 1, 0])).toBe(g);
+  });
+
+  it('setVertexPosition returns this for chaining', () => {
+    const g = new Graph({ vertices: [1] });
+    expect(g.setVertexPosition(1, [0, 0, 0])).toBe(g);
+  });
+
+  it('getVertexMobject returns Dot for existing vertex', () => {
+    const g = new Graph({ vertices: ['a'] });
+    expect(g.getVertexMobject('a')).toBeDefined();
+  });
+
+  it('getVertexMobject returns undefined for missing vertex', () => {
+    expect(new Graph().getVertexMobject('x')).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Neighbor and degree
+// ============================================================================
+
+describe('Neighbors and degree', () => {
+  it('getNeighbors returns adjacent vertices', () => {
+    const g = new Graph({
+      vertices: [1, 2, 3, 4],
+      edges: [
+        [1, 2],
+        [1, 3],
+        [3, 4],
+      ],
+    });
+    expect(g.getNeighbors(1).sort()).toEqual([2, 3]);
+  });
+
+  it('getNeighbors returns empty array for isolated vertex', () => {
+    const g = new Graph({ vertices: [1, 2] });
+    expect(g.getNeighbors(1)).toEqual([]);
+  });
+
+  it('getDegree returns correct count', () => {
+    const g = new Graph({
+      vertices: [1, 2, 3, 4],
+      edges: [
+        [1, 2],
+        [1, 3],
+        [1, 4],
+      ],
+    });
+    expect(g.getDegree(1)).toBe(3);
+    expect(g.getDegree(2)).toBe(1);
+  });
+
+  it('getDegree is 0 for isolated vertex', () => {
+    expect(new Graph({ vertices: ['solo'] }).getDegree('solo')).toBe(0);
+  });
+});
+
+// ============================================================================
+// Edge operations
+// ============================================================================
+
+describe('Edge operations', () => {
+  it('addEdge adds a new edge', () => {
+    const g = new Graph({ vertices: ['a', 'b'] });
+    g.addEdge('a', 'b');
+    expect(g.hasEdge('a', 'b')).toBe(true);
+    expect(g.numEdges).toBe(1);
+  });
+
+  it('addEdge also adds missing vertices', () => {
+    const g = new Graph();
+    g.addEdge('x', 'y');
+    expect(g.hasVertex('x')).toBe(true);
+    expect(g.hasVertex('y')).toBe(true);
+    expect(g.numEdges).toBe(1);
+  });
+
+  it('addEdge is idempotent for duplicate edge', () => {
+    const g = new Graph({ vertices: ['a', 'b'], edges: [['a', 'b']] });
+    g.addEdge('a', 'b');
+    expect(g.numEdges).toBe(1);
+  });
+
+  it('addEdge returns this for chaining', () => {
+    const g = new Graph({ vertices: [1, 2] });
+    expect(g.addEdge(1, 2)).toBe(g);
+  });
+
+  it('addEdges adds multiple edges', () => {
+    const g = new Graph({ vertices: [1, 2, 3, 4] });
+    g.addEdges([1, 2], [3, 4]);
+    expect(g.numEdges).toBe(2);
+    expect(g.hasEdge(1, 2)).toBe(true);
+    expect(g.hasEdge(3, 4)).toBe(true);
+  });
+
+  it('addEdges creates missing vertices', () => {
+    const g = new Graph();
+    g.addEdges([10, 20], [20, 30]);
+    expect(g.numVertices).toBe(3);
+    expect(g.numEdges).toBe(2);
+  });
+
+  it('addEdges returns this for chaining', () => {
+    expect(new Graph().addEdges([1, 2])).toBeInstanceOf(Graph);
+  });
+
+  it('removeEdge removes an existing edge', () => {
+    const g = new Graph({
+      vertices: [1, 2, 3],
+      edges: [
+        [1, 2],
+        [2, 3],
+      ],
+    });
+    g.removeEdge(1, 2);
+    expect(g.hasEdge(1, 2)).toBe(false);
+    expect(g.numEdges).toBe(1);
+    expect(g.hasVertex(1)).toBe(true);
+    expect(g.hasVertex(2)).toBe(true);
+  });
+
+  it('removeEdge on non-existent edge is a no-op', () => {
+    const g = new Graph({ vertices: [1, 2], edges: [[1, 2]] });
+    g.removeEdge(1, 3);
+    expect(g.numEdges).toBe(1);
+  });
+
+  it('removeEdge returns this for chaining', () => {
+    expect(new Graph().removeEdge(1, 2)).toBeInstanceOf(Graph);
+  });
+
+  it('getEdges returns a copy of edge list', () => {
+    const g = new Graph({ vertices: [1, 2], edges: [[1, 2]] });
+    const edges = g.getEdges();
+    edges.push([3, 4]);
+    expect(g.numEdges).toBe(1);
+  });
+
+  it('hasEdge is symmetric for undirected graph', () => {
+    const g = new Graph({ vertices: ['a', 'b'], edges: [['a', 'b']] });
+    expect(g.hasEdge('a', 'b')).toBe(true);
+    expect(g.hasEdge('b', 'a')).toBe(true);
+  });
+
+  it('getEdgeMobject returns mobject for existing edge', () => {
+    const g = new Graph({ vertices: [1, 2], edges: [[1, 2]] });
+    expect(g.getEdgeMobject(1, 2)).toBeDefined();
+  });
+
+  it('getEdgeMobject returns undefined for missing edge', () => {
+    expect(new Graph({ vertices: [1, 2] }).getEdgeMobject(1, 2)).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// DiGraph (directed)
+// ============================================================================
+
+describe('DiGraph', () => {
+  it('constructs an empty directed graph', () => {
+    const dg = new DiGraph();
+    expect(dg.numVertices).toBe(0);
+    expect(dg.numEdges).toBe(0);
+  });
+
+  it('is an instance of GenericGraph', () => {
+    expect(new DiGraph()).toBeInstanceOf(GenericGraph);
+  });
+
+  it('constructs with vertices and edges', () => {
+    const dg = new DiGraph({
+      vertices: ['a', 'b', 'c'],
+      edges: [
+        ['a', 'b'],
+        ['b', 'c'],
+      ],
+    });
+    expect(dg.numVertices).toBe(3);
+    expect(dg.numEdges).toBe(2);
+  });
+
+  it('hasEdge is directional', () => {
+    const dg = new DiGraph({ vertices: ['a', 'b'], edges: [['a', 'b']] });
+    expect(dg.hasEdge('a', 'b')).toBe(true);
+    expect(dg.hasEdge('b', 'a')).toBe(false);
+  });
+
+  it('getOutNeighbors returns outgoing neighbors', () => {
+    const dg = new DiGraph({
+      vertices: [1, 2, 3],
+      edges: [
+        [1, 2],
+        [1, 3],
+        [2, 3],
+      ],
+    });
+    expect(dg.getOutNeighbors(1).sort()).toEqual([2, 3]);
+    expect(dg.getOutNeighbors(3)).toEqual([]);
+  });
+
+  it('getInNeighbors returns incoming neighbors', () => {
+    const dg = new DiGraph({
+      vertices: [1, 2, 3],
+      edges: [
+        [1, 2],
+        [1, 3],
+        [2, 3],
+      ],
+    });
+    expect(dg.getInNeighbors(3).sort()).toEqual([1, 2]);
+    expect(dg.getInNeighbors(1)).toEqual([]);
+  });
+
+  it('getOutDegree counts outgoing edges', () => {
+    const dg = new DiGraph({
+      vertices: [1, 2, 3],
+      edges: [
+        [1, 2],
+        [1, 3],
+      ],
+    });
+    expect(dg.getOutDegree(1)).toBe(2);
+    expect(dg.getOutDegree(2)).toBe(0);
+  });
+
+  it('getInDegree counts incoming edges', () => {
+    const dg = new DiGraph({
+      vertices: [1, 2, 3],
+      edges: [
+        [1, 3],
+        [2, 3],
+      ],
+    });
+    expect(dg.getInDegree(3)).toBe(2);
+    expect(dg.getInDegree(1)).toBe(0);
+  });
+
+  it('addEdge works on directed graph', () => {
+    const dg = new DiGraph({ vertices: ['a', 'b'] });
+    dg.addEdge('a', 'b');
+    expect(dg.hasEdge('a', 'b')).toBe(true);
+    expect(dg.hasEdge('b', 'a')).toBe(false);
+  });
+
+  it('removeEdge works on directed graph', () => {
+    const dg = new DiGraph({ vertices: ['a', 'b'], edges: [['a', 'b']] });
+    dg.removeEdge('a', 'b');
+    expect(dg.hasEdge('a', 'b')).toBe(false);
+  });
+});
+
+// ============================================================================
+// Edge shortening (tested via construction since _shortenEdge is protected)
+// ============================================================================
+
+describe('Edge shortening', () => {
+  it('edges between distant vertices are created', () => {
+    const positions = new Map<string | number, [number, number, number]>();
+    positions.set('a', [-5, 0, 0]);
+    positions.set('b', [5, 0, 0]);
+    const g = new Graph({
+      vertices: ['a', 'b'],
+      edges: [['a', 'b']],
+      layout: { type: 'custom', positions },
+    });
+    expect(g.getEdgeMobject('a', 'b')).toBeDefined();
+  });
+
+  it('edges between very close vertices are still created', () => {
+    const positions = new Map<string | number, [number, number, number]>();
+    positions.set('a', [0, 0, 0]);
+    positions.set('b', [0.01, 0, 0]);
+    const g = new Graph({
+      vertices: ['a', 'b'],
+      edges: [['a', 'b']],
+      layout: { type: 'custom', positions },
+    });
+    expect(g.getEdgeMobject('a', 'b')).toBeDefined();
+  });
+});
+
+// ============================================================================
+// Custom vertex/edge styling
+// ============================================================================
+
+describe('Custom vertex/edge styling via options', () => {
+  it('custom vertexStyle is applied', () => {
+    const g = new Graph({
+      vertices: [1],
+      vertexStyle: { radius: 0.5, color: '#FF0000' },
+    });
+    expect(g.getVertexMobject(1)).toBeDefined();
+  });
+
+  it('custom edgeStyle is applied', () => {
+    const g = new Graph({
+      vertices: [1, 2],
+      edges: [[1, 2]],
+      edgeStyle: { color: '#00FF00', strokeWidth: 8 },
+    });
+    expect(g.getEdgeMobject(1, 2)).toBeDefined();
+  });
+
+  it('per-vertex style overrides default', () => {
+    const vcfg = new Map();
+    vcfg.set(1, { style: { color: '#FF0000', radius: 0.3 } });
+    const g = new Graph({ vertices: [1, 2], vertexConfig: vcfg });
+    expect(g.getVertexMobject(1)).toBeDefined();
+    expect(g.getVertexMobject(2)).toBeDefined();
+  });
+
+  it('vertexConfig as plain object', () => {
+    const g = new Graph({
+      vertices: ['a'],
+      vertexConfig: { a: { position: [7, 8, 0] } },
+    });
+    const pos = g.getVertexPosition('a')!;
+    expect(pos[0]).toBeCloseTo(7, 5);
+    expect(pos[1]).toBeCloseTo(8, 5);
+  });
+
+  it('edgeConfig as plain object', () => {
+    const g = new Graph({
+      vertices: ['a', 'b'],
+      edges: [['a', 'b']],
+      edgeConfig: { 'a--b': { weight: 5 } },
+    });
+    expect(g.hasEdge('a', 'b')).toBe(true);
+  });
+
+  it('edgeConfig as Map', () => {
+    const ecfg = new Map();
+    ecfg.set('a--b', { weight: 3 });
+    const g = new Graph({
+      vertices: ['a', 'b'],
+      edges: [['a', 'b']],
+      edgeConfig: ecfg,
+    });
+    expect(g.hasEdge('a', 'b')).toBe(true);
+  });
+
+  it('vertexConfig as Map overrides layout position', () => {
+    const vcfg = new Map();
+    vcfg.set('a', { position: [10, 20, 0] as [number, number, number] });
+    const g = new Graph({ vertices: ['a', 'b'], layout: 'circular', vertexConfig: vcfg });
+    const pos = g.getVertexPosition('a')!;
+    expect(pos[0]).toBeCloseTo(10, 5);
+    expect(pos[1]).toBeCloseTo(20, 5);
+  });
+});


### PR DESCRIPTION
…mprove coverage from 65% to 72%

New test files (10):
- animation-numbers: ChangingDecimal, ChangeDecimalToValue (34 tests)
- animation-speed: ChangeSpeed, speed functions (31 tests)
- animation-utility: Add, Remove, Wait, Rotating, Broadcast (49 tests)
- indication-extra: ApplyWave, Circumscribe, Flash (46 tests)
- indication-pulse: FocusOn, Pulse (27 tests)
- creation: Create, Write, Uncreate, DrawBorderThenFill, text animations (51 tests)
- core-camera: Camera2DFrame, CameraFrame, CameraAnimateProxy (47 tests)
- graph: Graph, DiGraph, vertex/edge operations (60 tests)
- graph-helpers: layouts, completeGraph, cycleGraph, pathGraph, starGraph (65 tests)
- fractals: MandelbrotSet, NewtonFractal (44 tests)

## Summary
Brief description of changes.

## Changes
- ...

## Testing
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types check (`npm run typecheck`)

## Related Issues
Closes #
