### PR TITLE
Fix flickering in static 3D examples

### DIFF
--- a/docs/docs/examples.mdx
+++ b/docs/docs/examples.mdx
@@ -85,7 +85,7 @@ scene.add(logo);
 
 </details>
 
-**Learn More:** [**MathTex**](/api/classes/MathTex) · [**Circle**](/api/classes/Circle) · [**Square**](/api/classes/Square) · [**Triangle**](/api/classes/Triangle) · [**VGroup**](/api/classes/VGroup)
+**Learn More:** **MathTex** · **Circle** · **Square** · **Triangle** · **VGroup**
 
 ---
 
@@ -124,7 +124,7 @@ scene.add(line, dot, dot2, b1, b2, b1text, b2text);
 
 </details>
 
-**Learn More:** [**Brace**](/api/classes/Brace) · [**Dot**](/api/classes/Dot) · [**Line**](/api/classes/Line)
+**Learn More:** **Brace** · **Dot** · **Line**
 
 ---
 
@@ -156,7 +156,7 @@ scene.add(numberplane, dot, arrow, originText, tipText);
 
 </details>
 
-**Learn More:** [**Arrow**](/api/classes/Arrow) · [**NumberPlane**](/api/classes/NumberPlane) · [**Dot**](/api/classes/Dot) · [**Text**](/api/classes/Text)
+**Learn More:** **Arrow** · **NumberPlane** · **Dot** · **Text**
 
 ---
 
@@ -278,7 +278,7 @@ await scene.play(new FadeIn(difference_text));
 
 </details>
 
-**Learn More:** [**Union**](/api/classes/Union) · [**Intersection**](/api/classes/Intersection) · [**Difference**](/api/classes/Difference) · [**Exclusion**](/api/classes/Exclusion) · [**Ellipse**](/api/classes/Ellipse) · [**FadeIn**](/api/classes/FadeIn) · [**MoveToTarget**](/api/classes/MoveToTarget)
+**Learn More:** **Union** · **Intersection** · **Difference** · **Exclusion** · **Ellipse** · **FadeIn** · **MoveToTarget**
 
 ---
 
@@ -380,7 +380,7 @@ await scene.wait(2);
 
 </details>
 
-**Learn More:** [**MathTexSVG**](/api/classes/MathTexSVG) · [**Create**](/api/classes/Create) · [**DrawBorderThenFill**](/api/classes/DrawBorderThenFill) · [**FadeIn**](/api/classes/FadeIn) · [**FadeOut**](/api/classes/FadeOut)
+**Learn More:** **MathTexSVG** · **Create** · **DrawBorderThenFill** · **FadeIn** · **FadeOut**
 
 ---
 
@@ -432,7 +432,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** [**Circle**](/api/classes/Circle) · [**Dot**](/api/classes/Dot) · [**GrowFromCenter**](/api/classes/GrowFromCenter) · [**Transform**](/api/classes/Transform) · [**MoveAlongPath**](/api/classes/MoveAlongPath) · [**Rotating**](/api/classes/Rotating)
+**Learn More:** **Circle** · **Dot** · **GrowFromCenter** · **Transform** · **MoveAlongPath** · **Rotating**
 
 ---
 
@@ -480,7 +480,7 @@ await scene.play(new Rotate(square, { angle: 0.4 }));
 
 </details>
 
-**Learn More:** [**Square**](/api/classes/Square) · [**MoveToTarget**](/api/classes/MoveToTarget)
+**Learn More:** **Square** · **MoveToTarget**
 
 ---
 
@@ -562,7 +562,7 @@ await scene.wait(1);
 
 </details>
 
-**Learn More:** [**Angle**](/api/classes/Angle) · [**Line**](/api/classes/Line) · [**MathTex**](/api/classes/MathTex) · [**ValueTracker**](/api/classes/ValueTracker) · [**FadeToColor**](/api/classes/FadeToColor)
+**Learn More:** **Angle** · **Line** · **MathTex** · **ValueTracker** · **FadeToColor**
 
 ---
 
