### PR TITLE
Fix broken Learn More links in documentation examples

### DIFF
--- a/docs/docs/examples.mdx
+++ b/docs/docs/examples.mdx
@@ -85,7 +85,7 @@ scene.add(logo);
 
 </details>
 
-**Learn More:** **MathTex** · **Circle** · **Square** · **Triangle** · **VGroup**
+**Learn More:** [**MathTex**](/api/classes/MathTex) · [**Circle**](/api/classes/Circle) · [**Square**](/api/classes/Square) · [**Triangle**](/api/classes/Triangle) · [**VGroup**](/api/classes/VGroup)
 
 ---
 
@@ -124,7 +124,7 @@ scene.add(line, dot, dot2, b1, b2, b1text, b2text);
 
 </details>
 
-**Learn More:** **Brace** · **Dot** · **Line**
+**Learn More:** [**Brace**](/api/classes/Brace) · [**Dot**](/api/classes/Dot) · [**Line**](/api/classes/Line)
 
 ---
 
@@ -156,7 +156,7 @@ scene.add(numberplane, dot, arrow, originText, tipText);
 
 </details>
 
-**Learn More:** **Arrow** · **NumberPlane** · **Dot** · **Text**
+**Learn More:** [**Arrow**](/api/classes/Arrow) · [**NumberPlane**](/api/classes/NumberPlane) · [**Dot**](/api/classes/Dot) · [**Text**](/api/classes/Text)
 
 ---
 
@@ -278,7 +278,7 @@ await scene.play(new FadeIn(difference_text));
 
 </details>
 
-**Learn More:** **Union** · **Intersection** · **Difference** · **Exclusion** · **Ellipse** · **FadeIn** · **MoveToTarget**
+**Learn More:** [**Union**](/api/classes/Union) · [**Intersection**](/api/classes/Intersection) · [**Difference**](/api/classes/Difference) · [**Exclusion**](/api/classes/Exclusion) · [**Ellipse**](/api/classes/Ellipse) · [**FadeIn**](/api/classes/FadeIn) · [**MoveToTarget**](/api/classes/MoveToTarget)
 
 ---
 
@@ -380,7 +380,7 @@ await scene.wait(2);
 
 </details>
 
-**Learn More:** **MathTexSVG** · **Create** · **DrawBorderThenFill** · **FadeIn** · **FadeOut**
+**Learn More:** [**MathTexSVG**](/api/classes/MathTexSVG) · [**Create**](/api/classes/Create) · [**DrawBorderThenFill**](/api/classes/DrawBorderThenFill) · [**FadeIn**](/api/classes/FadeIn) · [**FadeOut**](/api/classes/FadeOut)
 
 ---
 
@@ -432,7 +432,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **Circle** · **Dot** · **GrowFromCenter** · **Transform** · **MoveAlongPath** · **Rotating**
+**Learn More:** [**Circle**](/api/classes/Circle) · [**Dot**](/api/classes/Dot) · [**GrowFromCenter**](/api/classes/GrowFromCenter) · [**Transform**](/api/classes/Transform) · [**MoveAlongPath**](/api/classes/MoveAlongPath) · [**Rotating**](/api/classes/Rotating)
 
 ---
 
@@ -480,7 +480,7 @@ await scene.play(new Rotate(square, { angle: 0.4 }));
 
 </details>
 
-**Learn More:** **Square** · **MoveToTarget**
+**Learn More:** [**Square**](/api/classes/Square) · [**MoveToTarget**](/api/classes/MoveToTarget)
 
 ---
 
@@ -562,7 +562,7 @@ await scene.wait(1);
 
 </details>
 
-**Learn More:** **Angle** · **Line** · **MathTex** · **ValueTracker** · **FadeToColor**
+**Learn More:** [**Angle**](/api/classes/Angle) · [**Line**](/api/classes/Line) · [**MathTex**](/api/classes/MathTex) · [**ValueTracker**](/api/classes/ValueTracker) · [**FadeToColor**](/api/classes/FadeToColor)
 
 ---
 
@@ -601,7 +601,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **Dot** · **Line** · **VGroup** · **ValueTracker**
+**Learn More:** [**Dot**](/api/classes/Dot) · [**Line**](/api/classes/Line) · [**VGroup**](/api/classes/VGroup) · [**ValueTracker**](/api/classes/ValueTracker)
 
 ---
 
@@ -657,7 +657,7 @@ await scene.wait(0.5);
 
 </details>
 
-**Learn More:** **VGroup** · **Dot** · **Shift**
+**Learn More:** [**VGroup**](/api/classes/VGroup) · [**Dot**](/api/classes/Dot) · [**Shift**](/api/classes/Shift)
 
 ---
 
@@ -700,7 +700,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **MathTex** · **SurroundingRectangle** · **Create** · **ReplacementTransform**
+**Learn More:** [**MathTex**](/api/classes/MathTex) · [**SurroundingRectangle**](/api/classes/SurroundingRectangle) · [**Create**](/api/classes/Create) · [**ReplacementTransform**](/api/classes/ReplacementTransform)
 
 ---
 
@@ -742,7 +742,7 @@ await scene.wait(0.5);
 
 </details>
 
-**Learn More:** **Line**
+**Learn More:** [**Line**](/api/classes/Line)
 
 ---
 
@@ -787,7 +787,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **VMobject** · **Dot** · **Rotating** · **Shift**
+**Learn More:** [**VMobject**](/api/classes/VMobject) · [**Dot**](/api/classes/Dot) · [**Rotating**](/api/classes/Rotating) · [**Shift**](/api/classes/Shift)
 
 ---
 
@@ -917,7 +917,7 @@ dot.removeUpdater(goAroundCircle);
 
 </details>
 
