### PR TITLE
Fix broken Learn More links in documentation examples

### DIFF
--- a/docs/docs/examples.mdx
+++ b/docs/docs/examples.mdx
@@ -88,7 +88,7 @@ scene.add(logo);
 
 </details>
 
-**Learn More:** **MathTex** · **Circle** · **Square** · **Triangle** · **VGroup**
+**Learn More:** [**MathTex**](/api/classes/MathTex) · [**Circle**](/api/classes/Circle) · [**Square**](/api/classes/Square) · [**Triangle**](/api/classes/Triangle) · [**VGroup**](/api/classes/VGroup)
 
 ---
 
@@ -127,7 +127,7 @@ scene.add(line, dot, dot2, b1, b2, b1text, b2text);
 
 </details>
 
-**Learn More:** **Brace** · **Dot** · **Line**
+**Learn More:** [**Brace**](/api/classes/Brace) · [**Dot**](/api/classes/Dot) · [**Line**](/api/classes/Line)
 
 ---
 
@@ -159,7 +159,7 @@ scene.add(numberplane, dot, arrow, originText, tipText);
 
 </details>
 
-**Learn More:** **Arrow** · **NumberPlane** · **Dot** · **Text**
+**Learn More:** [**Arrow**](/api/classes/Arrow) · [**NumberPlane**](/api/classes/NumberPlane) · [**Dot**](/api/classes/Dot) · [**Text**](/api/classes/Text)
 
 ---
 
@@ -281,7 +281,7 @@ await scene.play(new FadeIn(difference_text));
 
 </details>
 
-**Learn More:** **Union** · **Intersection** · **Difference** · **Exclusion** · **Ellipse** · **FadeIn** · **MoveToTarget**
+**Learn More:** [**Union**](/api/classes/Union) · [**Intersection**](/api/classes/Intersection) · [**Difference**](/api/classes/Difference) · [**Exclusion**](/api/classes/Exclusion) · [**Ellipse**](/api/classes/Ellipse) · [**FadeIn**](/api/classes/FadeIn) · [**MoveToTarget**](/api/classes/MoveToTarget)
 
 ---
 
@@ -383,7 +383,7 @@ await scene.wait(2);
 
 </details>
 
-**Learn More:** **MathTexSVG** · **Create** · **DrawBorderThenFill** · **FadeIn** · **FadeOut**
+**Learn More:** [**MathTexSVG**](/api/classes/MathTexSVG) · [**Create**](/api/classes/Create) · [**DrawBorderThenFill**](/api/classes/DrawBorderThenFill) · [**FadeIn**](/api/classes/FadeIn) · [**FadeOut**](/api/classes/FadeOut)
 
 ---
 
@@ -435,7 +435,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **Circle** · **Dot** · **GrowFromCenter** · **Transform** · **MoveAlongPath** · **Rotating**
+**Learn More:** [**Circle**](/api/classes/Circle) · [**Dot**](/api/classes/Dot) · [**GrowFromCenter**](/api/classes/GrowFromCenter) · [**Transform**](/api/classes/Transform) · [**MoveAlongPath**](/api/classes/MoveAlongPath) · [**Rotating**](/api/classes/Rotating)
 
 ---
 
@@ -483,7 +483,7 @@ await scene.play(new Rotate(square, { angle: 0.4 }));
 
 </details>
 
-**Learn More:** **Square** · **MoveToTarget**
+**Learn More:** [**Square**](/api/classes/Square) · [**MoveToTarget**](/api/classes/MoveToTarget)
 
 ---
 
@@ -565,7 +565,7 @@ await scene.wait(1);
 
 </details>
 
-**Learn More:** **Angle** · **Line** · **MathTex** · **ValueTracker** · **FadeToColor**
+**Learn More:** [**Angle**](/api/classes/Angle) · [**Line**](/api/classes/Line) · [**MathTex**](/api/classes/MathTex) · [**ValueTracker**](/api/classes/ValueTracker) · [**FadeToColor**](/api/classes/FadeToColor)
 
 ---
 
@@ -604,7 +604,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **Dot** · **Line** · **VGroup** · **ValueTracker**
+**Learn More:** [**Dot**](/api/classes/Dot) · [**Line**](/api/classes/Line) · [**VGroup**](/api/classes/VGroup) · [**ValueTracker**](/api/classes/ValueTracker)
 
 ---
 
