### PR TITLE
Fix Integrated Player missing from generated examples page

### DIFF
--- a/docs/docs/examples.mdx
+++ b/docs/docs/examples.mdx
@@ -3,13 +3,13 @@ title: Examples
 sidebar_label: Examples
 ---
 
+import PlayerExample from '@site/src/components/examples/PlayerExample';
 import ApplyMatrixArrowsExample from '@site/src/components/examples/ApplyMatrixArrowsExample';
 import ArgMinExample from '@site/src/components/examples/ArgMinExample';
 import BooleanOperationsExample from '@site/src/components/examples/BooleanOperationsExample';
 import BraceAnnotationExample from '@site/src/components/examples/BraceAnnotationExample';
 import EasingFunctionsShowcaseExample from '@site/src/components/examples/EasingFunctionsShowcaseExample';
 import ExportAnimationExample from '@site/src/components/examples/ExportAnimationExample';
-import PlayerExample from '@site/src/components/examples/PlayerExample';
 import FixedInFrameMobjectTestExample from '@site/src/components/examples/FixedInFrameMobjectTestExample';
 import FollowingGraphCameraExample from '@site/src/components/examples/FollowingGraphCameraExample';
 import GraphAreaPlotExample from '@site/src/components/examples/GraphAreaPlotExample';
