### PR TITLE
Bump version to 0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.3.9](https://github.com/maloyan/manim-js/compare/v0.3.6...v0.3.9) (2026-03-05)
+
+
+### Bug Fixes
+
+* eliminate black flash between animation loops in docs examples ([c21961a](https://github.com/maloyan/manim-js/commit/c21961a645da7b1af4e813a4fe13b99925e3a45c))
+* preserve per-child opacities in Create animation ([#109](https://github.com/maloyan/manim-js/issues/109)) ([a8f56f1](https://github.com/maloyan/manim-js/commit/a8f56f15acb526b1f810bb4bfc7231490f406002))
+* restore mobject opacity when segment starts during playback ([e88b557](https://github.com/maloyan/manim-js/commit/e88b55783288365fe264125873f4e19efd22f397)), closes [#106](https://github.com/maloyan/manim-js/issues/106)
+
 ### [0.3.4](https://github.com/maloyan/manim-js/compare/v0.3.0...v0.3.4) (2026-02-16)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manim-web",
-  "version": "0.3.6",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manim-web",
-      "version": "0.3.6",
+      "version": "0.3.9",
       "license": "MIT",
       "dependencies": {
         "earcut": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manim-web",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Manim-like mathematical animation library for the web",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version from 0.3.8 to 0.3.9
- Update CHANGELOG.md with recent bug fixes:
  - Fix: eliminate black flash between animation loops in docs examples
  - Fix: preserve per-child opacities in Create animation (#109)
  - Fix: restore mobject opacity when segment starts during playback (#106)

## Test plan
- [ ] CI passes
- [ ] Version in package.json is 0.3.9