### PR TITLE
Transparency support for scenes

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -25,6 +25,7 @@ const scene = new Scene(container, {
   width: 800,
   height: 450,
   backgroundColor: BLACK,
+  backgroundOpacity: 1, // 0 = fully transparent, 1 = fully opaque
 });
 
 // Create and animate a circle

--- a/examples/transparent_background.html
+++ b/examples/transparent_background.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ManimWeb - Transparent Background</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      /* Colorful gradient so transparency is immediately visible */
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f7971e 100%);
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+    }
+    h1 { color: #fff; margin-bottom: 12px; text-shadow: 0 2px 8px rgba(0,0,0,0.3); }
+    p { color: rgba(255,255,255,0.8); margin-bottom: 20px; font-size: 14px; }
+    #container {
+      border: 2px solid rgba(255,255,255,0.3);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .controls {
+      margin-top: 20px;
+      display: flex;
+      gap: 10px;
+    }
+    button {
+      padding: 10px 20px;
+      background: rgba(255,255,255,0.2);
+      backdrop-filter: blur(8px);
+      border: 1px solid rgba(255,255,255,0.3);
+      border-radius: 4px;
+      color: white;
+      cursor: pointer;
+      font-size: 14px;
+    }
+    button:hover { background: rgba(255,255,255,0.35); }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .opacity-control {
+      margin-top: 16px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      color: #fff;
+      font-size: 14px;
+    }
+    .opacity-control input { width: 200px; }
+    .slider-row {
+      margin-top: 10px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      color: #fff;
+      font-size: 14px;
+    }
+    .slider-row input { width: 200px; }
+  </style>
+</head>
+<body>
+  <h1>Transparent Background</h1>
+  <p>The page gradient is visible through the scene canvas</p>
+  <div id="container"></div>
+  <div class="controls">
+    <button id="playBtn">Play Animation</button>
+    <button id="resetBtn">Reset</button>
+  </div>
+  <div class="opacity-control">
+    <label for="opacityRange">Background opacity:</label>
+    <input id="opacityRange" type="range" min="0" max="1" step="0.05" value="0">
+    <span id="opacityValue">0</span>
+  </div>
+  <div class="slider-row">
+    <label for="hueRange">Background hue:</label>
+    <input id="hueRange" type="range" min="0" max="360" step="1" value="0">
+    <span id="hueValue">0°</span>
+  </div>
+
+  <script type="module">
+    import {
+      Scene,
+      Circle,
+      Square,
+      NumberPlane,
+      Create,
+      FadeIn,
+      Transform,
+      WHITE,
+      BLUE,
+      YELLOW,
+    } from '../src/index.ts';
+
+    const container = document.getElementById('container');
+    const scene = new Scene(container, {
+      width: 800,
+      height: 450,
+      backgroundOpacity: 0,
+    });
+
+    // Add a NumberPlane grid so you can see how grid lines composite
+    const grid = new NumberPlane();
+    scene.add(grid);
+
+    let isAnimating = false;
+
+    document.getElementById('playBtn').addEventListener('click', async () => {
+      if (isAnimating) return;
+      isAnimating = true;
+      document.getElementById('playBtn').disabled = true;
+
+      scene.clear();
+      scene.add(grid);
+
+      const square = new Square({ sideLength: 2, color: BLUE, fillOpacity: 0.6 });
+      const circle = new Circle({ radius: 1.5, color: YELLOW, fillOpacity: 0.6 });
+
+      await scene.play(new Create(square));
+      await scene.play(new Transform(square, circle));
+      await scene.play(new FadeIn(
+        new Circle({ radius: 0.3, color: WHITE, fillOpacity: 1 })
+      ));
+
+      isAnimating = false;
+      document.getElementById('playBtn').disabled = false;
+    });
+
+    document.getElementById('resetBtn').addEventListener('click', () => {
+      scene.clear();
+      scene.add(grid);
+    });
+
+    // Runtime opacity slider
+    const slider = document.getElementById('opacityRange');
+    const label = document.getElementById('opacityValue');
+    slider.addEventListener('input', () => {
+      const value = parseFloat(slider.value);
+      scene.backgroundOpacity = value;
+      label.textContent = value.toFixed(2);
+    });
+
+    // Page hue slider — changes scene backgroundColor
+    const hueSlider = document.getElementById('hueRange');
+    const hueLabel = document.getElementById('hueValue');
+    hueSlider.addEventListener('input', () => {
+      const hue = hueSlider.value;
+      scene.renderer.backgroundColor = `hsl(${hue}, 50%, 30%)`;
+      hueLabel.textContent = hue + '°';
+    });
+  </script>
+</body>
+</html>

--- a/src/core/Renderer.ts
+++ b/src/core/Renderer.ts
@@ -18,6 +18,8 @@ export interface RendererOptions {
   powerPreference?: 'default' | 'high-performance' | 'low-power';
   /** Enable alpha channel. Defaults to false. */
   alpha?: boolean;
+  /** Background opacity (0 = fully transparent, 1 = fully opaque). Defaults to 1. When < 1, alpha channel is enabled automatically. */
+  backgroundOpacity?: number;
   /** Preserve drawing buffer for export. Defaults to true for video/image export support. */
   preserveDrawingBuffer?: boolean;
   /** Existing canvas element to reuse. If not provided, a new canvas is created. */
@@ -33,6 +35,8 @@ export class Renderer {
   private _width: number;
   private _height: number;
   private _backgroundColor: THREE.Color;
+  private _backgroundOpacity: number;
+  private _alpha: boolean;
   private _contextLost: boolean = false;
 
   /**
@@ -50,9 +54,14 @@ export class Renderer {
       pixelRatio = typeof window !== 'undefined' ? Math.min(window.devicePixelRatio, 2) : 1,
       powerPreference = 'high-performance',
       alpha = false,
+      backgroundOpacity = 1,
       preserveDrawingBuffer = true, // Needed for video/image export
       canvas,
     } = options;
+
+    this._backgroundOpacity = Math.max(0, Math.min(1, backgroundOpacity));
+    // Enable alpha channel if background is semi-transparent or explicitly requested
+    this._alpha = alpha || this._backgroundOpacity < 1;
 
     this._width = width;
     this._height = height;
@@ -61,7 +70,7 @@ export class Renderer {
     this._renderer = new THREE.WebGLRenderer({
       canvas, // Reuse existing canvas if provided
       antialias,
-      alpha,
+      alpha: this._alpha,
       preserveDrawingBuffer,
       powerPreference,
       stencil: true, // Needed for anti-overlap stencil on transparent strokes
@@ -70,7 +79,7 @@ export class Renderer {
     this._renderer.setSize(this._width, this._height);
     // Ensure pixel ratio is capped at 2x even if explicitly provided higher
     this._renderer.setPixelRatio(Math.min(pixelRatio, 2));
-    this._renderer.setClearColor(this._backgroundColor);
+    this._renderer.setClearColor(this._backgroundColor, this._backgroundOpacity);
 
     // Handle WebGL context loss/restore (common on mobile, GPU pressure, backgrounded tabs)
     const domElement = this._renderer.domElement;
@@ -123,7 +132,30 @@ export class Renderer {
    */
   set backgroundColor(color: THREE.Color | string) {
     this._backgroundColor = color instanceof THREE.Color ? color : new THREE.Color(color);
-    this._renderer.setClearColor(this._backgroundColor);
+    this._renderer.setClearColor(this._backgroundColor, this._backgroundOpacity);
+  }
+
+  /**
+   * Get the background opacity (0 = fully transparent, 1 = fully opaque).
+   */
+  get backgroundOpacity(): number {
+    return this._backgroundOpacity;
+  }
+
+  /**
+   * Set the background opacity (0 = fully transparent, 1 = fully opaque).
+   * Only effective if the scene was created with backgroundOpacity < 1 or alpha enabled.
+   */
+  set backgroundOpacity(value: number) {
+    const clamped = Math.max(0, Math.min(1, value));
+    if (!this._alpha && clamped < 1) {
+      console.warn(
+        'Renderer: backgroundOpacity < 1 has no effect because the WebGL context ' +
+          'was created without alpha. Set backgroundOpacity < 1 in the initial options.'
+      );
+    }
+    this._backgroundOpacity = clamped;
+    this._renderer.setClearColor(this._backgroundColor, this._backgroundOpacity);
   }
 
   /**

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -55,6 +55,8 @@ export interface SceneOptions {
   frustumCulling?: boolean;
   /** Enable auto-render on add/remove. Defaults to true. */
   autoRender?: boolean;
+  /** Background opacity (0 = fully transparent, 1 = fully opaque). Defaults to 1. */
+  backgroundOpacity?: number;
 }
 
 /**
@@ -116,6 +118,7 @@ export class Scene {
       targetFps = 60,
       frustumCulling = true,
       autoRender = true,
+      backgroundOpacity = 1,
     } = options;
 
     // Initialize performance options
@@ -132,6 +135,7 @@ export class Scene {
       width,
       height,
       backgroundColor,
+      backgroundOpacity,
       antialias: true,
     };
     this._renderer = new Renderer(container, rendererOptions);
@@ -1026,6 +1030,21 @@ export class Scene {
    */
   getHeight(): number {
     return this._renderer.height;
+  }
+
+  /**
+   * Get the background opacity (0 = fully transparent, 1 = fully opaque).
+   */
+  get backgroundOpacity(): number {
+    return this._renderer.backgroundOpacity;
+  }
+
+  /**
+   * Set the background opacity (0 = fully transparent, 1 = fully opaque).
+   * Only effective if the scene was created with backgroundOpacity < 1.
+   */
+  set backgroundOpacity(value: number) {
+    this._renderer.backgroundOpacity = value;
   }
 
   /**

--- a/src/integrations/react.tsx
+++ b/src/integrations/react.tsx
@@ -146,6 +146,8 @@ export interface ManimSceneProps {
   height?: number;
   /** Background color as CSS color string. Defaults to '#1a1a2e'. */
   backgroundColor?: string;
+  /** Background opacity (0 = fully transparent, 1 = fully opaque). Defaults to 1. */
+  backgroundOpacity?: number;
   /** Callback when scene is ready */
   onSceneReady?: (scene: Scene) => void;
   /** Child elements to render (overlay content) */
@@ -176,13 +178,14 @@ export function ManimScene({
   width = 800,
   height = 450,
   backgroundColor = '#1a1a2e',
+  backgroundOpacity,
   onSceneReady,
   children,
   className,
   style,
 }: ManimSceneProps): ReactElement {
   const containerRef = useRef<HTMLDivElement>(null);
-  const scene = useScene(containerRef, { width, height, backgroundColor });
+  const scene = useScene(containerRef, { width, height, backgroundColor, backgroundOpacity });
   const onSceneReadyRef = useRef(onSceneReady);
 
   // Update callback ref when it changes
@@ -237,6 +240,8 @@ export interface ManimProviderProps {
   height?: number;
   /** Background color as CSS color string. Defaults to '#1a1a2e'. */
   backgroundColor?: string;
+  /** Background opacity (0 = fully transparent, 1 = fully opaque). Defaults to 1. */
+  backgroundOpacity?: number;
   /** CSS class name for the container */
   className?: string;
   /** Inline styles for the container */
@@ -263,11 +268,12 @@ export function ManimProvider({
   width = 800,
   height = 450,
   backgroundColor = '#1a1a2e',
+  backgroundOpacity,
   className,
   style,
 }: ManimProviderProps): ReactElement {
   const containerRef = useRef<HTMLDivElement>(null);
-  const scene = useScene(containerRef, { width, height, backgroundColor });
+  const scene = useScene(containerRef, { width, height, backgroundColor, backgroundOpacity });
 
   return (
     <SceneContext.Provider value={scene}>

--- a/src/integrations/vue.ts
+++ b/src/integrations/vue.ts
@@ -294,6 +294,14 @@ export const ManimScene = defineComponent({
       type: Number as PropType<number>,
       default: 8,
     },
+    /**
+     * Background opacity (0 = fully transparent, 1 = fully opaque).
+     * @default 1
+     */
+    backgroundOpacity: {
+      type: Number as PropType<number>,
+      default: 1,
+    },
   },
 
   emits: {
@@ -311,6 +319,7 @@ export const ManimScene = defineComponent({
       width: props.width,
       height: props.height,
       backgroundColor: props.backgroundColor,
+      backgroundOpacity: props.backgroundOpacity,
       frameWidth: props.frameWidth,
       frameHeight: props.frameHeight,
     });


### PR DESCRIPTION
## Summary

`backgroundOpacity` property for scenes, example HTML page, docs update.

It was made with help of Claude Opus 4.6 but it looks normal enough for me.
Still a verification from someone who understands how three.js works is required.

## Related Issues

Closes #120 

## Possible Todos

- Support transparent and alpha colors in Player UI.
- Check how well transparent scene background works with "export as video" player option. Maybe add a JSDoc that `backgroundOpacity` is not supported for exporting: GIF 100% does not support it, MP4 too,  `webm` does support transparent backgrounds but I havent seen such an export option.

Though I am not sure whether this should be done now or the player is still in active development and its core design might change soon. Review required.