### PR TITLE
Fix 4 P3-low bugs: render order, boolean ops, ESLint, complexity

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,7 +30,7 @@ export default [
         { selector: "enum", format: ["PascalCase"] },
         { selector: "enumMember", format: ["UPPER_CASE", "PascalCase"] },
         { selector: "function", format: ["camelCase", "PascalCase"] },
-        { selector: "method", format: ["camelCase"] },
+        { selector: "method", format: ["camelCase"], leadingUnderscore: "allow" },
         { selector: "variable", format: ["camelCase", "UPPER_CASE", "PascalCase"] },
         {
           selector: "parameter",

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -409,6 +409,7 @@ export class Scene {
       mobject.dispose();
     }
     this._mobjects.clear();
+    this._renderOrderCounter = 0;
 
     // Also remove any untracked Three.js objects (e.g., cross-fade targets
     // added directly by Transform animations)

--- a/src/mobjects/geometry/BooleanOperations.ts
+++ b/src/mobjects/geometry/BooleanOperations.ts
@@ -226,10 +226,11 @@ function performBooleanOp(
         result = polygonClipping.xor(geomA, geomB);
         break;
     }
-  } catch {
+  } catch (err) {
     // If polygon-clipping throws (extremely degenerate input), fall back
     // to returning the subject polygon for union/difference, or empty for
     // intersection/xor.
+    console.warn(`BooleanOperations: ${operation} failed, returning fallback.`, err);
     if (operation === 'union' || operation === 'difference') {
       return [polyA];
     }

--- a/src/utils/hungarian.ts
+++ b/src/utils/hungarian.ts
@@ -91,7 +91,7 @@ export function hungarian(costMatrix: number[][]): HungarianResult {
         return costMatrix[i][j];
       }
       return DUMMY_COST;
-    })
+    }),
   );
 
   // Hungarian algorithm (Kuhn-Munkres) using the potential method.
