### PR TITLE
Fix review issues for backgroundOpacity (#121)

### DIFF
--- a/src/core/Renderer.test.ts
+++ b/src/core/Renderer.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as THREE from 'three';
+import { Renderer } from './Renderer';
+
+const mockCanvas = {
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  parentElement: null,
+  style: {},
+};
+
+vi.mock('three', async () => {
+  const actual = await vi.importActual<typeof THREE>('three');
+  // Must use function() (not arrow) so it can be called with `new`
+  const MockWebGLRenderer = vi.fn().mockImplementation(function () {
+    return {
+      setSize: vi.fn(),
+      setPixelRatio: vi.fn(),
+      setClearColor: vi.fn(),
+      domElement: mockCanvas,
+      dispose: vi.fn(),
+      render: vi.fn(),
+    };
+  });
+  return { ...actual, WebGLRenderer: MockWebGLRenderer };
+});
+
+function createContainer(): HTMLElement {
+  return {
+    clientWidth: 800,
+    clientHeight: 450,
+    appendChild: vi.fn(),
+  } as unknown as HTMLElement;
+}
+
+describe('Renderer backgroundOpacity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults backgroundOpacity to 1', () => {
+    const renderer = new Renderer(createContainer());
+    expect(renderer.backgroundOpacity).toBe(1);
+  });
+
+  it('accepts backgroundOpacity in options', () => {
+    const renderer = new Renderer(createContainer(), { backgroundOpacity: 0.5 });
+    expect(renderer.backgroundOpacity).toBe(0.5);
+  });
+
+  it('clamps backgroundOpacity to [0, 1] on construction', () => {
+    const over = new Renderer(createContainer(), { backgroundOpacity: 2 });
+    expect(over.backgroundOpacity).toBe(1);
+
+    const under = new Renderer(createContainer(), { backgroundOpacity: -0.5 });
+    expect(under.backgroundOpacity).toBe(0);
+  });
+
+  it('clamps backgroundOpacity to [0, 1] via setter', () => {
+    const renderer = new Renderer(createContainer(), { backgroundOpacity: 0 });
+    renderer.backgroundOpacity = 5;
+    expect(renderer.backgroundOpacity).toBe(1);
+
+    renderer.backgroundOpacity = -1;
+    expect(renderer.backgroundOpacity).toBe(0);
+  });
+
+  it('auto-enables alpha when backgroundOpacity < 1', () => {
+    new Renderer(createContainer(), { backgroundOpacity: 0.5 });
+    const ctorCall = (THREE.WebGLRenderer as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(ctorCall.alpha).toBe(true);
+  });
+
+  it('does not enable alpha when backgroundOpacity is 1', () => {
+    new Renderer(createContainer(), { backgroundOpacity: 1 });
+    const ctorCall = (THREE.WebGLRenderer as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(ctorCall.alpha).toBe(false);
+  });
+
+  it('respects explicit alpha=true even when backgroundOpacity is 1', () => {
+    new Renderer(createContainer(), { alpha: true, backgroundOpacity: 1 });
+    const ctorCall = (THREE.WebGLRenderer as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(ctorCall.alpha).toBe(true);
+  });
+
+  it('passes backgroundOpacity to setClearColor on construction', () => {
+    const renderer = new Renderer(createContainer(), { backgroundOpacity: 0.3 });
+    const mockRenderer = (renderer as any)._renderer;
+    expect(mockRenderer.setClearColor).toHaveBeenCalledWith(expect.any(THREE.Color), 0.3);
+  });
+
+  it('passes backgroundOpacity to setClearColor when setter is used', () => {
+    const renderer = new Renderer(createContainer(), { backgroundOpacity: 0 });
+    const mockRenderer = (renderer as any)._renderer;
+    mockRenderer.setClearColor.mockClear();
+
+    renderer.backgroundOpacity = 0.7;
+    expect(mockRenderer.setClearColor).toHaveBeenCalledWith(expect.any(THREE.Color), 0.7);
+  });
+
+  it('warns when setting opacity < 1 on non-alpha context', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const renderer = new Renderer(createContainer(), { backgroundOpacity: 1 });
+
+    renderer.backgroundOpacity = 0.5;
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('backgroundOpacity < 1 has no effect'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('does not warn when setting opacity < 1 on alpha context', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const renderer = new Renderer(createContainer(), { backgroundOpacity: 0 });
+
+    renderer.backgroundOpacity = 0.5;
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('updates setClearColor when backgroundColor is changed', () => {
+    const renderer = new Renderer(createContainer(), { backgroundOpacity: 0.4 });
+    const mockRenderer = (renderer as any)._renderer;
+    mockRenderer.setClearColor.mockClear();
+
+    renderer.backgroundColor = '#ff0000';
+    expect(mockRenderer.setClearColor).toHaveBeenCalledWith(expect.any(THREE.Color), 0.4);
+  });
+});

--- a/src/core/Renderer.ts
+++ b/src/core/Renderer.ts
@@ -18,7 +18,7 @@ export interface RendererOptions {
   powerPreference?: 'default' | 'high-performance' | 'low-power';
   /** Enable alpha channel. Defaults to false. */
   alpha?: boolean;
-  /** Background opacity (0 = fully transparent, 1 = fully opaque). Defaults to 1. When < 1, alpha channel is enabled automatically. */
+  /** Background opacity (0 = fully transparent, 1 = fully opaque). Defaults to 1. When < 1, alpha channel is enabled automatically. Not supported when exporting to video or GIF formats. */
   backgroundOpacity?: number;
   /** Preserve drawing buffer for export. Defaults to true for video/image export support. */
   preserveDrawingBuffer?: boolean;
@@ -151,7 +151,7 @@ export class Renderer {
     if (!this._alpha && clamped < 1) {
       console.warn(
         'Renderer: backgroundOpacity < 1 has no effect because the WebGL context ' +
-          'was created without alpha. Set backgroundOpacity < 1 in the initial options.'
+          'was created without alpha. Set backgroundOpacity < 1 in the initial options.',
       );
     }
     this._backgroundOpacity = clamped;

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -55,7 +55,7 @@ export interface SceneOptions {
   frustumCulling?: boolean;
   /** Enable auto-render on add/remove. Defaults to true. */
   autoRender?: boolean;
-  /** Background opacity (0 = fully transparent, 1 = fully opaque). Defaults to 1. */
+  /** Background opacity (0 = fully transparent, 1 = fully opaque). Defaults to 1. Not supported when exporting to video or GIF formats. */
   backgroundOpacity?: number;
 }
 

--- a/src/integrations/vue.ts
+++ b/src/integrations/vue.ts
@@ -32,10 +32,7 @@ export * from '../index';
  * const { scene, isReady } = useScene(containerRef, { backgroundColor: '#1a1a2e' });
  * ```
  */
-export function useScene(
-  containerRef: Ref<HTMLElement | null>,
-  options?: SceneOptions
-) {
+export function useScene(containerRef: Ref<HTMLElement | null>, options?: SceneOptions) {
   const scene = shallowRef<Scene | null>(null);
   const isReady = ref(false);
 
@@ -90,7 +87,7 @@ export function useScene(
  */
 export function useMobject<T extends Mobject>(
   scene: Ref<Scene | null>,
-  createMobject: () => T
+  createMobject: () => T,
 ): Ref<T | null> {
   const mobject = shallowRef<T | null>(null);
 
@@ -110,7 +107,7 @@ export function useMobject<T extends Mobject>(
         newScene.add(mobject.value);
       }
     },
-    { immediate: true }
+    { immediate: true },
   );
 
   onUnmounted(() => {
@@ -197,10 +194,7 @@ export function useAnimation(scene: Ref<Scene | null>) {
  * });
  * ```
  */
-export function useUpdater(
-  mobject: Ref<Mobject | null>,
-  updater: UpdaterFunction
-): void {
+export function useUpdater(mobject: Ref<Mobject | null>, updater: UpdaterFunction): void {
   watch(
     mobject,
     (newMobject, oldMobject) => {
@@ -211,7 +205,7 @@ export function useUpdater(
         newMobject.addUpdater(updater);
       }
     },
-    { immediate: true }
+    { immediate: true },
   );
 
   onUnmounted(() => {
@@ -300,7 +294,7 @@ export const ManimScene = defineComponent({
      */
     backgroundOpacity: {
       type: Number as PropType<number>,
-      default: 1,
+      default: undefined,
     },
   },
 
@@ -345,7 +339,7 @@ export const ManimScene = defineComponent({
             position: 'relative',
           },
         },
-        slots.default?.()
+        slots.default?.(),
       );
   },
 });


### PR DESCRIPTION
## Summary

Follow-up fixes for #121 (backgroundOpacity support):

- Add 12 unit tests for `Renderer.backgroundOpacity` (clamping, alpha auto-enable, setClearColor passthrough, warning on non-alpha context)
- Fix Vue/React default inconsistency: Vue now uses `undefined` default to let Scene handle the default, matching React's approach
- Add JSDoc note that `backgroundOpacity` is not supported for video/GIF export