### PR TITLE
Fix: add Integrated Player to example generation script

### DIFF
--- a/docs/docs/examples.mdx
+++ b/docs/docs/examples.mdx
@@ -3,13 +3,13 @@ title: Examples
 sidebar_label: Examples
 ---
 
+import PlayerExample from '@site/src/components/examples/PlayerExample';
 import ApplyMatrixArrowsExample from '@site/src/components/examples/ApplyMatrixArrowsExample';
 import ArgMinExample from '@site/src/components/examples/ArgMinExample';
 import BooleanOperationsExample from '@site/src/components/examples/BooleanOperationsExample';
 import BraceAnnotationExample from '@site/src/components/examples/BraceAnnotationExample';
 import EasingFunctionsShowcaseExample from '@site/src/components/examples/EasingFunctionsShowcaseExample';
 import ExportAnimationExample from '@site/src/components/examples/ExportAnimationExample';
-import PlayerExample from '@site/src/components/examples/PlayerExample';
 import FixedInFrameMobjectTestExample from '@site/src/components/examples/FixedInFrameMobjectTestExample';
 import FollowingGraphCameraExample from '@site/src/components/examples/FollowingGraphCameraExample';
 import GraphAreaPlotExample from '@site/src/components/examples/GraphAreaPlotExample';