-**Learn More:** **Circle** · **Dot** · **Line** · **VGroup** · **MathTex**
+**Learn More:** [**Circle**](/api/classes/Circle) · [**Dot**](/api/classes/Dot) · [**Line**](/api/classes/Line) · [**VGroup**](/api/classes/VGroup) · [**MathTex**](/api/classes/MathTex)
 
 ---
 
@@ -993,7 +993,7 @@ await scene.wait(2);
 
 </details>
 
-**Learn More:** **Arrow** · **NumberPlane** · **ApplyMatrix**
+**Learn More:** [**Arrow**](/api/classes/Arrow) · [**NumberPlane**](/api/classes/NumberPlane) · [**ApplyMatrix**](/api/classes/ApplyMatrix)
 
 ---
 
@@ -1067,7 +1067,7 @@ scene.add(plot, labels);
 
 </details>
 
-**Learn More:** **Axes** · **Line** · **VGroup**
+**Learn More:** [**Axes**](/api/classes/Axes) · [**Line**](/api/classes/Line) · [**VGroup**](/api/classes/VGroup)
 
 ---
 
@@ -1117,7 +1117,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **Axes** · **Dot** · **ValueTracker**
+**Learn More:** [**Axes**](/api/classes/Axes) · [**Dot**](/api/classes/Dot) · [**ValueTracker**](/api/classes/ValueTracker)
 
 ---
 
@@ -1169,7 +1169,7 @@ scene.add(ax, labels, curve1, curve2, line1, line2, riemannArea, area);
 
 </details>
 
-**Learn More:** **Axes**
+**Learn More:** [**Axes**](/api/classes/Axes)
 
 ---
 
@@ -1250,7 +1250,7 @@ function getRectangleCorners(bottomLeft, topRight) {
 
 </details>
 
-**Learn More:** **Axes** · **Polygon** · **ValueTracker**
+**Learn More:** [**Axes**](/api/classes/Axes) · [**Polygon**](/api/classes/Polygon) · [**ValueTracker**](/api/classes/ValueTracker)
 
 ---
 
@@ -1299,7 +1299,7 @@ scene.add(ax, labels, graph);
 
 </details>
 
-**Learn More:** **Axes** · **Tex**
+**Learn More:** [**Axes**](/api/classes/Axes) · [**Tex**](/api/classes/Tex)
 
 ---
 
@@ -1367,7 +1367,7 @@ await scene.play(new Restore(scene.camera.frame));
 
 </details>
 
-**Learn More:** **Axes** · **Dot** · **MoveAlongPath** · **MoveToTarget** · **Restore**
+**Learn More:** [**Axes**](/api/classes/Axes) · [**Dot**](/api/classes/Dot) · [**MoveAlongPath**](/api/classes/MoveAlongPath) · [**MoveToTarget**](/api/classes/MoveToTarget) · [**Restore**](/api/classes/Restore)
 
 ---
 
@@ -1492,7 +1492,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **ZoomedScene** · **ImageMobject** · **BackgroundRectangle** · **Create** · **FadeIn** · **Scale** · **Shift**
+**Learn More:** [**ZoomedScene**](/api/classes/ZoomedScene) · [**ImageMobject**](/api/classes/ImageMobject) · [**BackgroundRectangle**](/api/classes/BackgroundRectangle) · [**Create**](/api/classes/Create) · [**FadeIn**](/api/classes/FadeIn) · [**Scale**](/api/classes/Scale) · [**Shift**](/api/classes/Shift)
 
 ---
 
@@ -1536,7 +1536,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Text**
+**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Text**](/api/classes/Text)
 
 ---
 
@@ -1599,7 +1599,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Surface3D** · **Lighting**
+**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Surface3D**](/api/classes/Surface3D) · [**Lighting**](/api/classes/Lighting)
 
 ---
 
@@ -1670,7 +1670,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Surface3D**
+**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Surface3D**](/api/classes/Surface3D)
 
 ---
 
@@ -1733,7 +1733,7 @@ scene.setCameraOrientation(75 * (Math.PI / 180), 30 * (Math.PI / 180));
 
 </details>
 
-**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Circle**
+**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Circle**](/api/classes/Circle)
 
 ---
 
@@ -1791,7 +1791,7 @@ scene.setCameraOrientation(75 * (Math.PI / 180), 30 * (Math.PI / 180));
 
 </details>
 
-**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Circle**
+**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Circle**](/api/classes/Circle)
 
 ---
 
@@ -1903,4 +1903,4 @@ await scene.wait(1);
 
 </details>
 
-**Learn More:** **Text** · **MathTex** · **NumberPlane** · **Write** · **Transform** · **ApplyPointwiseFunction** · **Create**
+**Learn More:** [**Text**](/api/classes/Text) · [**MathTex**](/api/classes/MathTex) · [**NumberPlane**](/api/classes/NumberPlane) · [**Write**](/api/classes/Write) · [**Transform**](/api/classes/Transform) · [**ApplyPointwiseFunction**](/api/classes/ApplyPointwiseFunction) · [**Create**](/api/classes/Create)


### PR DESCRIPTION
## Summary
- Convert all 28 "Learn More" lines in `docs/docs/examples.mdx` from plain bold text (`**ClassName**`) to clickable links (`[**ClassName**](/api/classes/ClassName)`)
- Fixes #47 — users can now navigate directly to API class documentation from the Examples page

## Test plan
- [ ] Run `cd docs && npm start` and navigate to the Examples page
- [ ] Confirm all "Learn More" entries render as clickable links
- [ ] Click several links and verify they navigate to the correct `/api/classes/ClassName` pages