@@ -660,7 +660,7 @@ await scene.wait(0.5);
 
 </details>
 
-**Learn More:** **VGroup** · **Dot** · **Shift**
+**Learn More:** [**VGroup**](/api/classes/VGroup) · [**Dot**](/api/classes/Dot) · [**Shift**](/api/classes/Shift)
 
 ---
 
@@ -703,7 +703,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **MathTex** · **SurroundingRectangle** · **Create** · **ReplacementTransform**
+**Learn More:** [**MathTex**](/api/classes/MathTex) · [**SurroundingRectangle**](/api/classes/SurroundingRectangle) · [**Create**](/api/classes/Create) · [**ReplacementTransform**](/api/classes/ReplacementTransform)
 
 ---
 
@@ -745,7 +745,7 @@ await scene.wait(0.5);
 
 </details>
 
-**Learn More:** **Line**
+**Learn More:** [**Line**](/api/classes/Line)
 
 ---
 
@@ -790,7 +790,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **VMobject** · **Dot** · **Rotating** · **Shift**
+**Learn More:** [**VMobject**](/api/classes/VMobject) · [**Dot**](/api/classes/Dot) · [**Rotating**](/api/classes/Rotating) · [**Shift**](/api/classes/Shift)
 
 ---
 
@@ -920,7 +920,7 @@ dot.removeUpdater(goAroundCircle);
 
 </details>
 
-**Learn More:** **Circle** · **Dot** · **Line** · **VGroup** · **MathTex**
+**Learn More:** [**Circle**](/api/classes/Circle) · [**Dot**](/api/classes/Dot) · [**Line**](/api/classes/Line) · [**VGroup**](/api/classes/VGroup) · [**MathTex**](/api/classes/MathTex)
 
 ---
 
@@ -996,7 +996,7 @@ await scene.wait(2);
 
 </details>
 
-**Learn More:** **Arrow** · **NumberPlane** · **ApplyMatrix**
+**Learn More:** [**Arrow**](/api/classes/Arrow) · [**NumberPlane**](/api/classes/NumberPlane) · [**ApplyMatrix**](/api/classes/ApplyMatrix)
 
 ---
 
@@ -1226,7 +1226,7 @@ await scene.play(new AnimationGroup(animations));
 
 </details>
 
-**Learn More:** **Shift** · **AnimationGroup**
+**Learn More:** [**Shift**](/api/classes/Shift) · [**AnimationGroup**](/api/classes/AnimationGroup)
 
 ---
 
@@ -1300,7 +1300,7 @@ scene.add(plot, labels);
 
 </details>
 
-**Learn More:** **Axes** · **Line** · **VGroup**
+**Learn More:** [**Axes**](/api/classes/Axes) · [**Line**](/api/classes/Line) · [**VGroup**](/api/classes/VGroup)
 
 ---
 
@@ -1350,7 +1350,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **Axes** · **Dot** · **ValueTracker**
+**Learn More:** [**Axes**](/api/classes/Axes) · [**Dot**](/api/classes/Dot) · [**ValueTracker**](/api/classes/ValueTracker)
 
 ---
 
@@ -1402,7 +1402,7 @@ scene.add(ax, labels, curve1, curve2, line1, line2, riemannArea, area);
 
 </details>
 
-**Learn More:** **Axes**
+**Learn More:** [**Axes**](/api/classes/Axes)
 
 ---
 
@@ -1483,7 +1483,7 @@ function getRectangleCorners(bottomLeft, topRight) {
 
 </details>
 
-**Learn More:** **Axes** · **Polygon** · **ValueTracker**
+**Learn More:** [**Axes**](/api/classes/Axes) · [**Polygon**](/api/classes/Polygon) · [**ValueTracker**](/api/classes/ValueTracker)
 
 ---
 
@@ -1532,7 +1532,7 @@ scene.add(ax, labels, graph);
 
 </details>
 
-**Learn More:** **Axes** · **Tex**
+**Learn More:** [**Axes**](/api/classes/Axes) · [**Tex**](/api/classes/Tex)
 
 ---
 
@@ -1600,7 +1600,7 @@ await scene.play(new Restore(scene.camera.frame));
 
 </details>
 
-**Learn More:** **Axes** · **Dot** · **MoveAlongPath** · **MoveToTarget** · **Restore**
+**Learn More:** [**Axes**](/api/classes/Axes) · [**Dot**](/api/classes/Dot) · [**MoveAlongPath**](/api/classes/MoveAlongPath) · [**MoveToTarget**](/api/classes/MoveToTarget) · [**Restore**](/api/classes/Restore)
 
 ---
 
@@ -1725,7 +1725,7 @@ await scene.wait();
 
 </details>
 
-**Learn More:** **ZoomedScene** · **ImageMobject** · **BackgroundRectangle** · **Create** · **FadeIn** · **Scale** · **Shift**
+**Learn More:** [**ZoomedScene**](/api/classes/ZoomedScene) · [**ImageMobject**](/api/classes/ImageMobject) · [**BackgroundRectangle**](/api/classes/BackgroundRectangle) · [**Create**](/api/classes/Create) · [**FadeIn**](/api/classes/FadeIn) · [**Scale**](/api/classes/Scale) · [**Shift**](/api/classes/Shift)
 
 ---
 
@@ -1769,7 +1769,7 @@ await scene.wait(999999);
 
 </details>
 
-**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Text**
+**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Text**](/api/classes/Text)
 
 ---
 