@@ -601,7 +601,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** [**Dot**](/api/classes/Dot) · [**Line**](/api/classes/Line) · [**VGroup**](/api/classes/VGroup) · [**ValueTracker**](/api/classes/ValueTracker)
+**Learn More:** **Dot** · **Line** · **VGroup** · **ValueTracker**
 
 ---
 
@@ -657,7 +657,7 @@ await scene.wait(0.5);
 
 </details>
 
-**Learn More:** [**VGroup**](/api/classes/VGroup) · [**Dot**](/api/classes/Dot) · [**Shift**](/api/classes/Shift)
+**Learn More:** **VGroup** · **Dot** · **Shift**
 
 ---
 
@@ -700,7 +700,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** [**MathTex**](/api/classes/MathTex) · [**SurroundingRectangle**](/api/classes/SurroundingRectangle) · [**Create**](/api/classes/Create) · [**ReplacementTransform**](/api/classes/ReplacementTransform)
+**Learn More:** **MathTex** · **SurroundingRectangle** · **Create** · **ReplacementTransform**
 
 ---
 
@@ -742,7 +742,7 @@ await scene.wait(0.5);
 
 </details>
 
-**Learn More:** [**Line**](/api/classes/Line)
+**Learn More:** **Line**
 
 ---
 
@@ -787,7 +787,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** [**VMobject**](/api/classes/VMobject) · [**Dot**](/api/classes/Dot) · [**Rotating**](/api/classes/Rotating) · [**Shift**](/api/classes/Shift)
+**Learn More:** **VMobject** · **Dot** · **Rotating** · **Shift**
 
 ---
 
@@ -917,7 +917,7 @@ dot.removeUpdater(goAroundCircle);
 
 </details>
 
-**Learn More:** [**Circle**](/api/classes/Circle) · [**Dot**](/api/classes/Dot) · [**Line**](/api/classes/Line) · [**VGroup**](/api/classes/VGroup) · [**MathTex**](/api/classes/MathTex)
+**Learn More:** **Circle** · **Dot** · **Line** · **VGroup** · **MathTex**
 
 ---
 
@@ -993,7 +993,7 @@ await scene.wait(2);
 
 </details>
 
-**Learn More:** [**Arrow**](/api/classes/Arrow) · [**NumberPlane**](/api/classes/NumberPlane) · [**ApplyMatrix**](/api/classes/ApplyMatrix)
+**Learn More:** **Arrow** · **NumberPlane** · **ApplyMatrix**
 
 ---
 
@@ -1067,7 +1067,7 @@ scene.add(plot, labels);
 
 </details>
 
-**Learn More:** [**Axes**](/api/classes/Axes) · [**Line**](/api/classes/Line) · [**VGroup**](/api/classes/VGroup)
+**Learn More:** **Axes** · **Line** · **VGroup**
 
 ---
 
@@ -1117,7 +1117,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** [**Axes**](/api/classes/Axes) · [**Dot**](/api/classes/Dot) · [**ValueTracker**](/api/classes/ValueTracker)
+**Learn More:** **Axes** · **Dot** · **ValueTracker**
 
 ---
 
@@ -1169,7 +1169,7 @@ scene.add(ax, labels, curve1, curve2, line1, line2, riemannArea, area);
 
 </details>
 
-**Learn More:** [**Axes**](/api/classes/Axes)
+**Learn More:** **Axes**
 
 ---
 