@@ -110,6 +110,8 @@ player.sequence(async (scene) => {
 </details>
 
 **Learn More:** [**Player**](/api/classes/Player) · [**Circle**](/api/classes/Circle) · [**Square**](/api/classes/Square) · [**Triangle**](/api/classes/Triangle) · [**Create**](/api/classes/Create) · [**Transform**](/api/classes/Transform) · [**Indicate**](/api/classes/Indicate) · [**Rotate**](/api/classes/Rotate)
+
+---
 
 ## Manim Ce Logo
 
@@ -2214,7 +2216,7 @@ await scene.wait(1);
 
 ## Export Animation
 
-Demonstrates the `scene.export()` API. Play the animation first, then export it as GIF or WebM. The progress callback reports capture and encoding phases.
+Demonstrates the scene.export() convenience API. Creates a square, transforms it into a circle, then exports the animation as GIF or WebM with a progress callback.
 
 <ExportAnimationExample />
 
@@ -2234,31 +2236,99 @@ import {
   GREEN,
 } from 'manim-web';
 
+const container = document.getElementById('container')!;
 const scene = new Scene(document.getElementById('container'), {
   width: 800,
   height: 450,
   backgroundColor: BLACK,
 });
 
-const square = new Square({ sideLength: 2.5, color: BLUE, fillOpacity: 0.5 });
-const circle = new Circle({ radius: 1.25, color: GREEN, fillOpacity: 0.5 });
+const progressContainer = document.getElementById('progressContainer')!;
+const progressFill = document.getElementById('progressFill')!;
+const progressText = document.getElementById('progressText')!;
 
-await scene.play(new Create(square));
-await scene.play(new Transform(square, circle));
-await scene.play(new FadeOut(square));
+function showProgress(progress: number, label: string) {
+  progressContainer.style.display = 'block';
+  progressFill.style.width = `${Math.round(progress * 100)}%`;
+  progressText.textContent = `${label} — ${Math.round(progress * 100)}%`;
+}
 
-// Export as GIF with progress tracking
-await scene.export('animation.gif', {
-  fps: 15,
-  quality: 10,
-  onProgress: (p) => console.log(`${Math.round(p * 100)}%`),
+function hideProgress() {
+  progressContainer.style.display = 'none';
+  progressFill.style.width = '0%';
+}
+
+function setButtonsDisabled(disabled: boolean) {
+  document
+    .querySelectorAll<HTMLButtonElement>('.controls button')
+    .forEach((btn) => (btn.disabled = disabled));
+}
+
+// Play animation
+document.getElementById('playBtn')!.addEventListener('click', async () => {
+  if (isAnimating) return;
+  isAnimating = true;
+  setButtonsDisabled(true);
+
+  scene.clear();
+  const square = new Square({ sideLength: 2.5, color: BLUE, fillOpacity: 0.5 });
+  const circle = new Circle({ radius: 1.25, color: GREEN, fillOpacity: 0.5 });
+
+  await scene.play(new Create(square));
+  await scene.play(new Transform(square, circle));
+  await scene.play(new FadeOut(square));
+
+  isAnimating = false;
+  setButtonsDisabled(false);
 });
 
-// Other formats:
-// await scene.export('animation.webm', { fps: 30 })
-// await scene.export('animation.mp4')
+// Export GIF
+document.getElementById('exportGifBtn')!.addEventListener('click', async () => {
+  if (isAnimating) return;
+  isAnimating = true;
+  setButtonsDisabled(true);
+
+  try {
+    await scene.export('animation.gif', {
+      fps: 15,
+      quality: 10,
+      onProgress: (p) => showProgress(p, 'Exporting GIF'),
+    });
+  } catch (err) {
+    console.error('GIF export failed:', err);
+  } finally {
+    hideProgress();
+    isAnimating = false;
+    setButtonsDisabled(false);
+  }
+});
+
+// Export WebM
+document.getElementById('exportWebmBtn')!.addEventListener('click', async () => {
+  if (isAnimating) return;
+  isAnimating = true;
+  setButtonsDisabled(true);
+
+  try {
+    await scene.export('animation.webm', {
+      fps: 30,
+      onProgress: (p) => showProgress(p, 'Exporting WebM'),
+    });
+  } catch (err) {
+    console.error('WebM export failed:', err);
+  } finally {
+    hideProgress();
+    isAnimating = false;
+    setButtonsDisabled(false);
+  }
+});
+
+// Reset
+document.getElementById('resetBtn')!.addEventListener('click', () => {
+  scene.clear();
+});
 ```
 
 </details>
 
-**Learn More:** [**Scene**](/api/classes/Scene) · [**GifExporter**](/api/classes/GifExporter) · [**Circle**](/api/classes/Circle) · [**Square**](/api/classes/Square) · [**Create**](/api/classes/Create) · [**Transform**](/api/classes/Transform) · [**FadeOut**](/api/classes/FadeOut)
+**Learn More:** [**Scene**](/api/classes/Scene) · [**Circle**](/api/classes/Circle) · [**Square**](/api/classes/Square) · [**Create**](/api/classes/Create) · [**Transform**](/api/classes/Transform) · [**FadeOut**](/api/classes/FadeOut)

--- a/scripts/generate-example-docs.mjs
+++ b/scripts/generate-example-docs.mjs
@@ -1048,6 +1048,7 @@ function main() {
   ];
 
   // Add all component imports at the top
+  lines.push("import PlayerExample from '@site/src/components/examples/PlayerExample';");
   for (const ex of examples) {
     lines.push(`import ${ex.componentName} from '@site/src/components/examples/${ex.componentName}';`);
   }
@@ -1056,6 +1057,81 @@ function main() {
   lines.push('# Examples');
   lines.push('');
   lines.push('Interactive examples showing what you can build with manim-web. Each example includes a live animation and source code.');
+  lines.push('');
+
+  // -- Integrated Player (pinned at the top) ----------------------------------
+  lines.push('## Integrated Player');
+  lines.push('');
+  lines.push('A full-featured playback controller with play/pause, segment navigation, timeline scrubbing, speed control, fullscreen, and export. Use <kbd>Space</kbd> to play/pause, <kbd>&larr;</kbd>/<kbd>&rarr;</kbd> for segments, <kbd>Shift+&larr;/&rarr;</kbd> to scrub, and <kbd>F</kbd> for fullscreen.');
+  lines.push('');
+  lines.push('<PlayerExample />');
+  lines.push('');
+  lines.push('<details>');
+  lines.push('<summary>Source Code</summary>');
+  lines.push('');
+  lines.push('```typescript');
+  lines.push(`import {
+  Player,
+  Circle,
+  Square,
+  Triangle,
+  Create,
+  Transform,
+  FadeIn,
+  FadeOut,
+  Indicate,
+  Rotate,
+  BLACK,
+  BLUE,
+  RED,
+  GREEN,
+  YELLOW,
+} from 'manim-web';
+
+const player = new Player(document.getElementById('container'), {
+  width: 800,
+  height: 450,
+  backgroundColor: BLACK,
+});
+
+player.sequence(async (scene) => {
+  // Create a blue circle
+  const circle = new Circle({ radius: 1.5, color: BLUE });
+  await scene.play(new Create(circle));
+
+  await scene.wait(0.5);
+
+  // Transform to red square
+  const square = new Square({ sideLength: 3, color: RED });
+  await scene.play(new Transform(circle, square));
+
+  // Indicate
+  await scene.play(new Indicate(circle));
+
+  // Transform to green triangle
+  const triangle = new Triangle({ color: GREEN });
+  triangle.scale(2);
+  await scene.play(new Transform(circle, triangle));
+
+  // Rotate 180°
+  await scene.play(new Rotate(circle, { angle: Math.PI }));
+
+  // Fade out
+  await scene.play(new FadeOut(circle));
+
+  // Bring in a yellow circle
+  const circle2 = new Circle({ radius: 1, color: YELLOW });
+  await scene.play(new FadeIn(circle2));
+
+  await scene.wait(1);
+});`);
+  lines.push('```');
+  lines.push('');
+  lines.push('</details>');
+  lines.push('');
+  lines.push('**Learn More:** [**Player**](/api/classes/Player) \u00B7 [**Circle**](/api/classes/Circle) \u00B7 [**Square**](/api/classes/Square) \u00B7 [**Triangle**](/api/classes/Triangle) \u00B7 [**Create**](/api/classes/Create) \u00B7 [**Transform**](/api/classes/Transform) \u00B7 [**Indicate**](/api/classes/Indicate) \u00B7 [**Rotate**](/api/classes/Rotate)');
+  lines.push('');
+  lines.push('---');
   lines.push('');
 
   // Group examples by category, preserving CATEGORIES definition order


### PR DESCRIPTION
The generate-example-docs.mjs script was overwriting examples.mdx during CI build, removing the manually-added Player example. Now the script includes the Player example at the top of the generated page.

## Summary
Brief description of changes.

## Changes
- ...

## Testing
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types check (`npm run typecheck`)

## Related Issues
Closes #