@@ -99,67 +99,16 @@ export function hungarian(costMatrix: number[][]): HungarianResult {
   //
   // u[i] = potential for row i (worker)
   // v[j] = potential for column j (job)
-  // rowAssign[i] = column assigned to row i (-1 if unassigned)
-  // colAssign[j] = row assigned to column j (-1 if unassigned)
+  // rowAssign[j] = row assigned to col j (1-indexed, 0 = unassigned)
 
-  const u = new Float64Array(n + 1);  // row potentials (1-indexed, 0 unused)
-  const v = new Float64Array(n + 1);  // col potentials (1-indexed, 0 unused)
-  const rowAssign = new Int32Array(n + 1).fill(0);  // p[j] = row assigned to col j
-  const way = new Int32Array(n + 1).fill(0);         // way[j] = previous col in augmenting path
+  const u = new Float64Array(n + 1); // row potentials (1-indexed, 0 unused)
+  const v = new Float64Array(n + 1); // col potentials (1-indexed, 0 unused)
+  const rowAssign = new Int32Array(n + 1).fill(0);
+  const way = new Int32Array(n + 1).fill(0);
 
   // Process each row one at a time
   for (let i = 1; i <= n; i++) {
-    // Start a new augmenting path from row i.
-    // We use column 0 as a virtual "starting" column.
-    rowAssign[0] = i;
-    let j0 = 0; // current column in the path
-
-    const minv = new Float64Array(n + 1).fill(Infinity);
-    const used = new Uint8Array(n + 1); // boolean flags
-
-    // Find augmenting path using Dijkstra-like shortest path
-    do {
-      used[j0] = 1;
-      const i0 = rowAssign[j0];
-      let delta = Infinity;
-      let j1 = -1;
-
-      for (let j = 1; j <= n; j++) {
-        if (used[j]) continue;
-
-        // Reduced cost
-        const cur = cost[i0 - 1][j - 1] - u[i0] - v[j];
-
-        if (cur < minv[j]) {
-          minv[j] = cur;
-          way[j] = j0;
-        }
-
-        if (minv[j] < delta) {
-          delta = minv[j];
-          j1 = j;
-        }
-      }
-
-      // Update potentials along the path
-      for (let j = 0; j <= n; j++) {
-        if (used[j]) {
-          u[rowAssign[j]] += delta;
-          v[j] -= delta;
-        } else {
-          minv[j] -= delta;
-        }
-      }
-
-      j0 = j1;
-    } while (rowAssign[j0] !== 0);
-
-    // Trace back the augmenting path and update assignments
-    do {
-      const j1 = way[j0];
-      rowAssign[j0] = rowAssign[j1];
-      j0 = j1;
-    } while (j0 !== 0);
+    augmentRow(i, n, cost, u, v, rowAssign, way);
   }
 
   // Extract results (convert from 1-indexed to 0-indexed)
@@ -187,6 +136,66 @@ export function hungarian(costMatrix: number[][]): HungarianResult {
 }
 
 /**
+ * Find an augmenting path for row i and update assignments/potentials.
+ * Extracted from the main hungarian loop to reduce cyclomatic complexity.
+ */
+function augmentRow(
+  i: number,
+  n: number,
+  cost: number[][],
+  u: Float64Array,
+  v: Float64Array,
+  rowAssign: Int32Array,
+  way: Int32Array,
+): void {
+  rowAssign[0] = i;
+  let j0 = 0;
+
+  const minv = new Float64Array(n + 1).fill(Infinity);
+  const used = new Uint8Array(n + 1);
+
+  do {
+    used[j0] = 1;
+    const i0 = rowAssign[j0];
+    let delta = Infinity;
+    let j1 = -1;
+
+    for (let j = 1; j <= n; j++) {
+      if (used[j]) continue;
+
+      const cur = cost[i0 - 1][j - 1] - u[i0] - v[j];
+
+      if (cur < minv[j]) {
+        minv[j] = cur;
+        way[j] = j0;
+      }
+
+      if (minv[j] < delta) {
+        delta = minv[j];
+        j1 = j;
+      }
+    }
+
+    for (let j = 0; j <= n; j++) {
+      if (used[j]) {
+        u[rowAssign[j]] += delta;
+        v[j] -= delta;
+      } else {
+        minv[j] -= delta;
+      }
+    }
+
+    j0 = j1;
+  } while (rowAssign[j0] !== 0);
+
+  do {
+    const j1 = way[j0];
+    rowAssign[j0] = rowAssign[j1];
+    j0 = j1;
+  } while (j0 !== 0);
+}
+
+/**
  * Convenience function to find the optimal matching given a similarity matrix.
  * Converts similarities (higher = better) to costs (lower = better) and
  * runs the Hungarian algorithm.
@@ -198,7 +207,7 @@ export function hungarian(costMatrix: number[][]): HungarianResult {
  */
 export function hungarianFromSimilarity(
   similarityMatrix: number[][],
-  threshold: number = 0
+  threshold: number = 0,
 ): HungarianResult {
   const rows = similarityMatrix.length;
   if (rows === 0) {
@@ -233,7 +242,7 @@ export function hungarianFromSimilarity(
         return maxSim - similarityMatrix[i][j];
       }
       return penaltyCost;
-    })
+    }),
   );
 
   const result = hungarian(costMatrix);

