### PR TITLE
fix: restore mobject opacity when segment starts during playback

### DIFF
--- a/src/animation/MasterTimeline.test.ts
+++ b/src/animation/MasterTimeline.test.ts
@@ -723,6 +723,45 @@ describe('MasterTimeline', () => {
       expect(tl.getCurrentTime()).toBeCloseTo(2);
     });
 
+    it('restores opacity of mobjects when their segment starts during playback (GH-106)', () => {
+      // Reproduces the bug from PR #106:
+      // After seek(0), mobjects in later segments get opacity=0.
+      // During update() playback, their opacity is never restored
+      // because nothing sets it back to 1 when their segment begins.
+      const mob1 = new TestMobject();
+      const mob2 = new TestMobject();
+      const mob3 = new TestMobject();
+      const anim1 = new TestAnimation(mob1, { duration: 1 });
+      const anim2 = new TestAnimation(mob2, { duration: 1 });
+      const anim3 = new TestAnimation(mob3, { duration: 1 });
+
+      tl.addSegment([anim1]); // seg 0: 0-1
+      tl.addSegment([anim2]); // seg 1: 1-2
+      tl.addSegment([anim3]); // seg 2: 2-3
+
+      // Simulate what Player.sequence() does: seek(0) to show initial state
+      tl.seek(0);
+
+      // mob2 and mob3 should be hidden since their segments haven't started
+      expect(mob2.opacity).toBe(0);
+      expect(mob3.opacity).toBe(0);
+
+      // Now play forward past segment 1's start time
+      tl.play();
+      tl.update(1.5); // time is now 1.5, inside segment 1
+
+      // BUG: mob2.opacity is still 0 — it was never restored
+      // mob2's segment has started, so it should be visible
+      expect(mob2.opacity).toBeGreaterThan(0);
+
+      // mob3's segment hasn't started yet, should still be hidden
+      expect(mob3.opacity).toBe(0);
+
+      // Continue past segment 2's start
+      tl.update(1.0); // time is now 2.5, inside segment 2
+      expect(mob3.opacity).toBeGreaterThan(0);
+    });
+
     it('nextSegment and prevSegment navigate correctly', () => {
       const mob = new TestMobject();
       tl.addSegment([new TestAnimation(mob, { duration: 1 })]);

--- a/src/animation/MasterTimeline.ts
+++ b/src/animation/MasterTimeline.ts
@@ -62,6 +62,25 @@ export class MasterTimeline extends Timeline {
   }
 
   /**
+   * Override update to restore opacity for mobjects whose introducing
+   * segment starts during this tick. seek() hides future mobjects by
+   * setting opacity=0; this restores them exactly when playback crosses
+   * their segment boundary (not every frame).
+   */
+  override update(dt: number): void {
+    const prevTime = this.getCurrentTime();
+    super.update(dt);
+    const newTime = this.getCurrentTime();
+
+    for (const [mobject, segIndex] of this._mobjectFirstSegment) {
+      const seg = this._segments[segIndex];
+      if (seg && prevTime < seg.startTime && newTime >= seg.startTime) {
+        mobject.opacity = 1;
+      }
+    }
+  }
+
+  /**
    * Override reset to use seek(0) so future mobjects are hidden.
    */
   override reset(): this {


### PR DESCRIPTION
## Summary

- Fixes #106: mobjects in later segments stay invisible after `seek(0)` because `update()` never restores their opacity
- Adds `update()` override in `MasterTimeline` that detects segment boundary crossings and restores `opacity=1` at the exact transition frame

## Root cause

`MasterTimeline.seek()` hides future-segment mobjects by setting `opacity=0`. During normal `update()` playback, nothing ever set it back to `1` when the segment began — the base `Timeline._updateAnimationsAtTime()` calls `animation.update()` which interpolates the animation effect but doesn't undo the manual opacity override.

## Why this approach (vs PR #106's approach)

- **Right layer** — fix is in `MasterTimeline` (which caused the problem), not `Player`
- **Fires once** — only triggers when playback crosses a segment boundary, not every frame
- **No linear scan** — doesn't call `getCurrentSegment()` (O(n)) every frame
- **Won't clobber animations** — doesn't blindly set `opacity=1` on every frame, so `FadeOut` and other opacity-modifying animations still work correctly

## Test plan

- [x] Added regression test that reproduces the exact bug (seek → play → verify opacity restores)
- [x] All 60 MasterTimeline tests pass
- [x] Verified visually with the PR #106 reproduction scenario (NumberPlane + Circle + Line)