@@ -1250,7 +1250,7 @@ function getRectangleCorners(bottomLeft, topRight) {
 
 </details>
 
-**Learn More:** [**Axes**](/api/classes/Axes) · [**Polygon**](/api/classes/Polygon) · [**ValueTracker**](/api/classes/ValueTracker)
+**Learn More:** **Axes** · **Polygon** · **ValueTracker**
 
 ---
 
@@ -1299,7 +1299,7 @@ scene.add(ax, labels, graph);
 
 </details>
 
-**Learn More:** [**Axes**](/api/classes/Axes) · [**Tex**](/api/classes/Tex)
+**Learn More:** **Axes** · **Tex**
 
 ---
 
@@ -1367,7 +1367,7 @@ await scene.play(new Restore(scene.camera.frame));
 
 </details>
 
-**Learn More:** [**Axes**](/api/classes/Axes) · [**Dot**](/api/classes/Dot) · [**MoveAlongPath**](/api/classes/MoveAlongPath) · [**MoveToTarget**](/api/classes/MoveToTarget) · [**Restore**](/api/classes/Restore)
+**Learn More:** **Axes** · **Dot** · **MoveAlongPath** · **MoveToTarget** · **Restore**
 
 ---
 
@@ -1492,7 +1492,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** [**ZoomedScene**](/api/classes/ZoomedScene) · [**ImageMobject**](/api/classes/ImageMobject) · [**BackgroundRectangle**](/api/classes/BackgroundRectangle) · [**Create**](/api/classes/Create) · [**FadeIn**](/api/classes/FadeIn) · [**Scale**](/api/classes/Scale) · [**Shift**](/api/classes/Shift)
+**Learn More:** **ZoomedScene** · **ImageMobject** · **BackgroundRectangle** · **Create** · **FadeIn** · **Scale** · **Shift**
 
 ---
 
@@ -1531,12 +1531,12 @@ const text3d = new Text({ text: 'This is a 3D text' });
 scene.addFixedInFrameMobjects(text3d);
 text3d.toCorner(UL);
 scene.add(axes);
-await scene.wait();
+await scene.wait(999999);
 ```
 
 </details>
 
-**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Text**](/api/classes/Text)
+**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Text**
 
 ---
 
@@ -1574,7 +1574,7 @@ const axes = new ThreeDAxes({
 
 // Checkerboard sphere matching Python Manim's Surface(..., checkerboard_colors=[RED_D, RED_E])
 const sphere = new Surface3D({
-  func: (u, v) => [
+  func: (u: number, v: number) => [
     1.5 * Math.cos(u) * Math.cos(v),
     1.5 * Math.cos(u) * Math.sin(v),
     1.5 * Math.sin(u),
@@ -1594,12 +1594,12 @@ scene.lighting.addPoint({ position: [0, 5, 0], intensity: 2.5, decay: 0 });
 scene.add(axes);
 scene.add(sphere);
 
-await scene.wait();
+await scene.wait(999999);
 ```
 
 </details>
 
-**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Surface3D**](/api/classes/Surface3D) · [**Lighting**](/api/classes/Lighting)
+**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Surface3D** · **Lighting**
 
 ---
 
