### PR TITLE
Make docs examples responsive for mobile

### DIFF
--- a/docs/src/components/ManimExample.tsx
+++ b/docs/src/components/ManimExample.tsx
@@ -4,7 +4,11 @@ import BrowserOnly from '@docusaurus/BrowserOnly';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnimationFn = (scene: any) => Promise<void>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SceneFactory = (container: HTMLElement, manim: any) => any | Promise<any>;
+type SceneFactory = (
+  container: HTMLElement,
+  manim: any,
+  dims: { width: number; height: number },
+) => any | Promise<any>;
 
 interface ManimExampleProps {
   animationFn: AnimationFn;
@@ -12,10 +16,12 @@ interface ManimExampleProps {
   createScene?: SceneFactory;
 }
 
+const ASPECT_RATIO = 800 / 450; // ~16:9
+
 const placeholderStyle: React.CSSProperties = {
   width: '100%',
   maxWidth: 800,
-  height: 450,
+  aspectRatio: `${ASPECT_RATIO}`,
   background: '#000000',
   borderRadius: 12,
 };
@@ -61,11 +67,14 @@ function ManimExampleInner({ animationFn, createScene }: ManimExampleProps) {
         const container = containerRef.current;
         if (!container) return;
 
+        const width = container.clientWidth || 800;
+        const height = Math.round(width / ASPECT_RATIO);
+
         const scene = createScene
-          ? await createScene(container, manim)
+          ? await createScene(container, manim, { width, height })
           : new manim.Scene(container, {
-              width: 800,
-              height: 450,
+              width,
+              height,
               backgroundColor: '#000000',
             });
         sceneRef.current = scene;
@@ -123,7 +132,7 @@ function ManimExampleInner({ animationFn, createScene }: ManimExampleProps) {
       style={{
         width: '100%',
         maxWidth: 800,
-        height: 450,
+        aspectRatio: `${ASPECT_RATIO}`,
         background: '#000000',
         borderRadius: 12,
         overflow: 'hidden',

--- a/docs/src/components/examples/FixedInFrameMobjectTestExample.tsx
+++ b/docs/src/components/examples/FixedInFrameMobjectTestExample.tsx
@@ -21,16 +21,15 @@ async function animate(scene: any) {
   await scene.wait();
 }
 
-function createScene(container: HTMLElement, manim: any) {
+function createScene(container: HTMLElement, manim: any, dims: { width: number; height: number }) {
   return new manim.ThreeDScene(container, {
-  width: 800,
-  height: 450,
-  backgroundColor: '#000000',
-  phi: 75 * (Math.PI / 180),
-  theta: -45 * (Math.PI / 180),
-  distance: 20,
-  fov: 30,
-});
+    ...dims,
+    backgroundColor: '#000000',
+    phi: 75 * (Math.PI / 180),
+    theta: -45 * (Math.PI / 180),
+    distance: 20,
+    fov: 30,
+  });
 }
 
 export default function FixedInFrameMobjectTestExample() {

--- a/docs/src/components/examples/MovingZoomedSceneAroundExample.tsx
+++ b/docs/src/components/examples/MovingZoomedSceneAroundExample.tsx
@@ -3,7 +3,29 @@ import React from 'react';
 import ManimExample from '../ManimExample';
 
 async function animate(scene: any) {
-  const { BackgroundRectangle, BLACK, Create, Dot, DOWN, FadeIn, FadeOut, ImageMobject, MED_SMALL_BUFF, PURPLE, RED, Scale, ScaleInPlace, Shift, smooth, Text, UL, Uncreate, UP, UpdateFromFunc, scaleVec } = await import('manim-web');
+  const {
+    BackgroundRectangle,
+    BLACK,
+    Create,
+    Dot,
+    DOWN,
+    FadeIn,
+    FadeOut,
+    ImageMobject,
+    MED_SMALL_BUFF,
+    PURPLE,
+    RED,
+    Scale,
+    ScaleInPlace,
+    Shift,
+    smooth,
+    Text,
+    UL,
+    Uncreate,
+    UP,
+    UpdateFromFunc,
+    scaleVec,
+  } = await import('manim-web');
 
   // Grayscale image matching Python: np.uint8([[0, 100, 30, 200], [255, 0, 5, 33]])
   const image = new ImageMobject({
@@ -47,10 +69,7 @@ async function animate(scene: any) {
   scene.activateZooming();
 
   // Pop-out animation: display pops from frame position to its shifted position
-  await scene.play(
-    scene.getZoomedDisplayPopOutAnimation(),
-    unfoldCamera,
-  );
+  await scene.play(scene.getZoomedDisplayPopOutAnimation(), unfoldCamera);
 
   // Use zoomedDisplay (parent) for positioning since displayFrame is a nested
   // child whose world coords depend on parent transform being synced
@@ -81,18 +100,17 @@ async function animate(scene: any) {
   await scene.wait();
 }
 
-function createScene(container: HTMLElement, manim: any) {
+function createScene(container: HTMLElement, manim: any, dims: { width: number; height: number }) {
   return new manim.ZoomedScene(container, {
-  width: 800,
-  height: 450,
-  backgroundColor: manim.BLACK,
-  zoomFactor: 0.3,
-  displayWidth: 6,
-  displayHeight: 1,
-  cameraFrameStrokeWidth: 3,
-  displayFrameStrokeWidth: 3,
-  displayFrameColor: manim.RED,
-});
+    ...dims,
+    backgroundColor: manim.BLACK,
+    zoomFactor: 0.3,
+    displayWidth: 6,
+    displayHeight: 1,
+    cameraFrameStrokeWidth: 3,
+    displayFrameStrokeWidth: 3,
+    displayFrameColor: manim.RED,
+  });
 }
 
 export default function MovingZoomedSceneAroundExample() {

--- a/docs/src/components/examples/ThreeDCameraIllusionRotationExample.tsx
+++ b/docs/src/components/examples/ThreeDCameraIllusionRotationExample.tsx
@@ -35,16 +35,15 @@ async function animate(scene: any) {
   scene.setCameraOrientation(75 * (Math.PI / 180), 30 * (Math.PI / 180));
 }
 
-function createScene(container: HTMLElement, manim: any) {
+function createScene(container: HTMLElement, manim: any, dims: { width: number; height: number }) {
   return new manim.ThreeDScene(container, {
-  width: 800,
-  height: 450,
-  backgroundColor: '#000000',
-  phi: 75 * (Math.PI / 180),
-  theta: 30 * (Math.PI / 180),
-  distance: 20,
-  fov: 30,
-});
+    ...dims,
+    backgroundColor: '#000000',
+    phi: 75 * (Math.PI / 180),
+    theta: 30 * (Math.PI / 180),
+    distance: 20,
+    fov: 30,
+  });
 }
 
 export default function ThreeDCameraIllusionRotationExample() {

--- a/docs/src/components/examples/ThreeDCameraRotationExample.tsx
+++ b/docs/src/components/examples/ThreeDCameraRotationExample.tsx
@@ -40,16 +40,15 @@ async function animate(scene: any) {
   scene.setCameraOrientation(75 * (Math.PI / 180), 30 * (Math.PI / 180));
 }
 
-function createScene(container: HTMLElement, manim: any) {
+function createScene(container: HTMLElement, manim: any, dims: { width: number; height: number }) {
   return new manim.ThreeDScene(container, {
-  width: 800,
-  height: 450,
-  backgroundColor: '#000000',
-  phi: 75 * (Math.PI / 180),
-  theta: 30 * (Math.PI / 180),
-  distance: 20,
-  fov: 30,
-});
+    ...dims,
+    backgroundColor: '#000000',
+    phi: 75 * (Math.PI / 180),
+    theta: 30 * (Math.PI / 180),
+    distance: 20,
+    fov: 30,
+  });
 }
 
 export default function ThreeDCameraRotationExample() {

--- a/docs/src/components/examples/ThreeDLightSourcePositionExample.tsx
+++ b/docs/src/components/examples/ThreeDLightSourcePositionExample.tsx
@@ -4,14 +4,8 @@ import ManimExample from '../ManimExample';
 
 async function animate(scene: any) {
   const { ThreeDAxes, Group, RED_D, RED_E } = await import('manim-web');
-  const {
-    BufferAttribute,
-    Color,
-    FrontSide,
-    Mesh,
-    MeshLambertMaterial,
-    SphereGeometry,
-  } = await import('three');
+  const { BufferAttribute, Color, FrontSide, Mesh, MeshLambertMaterial, SphereGeometry } =
+    await import('three');
 
   const axes = new ThreeDAxes({
     xRange: [-5, 5, 1],
@@ -105,16 +99,15 @@ async function animate(scene: any) {
   await scene.wait();
 }
 
-function createScene(container: HTMLElement, manim: any) {
+function createScene(container: HTMLElement, manim: any, dims: { width: number; height: number }) {
   return new manim.ThreeDScene(container, {
-  width: 800,
-  height: 450,
-  backgroundColor: '#000000',
-  phi: 75 * (Math.PI / 180),
-  theta: 30 * (Math.PI / 180),
-  distance: 20,
-  fov: 30,
-});
+    ...dims,
+    backgroundColor: '#000000',
+    phi: 75 * (Math.PI / 180),
+    theta: 30 * (Math.PI / 180),
+    distance: 20,
+    fov: 30,
+  });
 }
 
 export default function ThreeDLightSourcePositionExample() {

--- a/docs/src/components/examples/ThreeDSurfacePlotExample.tsx
+++ b/docs/src/components/examples/ThreeDSurfacePlotExample.tsx
@@ -48,16 +48,15 @@ async function animate(scene: any) {
   await scene.wait();
 }
 
-function createScene(container: HTMLElement, manim: any) {
+function createScene(container: HTMLElement, manim: any, dims: { width: number; height: number }) {
   return new manim.ThreeDScene(container, {
-  width: 800,
-  height: 450,
-  backgroundColor: '#000000',
-  phi: 75 * (Math.PI / 180),
-  theta: -30 * (Math.PI / 180),
-  distance: 20,
-  fov: 30,
-});
+    ...dims,
+    backgroundColor: '#000000',
+    phi: 75 * (Math.PI / 180),
+    theta: -30 * (Math.PI / 180),
+    distance: 20,
+    fov: 30,
+  });
 }
 
 export default function ThreeDSurfacePlotExample() {


### PR DESCRIPTION
## Summary
- Replace fixed 800x450 canvas dimensions with container-measured sizes using `aspectRatio` CSS and `clientWidth`
- Pass `{ width, height }` to custom `createScene` factories so 3D (ThreeDScene) and ZoomedScene examples also scale on narrow screens
- All 7 affected components updated: ManimExample + 6 custom scene examples

Fixes #35

## Test plan
- [x] Verified on 390px-wide mobile viewport (iPhone 14) — all examples fit without overflow
- [x] 3D examples (ThreeDCameraRotation, ThreeDSurfacePlot, etc.) scale correctly
- [x] Desktop rendering unchanged (maxWidth: 800 preserved)