### PR TITLE
fix: objects are hidden at the start of respective segments

### DIFF
--- a/src/player/Player.ts
+++ b/src/player/Player.ts
@@ -364,6 +364,14 @@ export class Player {
     this._lastFrameTime = performance.now();
 
     const loop = (now: number) => {
+      const curSegment = this._masterTimeline.getCurrentSegment();
+
+      if (curSegment && curSegment.startTime <= this._masterTimeline.getCurrentTime()) {
+        for (const anim of curSegment.animations) {
+          anim.mobject.opacity = 1;
+        }
+      }
+
       if (!this._isPlaying) {
         this._animFrameId = null;
         return;


### PR DESCRIPTION
## Summary

This fixes a bug where objects' opacity do not get set to one after their respective segment starts.

This bug can be replicated by running the following:

```bash
npm create vite@latest bug -- --template vanilla
```

Reject both the Vite 8 beta and installing with npm.

then run:

```bash
cd bug && npm install manim-web
```

Change the generated `index.html` file to the following:

```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>my-app</title>
  </head>
  <body>
    <div id="container" style="width: 1000px; height: 1000px;"></div>
    <script type="module" src="./main.js"></script>
  </body>
</html>
```

Add a main.js script in the same directory containing the following:

```js
import { Circle, Create, Line, NumberPlane, Player } from "manim-web";

const container = document.getElementById("container");

const player = new Player(container, {
  loop: true,
  autoPlay: true,
});

player.sequence(async (scene) => {
  const plane = new NumberPlane();
  const circle = new Circle({});
  const line = new Line();

  await scene.play(new Create(plane, { duration: 1 }));
  await scene.play(new Create(circle, { duration: 1 }));
  await scene.play(new Create(line, { duration: 1 }));
});
```
You will notice that the `NumberPlane` gets rendered correctly at the start of its segment. But, neither the circle nor the line are visibile. Their animations run correctly, but they're not visible.

This is because the `seek` method here, which gets called on playback start, hides all objects that are not in the current segment, but their opacity is never set to 1 again during the rendering loop.
 
https://github.com/maloyan/manim-web/blob/43db264192af1dbd25bc16b0142e3d3c58bf59ce/src/animation/MasterTimeline.ts#L54-L59


## Changes
The following lines are added at the start of the loop. A loop runs through all the objects and sets their opacity to 1 if they're introduced in the current segment.

```js
const curSegment = this._masterTimeline.getCurrentSegment();

if (curSegment && curSegment.startTime <= this._masterTimeline.getCurrentTime()) {
  for (const anim of curSegment.animations) {
    anim.mobject.opacity = 1;
  }
}
```

This is just an initial solution. It's not the most performance friendly, especially since `getCurrentSegment()` does a linear search. It could be optimized to do a binary search instead.

## Testing

- [x] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [x] Types check (`npm run typecheck`)
