### PR TITLE
Change zoomed frame shift direction from RIGHT to DOWN

### DIFF
--- a/examples/moving_zoomed_scene_around.ts
+++ b/examples/moving_zoomed_scene_around.ts
@@ -10,7 +10,6 @@ import {
   MED_SMALL_BUFF,
   PURPLE,
   RED,
-  RIGHT,
   Scale,
   ScaleInPlace,
   Shift,
@@ -97,7 +96,7 @@ async function movingZoomedSceneAround(scene: ZoomedScene) {
   await scene.play(new ScaleInPlace(zoomedDisplay, { scaleFactor: 2 }));
   await scene.wait();
 
-  await scene.play(new Shift(frame, { direction: scaleVec(2.5, RIGHT) }));
+  await scene.play(new Shift(frame, { direction: scaleVec(2.5, DOWN) }));
   await scene.wait();
 
   // Reverse pop-out: move display back to frame


### PR DESCRIPTION
## Summary
- Changed the zoomed camera frame shift direction from `RIGHT` to `DOWN` in the `moving_zoomed_scene_around` example
- Removed unused `RIGHT` import

## Test plan
- [ ] Run the moving zoomed scene example and verify the frame shifts downward