@@ -1832,7 +1832,7 @@ await scene.wait(999999);
 
 </details>
 
-**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Surface3D** · **Lighting**
+**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Surface3D**](/api/classes/Surface3D) · [**Lighting**](/api/classes/Lighting)
 
 ---
 
@@ -1903,7 +1903,7 @@ await scene.wait(999999);
 
 </details>
 
-**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Surface3D**
+**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Surface3D**](/api/classes/Surface3D)
 
 ---
 
@@ -1966,7 +1966,7 @@ scene.setCameraOrientation(75 * (Math.PI / 180), 30 * (Math.PI / 180));
 
 </details>
 
-**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Circle**
+**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Circle**](/api/classes/Circle)
 
 ---
 
@@ -2024,7 +2024,7 @@ scene.setCameraOrientation(75 * (Math.PI / 180), 30 * (Math.PI / 180));
 
 </details>
 
-**Learn More:** **ThreeDScene** · **ThreeDAxes** · **Circle**
+**Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Circle**](/api/classes/Circle)
 
 ---
 
@@ -2136,7 +2136,7 @@ await scene.wait(1);
 
 </details>
 
-**Learn More:** **Text** · **MathTex** · **NumberPlane** · **Write** · **Transform** · **ApplyPointwiseFunction** · **Create**
+**Learn More:** [**Text**](/api/classes/Text) · [**MathTex**](/api/classes/MathTex) · [**NumberPlane**](/api/classes/NumberPlane) · [**Write**](/api/classes/Write) · [**Transform**](/api/classes/Transform) · [**ApplyPointwiseFunction**](/api/classes/ApplyPointwiseFunction) · [**Create**](/api/classes/Create)
 
 ---
 
@@ -2183,4 +2183,4 @@ await scene.play(new FadeOut(square));
 
 </details>
 
-**Learn More:** **Scene** · **Circle** · **Square** · **Create** · **Transform** · **FadeOut**
+**Learn More:** [**Scene**](/api/classes/Scene) · [**Circle**](/api/classes/Circle) · [**Square**](/api/classes/Square) · [**Create**](/api/classes/Create) · [**Transform**](/api/classes/Transform) · [**FadeOut**](/api/classes/FadeOut)

--- a/scripts/generate-example-docs.mjs
+++ b/scripts/generate-example-docs.mjs
@@ -1094,7 +1094,7 @@ function main() {
       lines.push('');
 
       if (ex.learnMore.length > 0) {
-        const learnMoreInline = ex.learnMore.map((name) => `**${name}**`).join(' \u00B7 ');
+        const learnMoreInline = ex.learnMore.map((name) => `[**${name}**](/api/classes/${name})`).join(' \u00B7 ');
         lines.push(`**Learn More:** ${learnMoreInline}`);
         lines.push('');
       }


### PR DESCRIPTION
## Summary
- Convert all 30 "Learn More" sections in `docs/docs/examples.mdx` from plain bold text (`**ClassName**`) to proper markdown links (`[**ClassName**](/api/classes/ClassName)`)
- Fix the generator script (`scripts/generate-example-docs.mjs`) so future regenerations produce correct links

## Test plan
- [x] Verified all 50 referenced class names have corresponding API docs in `docs/docs/api/classes/`
- [x] Built docs successfully with `npm run build`
- [x] Visually confirmed links render correctly on the examples page

Fixes #47