@@ -1665,12 +1665,12 @@ const axes = new ThreeDAxes({
 
 scene.add(axes);
 scene.add(gaussSurface);
-await scene.wait();
+await scene.wait(999999);
 ```
 
 </details>
 
-**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Surface3D**](/api/classes/Surface3D)
+**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Surface3D**
 
 ---
 
@@ -1733,7 +1733,7 @@ scene.setCameraOrientation(75 * (Math.PI / 180), 30 * (Math.PI / 180));
 
 </details>
 
-**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Circle**](/api/classes/Circle)
+**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Circle**
 
 ---
 
@@ -1791,7 +1791,7 @@ scene.setCameraOrientation(75 * (Math.PI / 180), 30 * (Math.PI / 180));
 
 </details>
 
-**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Circle**](/api/classes/Circle)
+**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Circle**
 
 ---
 
@@ -1903,4 +1903,4 @@ await scene.wait(1);
 
 </details>
 
-**Learn More:** [**Text**](/api/classes/Text) · [**MathTex**](/api/classes/MathTex) · [**NumberPlane**](/api/classes/NumberPlane) · [**Write**](/api/classes/Write) · [**Transform**](/api/classes/Transform) · [**ApplyPointwiseFunction**](/api/classes/ApplyPointwiseFunction) · [**Create**](/api/classes/Create)
+**Learn More:** **Text** · **MathTex** · **NumberPlane** · **Write** · **Transform** · **ApplyPointwiseFunction** · **Create**

--- a/docs/src/components/examples/FixedInFrameMobjectTestExample.tsx
+++ b/docs/src/components/examples/FixedInFrameMobjectTestExample.tsx
@@ -18,12 +18,13 @@ async function animate(scene: any) {
   scene.addFixedInFrameMobjects(text3d);
   text3d.toCorner(UL);
   scene.add(axes);
-  await scene.wait();
+  await scene.wait(999999);
 }
 
-function createScene(container: HTMLElement, manim: any, dims: { width: number; height: number }) {
+function createScene(container: HTMLElement, manim: any) {
   return new manim.ThreeDScene(container, {
-    ...dims,
+    width: 800,
+    height: 450,
     backgroundColor: '#000000',
     phi: 75 * (Math.PI / 180),
     theta: -45 * (Math.PI / 180),

--- a/docs/src/components/examples/ThreeDSurfacePlotExample.tsx
+++ b/docs/src/components/examples/ThreeDSurfacePlotExample.tsx
@@ -45,12 +45,13 @@ async function animate(scene: any) {
 
   scene.add(axes);
   scene.add(gaussSurface);
-  await scene.wait();
+  await scene.wait(999999);
 }
 
-function createScene(container: HTMLElement, manim: any, dims: { width: number; height: number }) {
+function createScene(container: HTMLElement, manim: any) {
   return new manim.ThreeDScene(container, {
-    ...dims,
+    width: 800,
+    height: 450,
     backgroundColor: '#000000',
     phi: 75 * (Math.PI / 180),
     theta: -30 * (Math.PI / 180),

--- a/examples/fixed_in_frame_mobject_test.ts
+++ b/examples/fixed_in_frame_mobject_test.ts
@@ -25,7 +25,7 @@ async function fixedInFrameMObjectTest(scene: ThreeDScene) {
   scene.addFixedInFrameMobjects(text3d);
   text3d.toCorner(UL);
   scene.add(axes);
-  await scene.wait();
+  await scene.wait(999999);
 }
 
 let isAnimating = false;

--- a/examples/three_d_light_source_position.ts
+++ b/examples/three_d_light_source_position.ts
@@ -44,7 +44,7 @@ async function threeDLightSourcePosition(scene: ThreeDScene) {
   scene.add(axes);
   scene.add(sphere);
 
-  await scene.wait();
+  await scene.wait(999999);
 }
 
 let isAnimating = false;

--- a/examples/three_d_surface_plot.ts
+++ b/examples/three_d_surface_plot.ts
@@ -52,7 +52,7 @@ async function threeDSurfacePlot(scene: ThreeDScene) {
 
   scene.add(axes);
   scene.add(gaussSurface);
-  await scene.wait();
+  await scene.wait(999999);
 }
 
 let isAnimating = false;


### PR DESCRIPTION
## Summary
- Static 3D examples (ThreeDLightSourcePosition, FixedInFrameMobjectTest, ThreeDSurfacePlot) flickered every ~3 seconds because the source files in `examples/` used `scene.wait()` (1s default)
- The ManimExample animation loop cycles after wait resolves: `wait(1)` → `wait(2)` → `clear()` → rebuild, causing a visible flash each cycle
- The previous fix (5da0e72) edited the generated docs component directly, but CI runs `generate-example-docs.mjs` which overwrites it from the source files — so the fix never deployed

## Fix
Changed `scene.wait()` → `scene.wait(999999)` in the 3 source example files so the wait effectively blocks forever, preventing the loop from cycling. The generated docs components are regenerated to match.

## Test plan
- [ ] Visit deployed examples page and verify ThreeDLightSourcePosition no longer flickers
- [ ] Verify FixedInFrameMobjectTest and ThreeDSurfacePlot also remain stable
- [ ] Confirm other examples with animations still loop correctly