--- a/src/utils/skeletonize.ts
+++ b/src/utils/skeletonize.ts
@@ -74,35 +74,43 @@ export function skeletonizeGlyph(
   if (chains.length === 0) return [];
 
   // 5. Convert pixel chains back to world coordinates, smooth, and fit Beziers
+  return chainsToBeziers(chains, bbox, cols, rows, smoothSubs);
+}
+
+/**
+ * Convert traced pixel chains to cubic Bezier control points.
+ * Each chain is smoothed with Catmull-Rom and fit to Bezier curves.
+ * Multiple chains are joined with degenerate zero-length segments.
+ */
+function chainsToBeziers(
+  chains: number[][][],
+  bbox: BBox,
+  cols: number,
+  rows: number,
+  smoothSubs: number,
+): number[][] {
   const allPoints: number[][] = [];
   let firstChain = true;
 
   for (const chain of chains) {
-    // Convert pixel coords to world coords
     const worldChain = chain.map(([px, py]) => pixelToWorld(px, py, bbox, cols, rows));
-
-    // Smooth with Catmull-Rom subdivision
     const smooth = catmullRomSmooth(worldChain, smoothSubs);
     if (smooth.length < 2) continue;
 
-    // Fit cubic Beziers
     const beziers = fitCubicBeziers(smooth);
     if (beziers.length === 0) continue;
 
     if (!firstChain && allPoints.length > 0) {
-      // Join chains with a degenerate zero-length segment
       const lastPt = allPoints[allPoints.length - 1];
       const newPt = beziers[0];
       allPoints.push([...lastPt]);
       allPoints.push([...newPt]);
       allPoints.push([...newPt]);
     } else {
-      // First anchor of first chain
       allPoints.push(beziers[0]);
       firstChain = false;
     }
 
-    // Append remaining Bezier points (handle1, handle2, anchor per segment)
     for (let i = 1; i < beziers.length; i++) {
       allPoints.push(beziers[i]);
     }
@@ -265,80 +273,94 @@ function flattenCubicsToSegments(
 function zhangSuenThin(grid: Uint8Array, cols: number, rows: number): void {
   let changed = true;
 
-  // Temporary flags: 0 = background, 1 = foreground, 2 = marked for removal
   while (changed) {
     changed = false;
 
-    // --- Sub-iteration 1 ---
-    for (let r = 1; r < rows - 1; r++) {
-      for (let c = 1; c < cols - 1; c++) {
-        if (grid[r * cols + c] !== 1) continue;
+    // Sub-iteration 1: check P2,P4,P6 and P4,P6,P8
+    if (zhangSuenPass(grid, cols, rows, 1)) changed = true;
 
-        const p2 = grid[(r - 1) * cols + c];
-        const p3 = grid[(r - 1) * cols + c + 1];
-        const p4 = grid[r * cols + c + 1];
-        const p5 = grid[(r + 1) * cols + c + 1];
-        const p6 = grid[(r + 1) * cols + c];
-        const p7 = grid[(r + 1) * cols + c - 1];
-        const p8 = grid[r * cols + c - 1];
-        const p9 = grid[(r - 1) * cols + c - 1];
+    // Sub-iteration 2: check P2,P4,P8 and P2,P6,P8
+    if (zhangSuenPass(grid, cols, rows, 2)) changed = true;
+  }
+}
 
-        const B = neighborCount(p2, p3, p4, p5, p6, p7, p8, p9);
-        if (B < 2 || B > 6) continue;
+/**
+ * Check common Zhang-Suen conditions shared by both sub-iterations:
+ * B (neighbor count) must be in [2, 6] and A (transitions) must be 1.
+ */
+function zhangSuenCommonCheck(
+  p2: number,
+  p3: number,
+  p4: number,
+  p5: number,
+  p6: number,
+  p7: number,
+  p8: number,
+  p9: number,
+): boolean {
+  const B = neighborCount(p2, p3, p4, p5, p6, p7, p8, p9);
+  if (B < 2 || B > 6) return false;
+  return transitions(p2, p3, p4, p5, p6, p7, p8, p9) === 1;
+}
 
-        const A = transitions(p2, p3, p4, p5, p6, p7, p8, p9);
-        if (A !== 1) continue;
+/**
+ * Step-specific condition for Zhang-Suen sub-iteration 1:
+ * At least one of {P2,P4,P6} and at least one of {P4,P6,P8} must be background.
+ */
+function zhangSuenStep1Check(p2: number, p4: number, p6: number, p8: number): boolean {
+  if (p2 && p4 && p6) return false;
+  if (p4 && p6 && p8) return false;
+  return true;
+}
 
-        // At least one of P2, P4, P6 is background
-        if (p2 && p4 && p6) continue;
+/**
+ * Step-specific condition for Zhang-Suen sub-iteration 2:
+ * At least one of {P2,P4,P8} and at least one of {P2,P6,P8} must be background.
+ */
+function zhangSuenStep2Check(p2: number, p4: number, p6: number, p8: number): boolean {
+  if (p2 && p4 && p8) return false;
+  if (p2 && p6 && p8) return false;
+  return true;
+}
 
-        // At least one of P4, P6, P8 is background
-        if (p4 && p6 && p8) continue;
+/**
+ * Execute one sub-iteration pass of Zhang-Suen thinning.
+ * @param step 1 for the first sub-iteration, 2 for the second.
+ * @returns true if any pixels were removed.
+ */
+function zhangSuenPass(grid: Uint8Array, cols: number, rows: number, step: 1 | 2): boolean {
+  let changed = false;
 
-        grid[r * cols + c] = 2; // mark for removal
+  for (let r = 1; r < rows - 1; r++) {
+    for (let c = 1; c < cols - 1; c++) {
+      if (grid[r * cols + c] !== 1) continue;
+
+      const idx = r * cols;
+      const p2 = grid[(r - 1) * cols + c];
+      const p3 = grid[(r - 1) * cols + c + 1];
+      const p4 = grid[idx + c + 1];
+      const p5 = grid[(r + 1) * cols + c + 1];
+      const p6 = grid[(r + 1) * cols + c];
+      const p7 = grid[(r + 1) * cols + c - 1];
+      const p8 = grid[idx + c - 1];
+      const p9 = grid[(r - 1) * cols + c - 1];
+
+      if (
+        zhangSuenCommonCheck(p2, p3, p4, p5, p6, p7, p8, p9) &&
+        (step === 1 ? zhangSuenStep1Check(p2, p4, p6, p8) : zhangSuenStep2Check(p2, p4, p6, p8))
+      ) {
+        grid[idx + c] = 2;
         changed = true;
       }
-    }
-    // Remove marked pixels
-    for (let i = 0; i < grid.length; i++) {
-      if (grid[i] === 2) grid[i] = 0;
-    }
-
-    // --- Sub-iteration 2 ---
-    for (let r = 1; r < rows - 1; r++) {
-      for (let c = 1; c < cols - 1; c++) {
-        if (grid[r * cols + c] !== 1) continue;
-
-        const p2 = grid[(r - 1) * cols + c];
-        const p3 = grid[(r - 1) * cols + c + 1];
-        const p4 = grid[r * cols + c + 1];
-        const p5 = grid[(r + 1) * cols + c + 1];
-        const p6 = grid[(r + 1) * cols + c];
-        const p7 = grid[(r + 1) * cols + c - 1];
-        const p8 = grid[r * cols + c - 1];
-        const p9 = grid[(r - 1) * cols + c - 1];
-
-        const B = neighborCount(p2, p3, p4, p5, p6, p7, p8, p9);
-        if (B < 2 || B > 6) continue;
-
-        const A = transitions(p2, p3, p4, p5, p6, p7, p8, p9);
-        if (A !== 1) continue;
-
-        // At least one of P2, P4, P8 is background
-        if (p2 && p4 && p8) continue;
-
-        // At least one of P2, P6, P8 is background
-        if (p2 && p6 && p8) continue;
-
-        grid[r * cols + c] = 2;
-        changed = true;
-      }
-    }
-    // Remove marked pixels
-    for (let i = 0; i < grid.length; i++) {
-      if (grid[i] === 2) grid[i] = 0;
     }
   }
+
+  // Remove marked pixels
+  for (let i = 0; i < grid.length; i++) {
+    if (grid[i] === 2) grid[i] = 0;
+  }
+
+  return changed;
 }
 
 /** Count the number of non-zero neighbors (B in Zhang-Suen). */


### PR DESCRIPTION
## Summary
- **#82**: Reset `_renderOrderCounter` in `Scene.clear()` to prevent unbounded growth in long-running apps where foreground objects eventually lose their ordering gap
- **#87**: Add `console.warn` when polygon-clipping throws in `BooleanOperations`, so users know the operation failed instead of silently getting a fallback result
- **#88**: Allow `_camelCase` private methods in ESLint naming convention by adding `leadingUnderscore: "allow"` — eliminates ~50 false-positive warnings
- **#92**: Reduce cyclomatic complexity in `zhangSuenThin` (30→15), `hungarian` (19→11), and `skeletonizeGlyph` (16→10) by extracting helper functions

## Test plan
- [x] All 5477 existing tests pass
- [x] ESLint complexity warnings eliminated for targeted functions
- [x] ESLint naming convention no longer flags `_camelCase` methods
- [x] TypeScript compiles without new errors

Closes #82 Closes #87 Closes #88 Closes #92