### PR TITLE
Fix VMobject GPU memory leak: dispose _cachedLine2 geometry

### DIFF
--- a/src/core/VMobject.ts
+++ b/src/core/VMobject.ts
@@ -1403,7 +1403,10 @@ export class VMobject extends Mobject {
   override dispose(): void {
     this._strokeMaterial?.dispose();
     this._fillMaterial?.dispose();
-    this._cachedLine2 = null;
+    if (this._cachedLine2) {
+      this._cachedLine2.geometry.dispose();
+      this._cachedLine2 = null;
+    }
     for (const line of this._cachedLine2Array) {
       line.geometry.dispose();
     }

--- a/src/core/core-extra.test.ts
+++ b/src/core/core-extra.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Mobject, UP, LEFT, RIGHT, UL, UR, DL, DR } from './Mobject';
 import {
   VMobject,
@@ -2897,6 +2897,24 @@ describe('VMobject.dispose', () => {
       [3, 0, 0],
     ]);
     expect(() => v.dispose()).not.toThrow();
+  });
+
+  it('disposes _cachedLine2 geometry before nulling', () => {
+    const v = new VMobject();
+    v.setPoints([
+      [0, 0, 0],
+      [1, 0, 0],
+      [2, 0, 0],
+      [3, 0, 0],
+    ]);
+    v.strokeWidth = 2;
+    v._syncToThree();
+    const cachedLine = (v as any)._cachedLine2;
+    expect(cachedLine).not.toBeNull();
+    const disposeSpy = vi.spyOn(cachedLine.geometry, 'dispose');
+    v.dispose();
+    expect(disposeSpy).toHaveBeenCalled();
+    expect((v as any)._cachedLine2).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Fix GPU memory leak where `_cachedLine2` geometry was not disposed in `VMobject.dispose()`
- Add test verifying geometry cleanup on dispose

## Test plan
- [x] Existing tests pass
- [x] New test verifies _cachedLine2 geometry is disposed

Fixes #74