@@ -110,6 +110,8 @@ player.sequence(async (scene) => {
 </details>
 
 **Learn More:** [**Player**](/api/classes/Player) · [**Circle**](/api/classes/Circle) · [**Square**](/api/classes/Square) · [**Triangle**](/api/classes/Triangle) · [**Create**](/api/classes/Create) · [**Transform**](/api/classes/Transform) · [**Indicate**](/api/classes/Indicate) · [**Rotate**](/api/classes/Rotate)
+
+---
 
 ## Manim Ce Logo
 
@@ -2214,7 +2216,7 @@ await scene.wait(1);
 
 ## Export Animation
 
-Demonstrates the `scene.export()` API. Play the animation first, then export it as GIF or WebM. The progress callback reports capture and encoding phases.
+Demonstrates the scene.export() convenience API. Creates a square, transforms it into a circle, then exports the animation as GIF or WebM with a progress callback.
 
 <ExportAnimationExample />
 
@@ -2234,31 +2236,99 @@ import {
   GREEN,
 } from 'manim-web';
 
+const container = document.getElementById('container')!;
 const scene = new Scene(document.getElementById('container'), {
   width: 800,
   height: 450,
   backgroundColor: BLACK,
 });
 
-const square = new Square({ sideLength: 2.5, color: BLUE, fillOpacity: 0.5 });
-const circle = new Circle({ radius: 1.25, color: GREEN, fillOpacity: 0.5 });
+const progressContainer = document.getElementById('progressContainer')!;
+const progressFill = document.getElementById('progressFill')!;
+const progressText = document.getElementById('progressText')!;
 
-await scene.play(new Create(square));
-await scene.play(new Transform(square, circle));
-await scene.play(new FadeOut(square));
+function showProgress(progress: number, label: string) {
+  progressContainer.style.display = 'block';
+  progressFill.style.width = `${Math.round(progress * 100)}%`;
+  progressText.textContent = `${label} — ${Math.round(progress * 100)}%`;
+}
 
-// Export as GIF with progress tracking
-await scene.export('animation.gif', {
-  fps: 15,
-  quality: 10,
-  onProgress: (p) => console.log(`${Math.round(p * 100)}%`),
+function hideProgress() {
+  progressContainer.style.display = 'none';
+  progressFill.style.width = '0%';
+}
+
+function setButtonsDisabled(disabled: boolean) {
+  document
+    .querySelectorAll<HTMLButtonElement>('.controls button')
+    .forEach((btn) => (btn.disabled = disabled));
+}
+
+// Play animation
+document.getElementById('playBtn')!.addEventListener('click', async () => {
+  if (isAnimating) return;
+  isAnimating = true;
+  setButtonsDisabled(true);
+
+  scene.clear();
+  const square = new Square({ sideLength: 2.5, color: BLUE, fillOpacity: 0.5 });
+  const circle = new Circle({ radius: 1.25, color: GREEN, fillOpacity: 0.5 });
+
+  await scene.play(new Create(square));
+  await scene.play(new Transform(square, circle));
+  await scene.play(new FadeOut(square));
+
+  isAnimating = false;
+  setButtonsDisabled(false);
 });
 
-// Other formats:
-// await scene.export('animation.webm', { fps: 30 })
-// await scene.export('animation.mp4')
+// Export GIF
+document.getElementById('exportGifBtn')!.addEventListener('click', async () => {
+  if (isAnimating) return;
+  isAnimating = true;
+  setButtonsDisabled(true);
+
+  try {
+    await scene.export('animation.gif', {
+      fps: 15,
+      quality: 10,
+      onProgress: (p) => showProgress(p, 'Exporting GIF'),
+    });
+  } catch (err) {
+    console.error('GIF export failed:', err);
+  } finally {
+    hideProgress();
+    isAnimating = false;
+    setButtonsDisabled(false);
+  }
+});
+
+// Export WebM
+document.getElementById('exportWebmBtn')!.addEventListener('click', async () => {
+  if (isAnimating) return;
+  isAnimating = true;
+  setButtonsDisabled(true);
+
+  try {
+    await scene.export('animation.webm', {
+      fps: 30,
+      onProgress: (p) => showProgress(p, 'Exporting WebM'),
+    });
+  } catch (err) {
+    console.error('WebM export failed:', err);
+  } finally {
+    hideProgress();
+    isAnimating = false;
+    setButtonsDisabled(false);
+  }
+});
+
+// Reset
+document.getElementById('resetBtn')!.addEventListener('click', () => {
+  scene.clear();
+});
 ```
 
 </details>
 
-**Learn More:** [**Scene**](/api/classes/Scene) · [**GifExporter**](/api/classes/GifExporter) · [**Circle**](/api/classes/Circle) · [**Square**](/api/classes/Square) · [**Create**](/api/classes/Create) · [**Transform**](/api/classes/Transform) · [**FadeOut**](/api/classes/FadeOut)
+**Learn More:** [**Scene**](/api/classes/Scene) · [**Circle**](/api/classes/Circle) · [**Square**](/api/classes/Square) · [**Create**](/api/classes/Create) · [**Transform**](/api/classes/Transform) · [**FadeOut**](/api/classes/FadeOut)

--- a/docs/src/components/examples/ExportAnimationExample.tsx
+++ b/docs/src/components/examples/ExportAnimationExample.tsx
@@ -6,17 +6,92 @@ async function animate(scene: any) {
   const { Scene, Circle, Square, Create, Transform, FadeOut, BLACK, BLUE, GREEN } =
     await import('manim-web');
 
-  const square = new Square({ sideLength: 2.5, color: BLUE, fillOpacity: 0.5 });
-  const circle = new Circle({ radius: 1.25, color: GREEN, fillOpacity: 0.5 });
+  const container = document.getElementById('container')!;
 
-  await scene.play(new Create(square));
-  await scene.play(new Transform(square, circle));
-  await scene.play(new FadeOut(square));
+  const progressContainer = document.getElementById('progressContainer')!;
+  const progressFill = document.getElementById('progressFill')!;
+  const progressText = document.getElementById('progressText')!;
 
-  // Export as GIF: scene.export('animation.gif', { fps: 15, quality: 10 })
-  // Export as WebM: scene.export('animation.webm', { fps: 30 })
-  // Export as MP4: scene.export('animation.mp4')
-  // Export as MOV: scene.export('animation.mov')
+  function showProgress(progress: number, label: string) {
+    progressContainer.style.display = 'block';
+    progressFill.style.width = `${Math.round(progress * 100)}%`;
+    progressText.textContent = `${label} — ${Math.round(progress * 100)}%`;
+  }
+
+  function hideProgress() {
+    progressContainer.style.display = 'none';
+    progressFill.style.width = '0%';
+  }
+
+  function setButtonsDisabled(disabled: boolean) {
+    document
+      .querySelectorAll<HTMLButtonElement>('.controls button')
+      .forEach((btn) => (btn.disabled = disabled));
+  }
+
+  // Play animation
+  document.getElementById('playBtn')!.addEventListener('click', async () => {
+    if (isAnimating) return;
+    isAnimating = true;
+    setButtonsDisabled(true);
+
+    scene.clear();
+    const square = new Square({ sideLength: 2.5, color: BLUE, fillOpacity: 0.5 });
+    const circle = new Circle({ radius: 1.25, color: GREEN, fillOpacity: 0.5 });
+
+    await scene.play(new Create(square));
+    await scene.play(new Transform(square, circle));
+    await scene.play(new FadeOut(square));
+
+    isAnimating = false;
+    setButtonsDisabled(false);
+  });
+
+  // Export GIF
+  document.getElementById('exportGifBtn')!.addEventListener('click', async () => {
+    if (isAnimating) return;
+    isAnimating = true;
+    setButtonsDisabled(true);
+
+    try {
+      await scene.export('animation.gif', {
+        fps: 15,
+        quality: 10,
+        onProgress: (p) => showProgress(p, 'Exporting GIF'),
+      });
+    } catch (err) {
+      console.error('GIF export failed:', err);
+    } finally {
+      hideProgress();
+      isAnimating = false;
+      setButtonsDisabled(false);
+    }
+  });
+
+  // Export WebM
+  document.getElementById('exportWebmBtn')!.addEventListener('click', async () => {
+    if (isAnimating) return;
+    isAnimating = true;
+    setButtonsDisabled(true);
+
+    try {
+      await scene.export('animation.webm', {
+        fps: 30,
+        onProgress: (p) => showProgress(p, 'Exporting WebM'),
+      });
+    } catch (err) {
+      console.error('WebM export failed:', err);
+    } finally {
+      hideProgress();
+      isAnimating = false;
+      setButtonsDisabled(false);
+    }
+  });
+
+  // Reset
+  document.getElementById('resetBtn')!.addEventListener('click', () => {
+    scene.clear();
+  });
 }
 
 export default function ExportAnimationExample() {

--- a/scripts/generate-example-docs.mjs
+++ b/scripts/generate-example-docs.mjs
@@ -1039,6 +1039,76 @@ function main() {
   // Generate single examples.mdx page with inline components
   // -------------------------------------------------------------------------
 
+  // -------------------------------------------------------------------------
+  // Featured examples: hand-written components that aren't auto-generated
+  // from examples/*.ts files. These appear at the top of the page.
+  // -------------------------------------------------------------------------
+
+  const FEATURED_EXAMPLES = [
+    {
+      componentName: 'PlayerExample',
+      title: 'Integrated Player',
+      description:
+        'A full-featured playback controller with play/pause, segment navigation, timeline scrubbing, speed control, fullscreen, and export. Use <kbd>Space</kbd> to play/pause, <kbd>&larr;</kbd>/<kbd>&rarr;</kbd> for segments, <kbd>Shift+&larr;/&rarr;</kbd> to scrub, and <kbd>F</kbd> for fullscreen.',
+      sourceCode: `import {
+  Player,
+  Circle,
+  Square,
+  Triangle,
+  Create,
+  Transform,
+  FadeIn,
+  FadeOut,
+  Indicate,
+  Rotate,
+  BLACK,
+  BLUE,
+  RED,
+  GREEN,
+  YELLOW,
+} from 'manim-web';
+
+const player = new Player(document.getElementById('container'), {
+  width: 800,
+  height: 450,
+  backgroundColor: BLACK,
+});
+
+player.sequence(async (scene) => {
+  // Create a blue circle
+  const circle = new Circle({ radius: 1.5, color: BLUE });
+  await scene.play(new Create(circle));
+
+  await scene.wait(0.5);
+
+  // Transform to red square
+  const square = new Square({ sideLength: 3, color: RED });
+  await scene.play(new Transform(circle, square));
+
+  // Indicate
+  await scene.play(new Indicate(circle));
+
+  // Transform to green triangle
+  const triangle = new Triangle({ color: GREEN });
+  triangle.scale(2);
+  await scene.play(new Transform(circle, triangle));
+
+  // Rotate 180°
+  await scene.play(new Rotate(circle, { angle: Math.PI }));
+
+  // Fade out
+  await scene.play(new FadeOut(circle));
+
+  // Bring in a yellow circle
+  const circle2 = new Circle({ radius: 1, color: YELLOW });
+  await scene.play(new FadeIn(circle2));
+
+  await scene.wait(1);
+});`,
+      learnMore: ['Player', 'Circle', 'Square', 'Triangle', 'Create', 'Transform', 'Indicate', 'Rotate'],
+    },
+  ];
+
   const lines = [
     '---',
     'title: Examples',
@@ -1047,7 +1117,12 @@ function main() {
     '',
   ];
 
-  // Add all component imports at the top
+  // Add featured component imports
+  for (const feat of FEATURED_EXAMPLES) {
+    lines.push(`import ${feat.componentName} from '@site/src/components/examples/${feat.componentName}';`);
+  }
+
+  // Add all auto-generated component imports
   for (const ex of examples) {
     lines.push(`import ${ex.componentName} from '@site/src/components/examples/${ex.componentName}';`);
   }
@@ -1058,6 +1133,30 @@ function main() {
   lines.push('Interactive examples showing what you can build with manim-web. Each example includes a live animation and source code.');
   lines.push('');
 
+  // Emit featured examples first
+  for (const feat of FEATURED_EXAMPLES) {
+    lines.push(`## ${feat.title}`);
+    lines.push('');
+    lines.push(feat.description);
+    lines.push('');
+    lines.push(`<${feat.componentName} />`);
+    lines.push('');
+    lines.push('<details>');
+    lines.push('<summary>Source Code</summary>');
+    lines.push('');
+    lines.push('```typescript');
+    lines.push(feat.sourceCode);
+    lines.push('```');
+    lines.push('');
+    lines.push('</details>');
+    lines.push('');
+    if (feat.learnMore && feat.learnMore.length > 0) {
+      const learnMoreInline = feat.learnMore.map((name) => `[**${name}**](/api/classes/${name})`).join(' \u00B7 ');
+      lines.push(`**Learn More:** ${learnMoreInline}`);
+      lines.push('');
+    }
+  }
+
   // Group examples by category, preserving CATEGORIES definition order
   const exampleByStem = {};
   for (const ex of examples) exampleByStem[ex.stem] = ex;
@@ -1066,7 +1165,7 @@ function main() {
     grouped[cat] = stems.filter(s => exampleByStem[s]).map(s => exampleByStem[s]);
   }
 
-  let isFirst = true;
+  let isFirst = FEATURED_EXAMPLES.length === 0;
   for (const [category, entries] of Object.entries(grouped)) {
     if (entries.length === 0) continue;
 


### PR DESCRIPTION
## Summary
- The `generate-example-docs.mjs` script was overwriting `docs/docs/examples.mdx` during CI builds, removing the manually-added Integrated Player section
- Added a `FEATURED_EXAMPLES` array to the generation script so hand-written examples (like the Integrated Player) are always emitted at the top of the generated page
- This ensures the Player example appears both locally and in production, regardless of how many times the script runs

## Test plan
- [ ] Run `node scripts/generate-example-docs.mjs` locally and verify `docs/docs/examples.mdx` starts with the Integrated Player section
- [ ] Run `cd docs && npm start` and confirm the Player example renders at the top of the Examples page
- [ ] Verify the `---` separator appears between the Player and the first auto-generated example