### PR TITLE
Fix 4 P1-high bugs: silent failures, unhandled rejection, stuck animations, context loss

### DIFF
--- a/src/animation/Animation.ts
+++ b/src/animation/Animation.ts
@@ -66,9 +66,14 @@ export abstract class Animation {
     if (!this._preAnimationState) {
       try {
         this._preAnimationState = this.mobject.copy();
-      } catch {
+      } catch (err) {
         // Some mobjects (test mocks, minimal subclasses) don't support copy().
         // Fall back to a lightweight property-only snapshot.
+        console.warn(
+          'Animation.begin(): mobject.copy() failed, using minimal state snapshot. ' +
+            'Backward seeking may not fully restore this mobject.',
+          err,
+        );
         this._preAnimationState = this._captureMinimalState();
       }
     }

--- a/src/animation/AnimationGroup.ts
+++ b/src/animation/AnimationGroup.ts
@@ -41,7 +41,7 @@ function computeGroupDuration(animations: Animation[], lagRatio: number): number
 
   if (lagRatio === 0) {
     // All parallel - duration is max of all durations
-    return Math.max(...animations.map(a => a.duration));
+    return Math.max(...animations.map((a) => a.duration));
   } else if (lagRatio >= 1) {
     // Sequential - duration is sum of all durations
     return animations.reduce((sum, a) => sum + a.duration, 0);
@@ -83,7 +83,7 @@ export class AnimationGroup extends Animation {
 
     super(dummyMobject, {
       duration: computedDuration,
-      rateFunc: options.rateFunc ?? linear
+      rateFunc: options.rateFunc ?? linear,
     });
 
     this.animations = animations;
@@ -172,7 +172,7 @@ export class AnimationGroup extends Animation {
    * Check if all child animations have finished
    */
   override isFinished(): boolean {
-    return this.animations.every(anim => anim.isFinished());
+    return this._isFinished || this.animations.every((anim) => anim.isFinished());
   }
 
   /**
@@ -193,7 +193,7 @@ export class AnimationGroup extends Animation {
  */
 export function animationGroup(
   animations: Animation[],
-  options?: AnimationGroupOptions
+  options?: AnimationGroupOptions,
 ): AnimationGroup {
   return new AnimationGroup(animations, options);
 }

--- a/src/core/Renderer.ts
+++ b/src/core/Renderer.ts
@@ -33,6 +33,7 @@ export class Renderer {
   private _width: number;
   private _height: number;
   private _backgroundColor: THREE.Color;
+  private _contextLost: boolean = false;
 
   /**
    * Create a new Renderer and append it to the container.
@@ -49,7 +50,7 @@ export class Renderer {
       pixelRatio = typeof window !== 'undefined' ? Math.min(window.devicePixelRatio, 2) : 1,
       powerPreference = 'high-performance',
       alpha = false,
-      preserveDrawingBuffer = true,  // Needed for video/image export
+      preserveDrawingBuffer = true, // Needed for video/image export
       canvas,
     } = options;
 
@@ -58,7 +59,7 @@ export class Renderer {
     this._backgroundColor = new THREE.Color(backgroundColor);
 
     this._renderer = new THREE.WebGLRenderer({
-      canvas,  // Reuse existing canvas if provided
+      canvas, // Reuse existing canvas if provided
       antialias,
       alpha,
       preserveDrawingBuffer,
@@ -70,10 +71,29 @@ export class Renderer {
     this._renderer.setPixelRatio(Math.min(pixelRatio, 2));
     this._renderer.setClearColor(this._backgroundColor);
 
+    // Handle WebGL context loss/restore (common on mobile, GPU pressure, backgrounded tabs)
+    const domElement = this._renderer.domElement;
+    domElement.addEventListener('webglcontextlost', (event) => {
+      event.preventDefault();
+      this._contextLost = true;
+      console.warn('Renderer: WebGL context lost. Rendering suspended.');
+    });
+    domElement.addEventListener('webglcontextrestored', () => {
+      this._contextLost = false;
+      console.warn('Renderer: WebGL context restored.');
+    });
+
     // Only append if we created a new canvas (no existing canvas provided)
     if (!canvas) {
       container.appendChild(this._renderer.domElement);
     }
+  }
+
+  /**
+   * Whether the WebGL context is currently lost.
+   */
+  get isContextLost(): boolean {
+    return this._contextLost;
   }
 
   /**
@@ -111,6 +131,7 @@ export class Renderer {
    * @param camera - Three.js camera to use
    */
   render(scene: THREE.Scene, camera: THREE.Camera): void {
+    if (this._contextLost) return;
     this._renderer.render(scene, camera);
   }
 

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -697,11 +697,16 @@ export class Scene {
       const stillRendering = typeof asyncMob.isRendering !== 'function' || asyncMob.isRendering();
 
       if (stillRendering) {
-        asyncMob.waitForRender().then(() => {
-          if (this._autoRender) {
-            this._render();
-          }
-        });
+        asyncMob
+          .waitForRender()
+          .then(() => {
+            if (this._autoRender) {
+              this._render();
+            }
+          })
+          .catch((err) => {
+            console.warn('Scene: async mobject render failed for', asyncMob, err);
+          });
       }
     }
     for (const child of mobject.children) {


### PR DESCRIPTION
## Summary

- **Animation.begin()**: Log warning when `mobject.copy()` fails instead of silently falling back to minimal state snapshot (fixes #84)
- **Scene._awaitAsyncRenders()**: Add `.catch()` handler to prevent unhandled promise rejections that crash Node.js test environments (fixes #83)
- **AnimationGroup.isFinished()**: Respect parent `_isFinished` flag so `finish()` properly terminates the group, preventing stuck animations in the Timeline (fixes #78)
- **Renderer**: Handle WebGL context loss/restore events with warnings, track state via `isContextLost` getter, and guard `render()` calls during context loss (fixes #76)

## Test plan

- [x] All 5393 existing tests pass
- [x] Type-check passes (no new errors)
- [x] Lint/prettier pass via pre-commit hooks