### PR TITLE
fix: mobjects that are immediately added via add are incorrectly hidden

### DIFF
--- a/src/animation/MasterTimeline.ts
+++ b/src/animation/MasterTimeline.ts
@@ -102,9 +102,10 @@ export class MasterTimeline extends Timeline {
     const newTime = this.getCurrentTime();
 
     // Re-hide mobjects whose introducing segment still hasn't started
+    // and were not added immediately via `scene.add()`.
     for (const [mobject, segIndex] of this._mobjectFirstSegment) {
       const seg = this._segments[segIndex];
-      if (seg && newTime < seg.startTime) {
+      if (seg && newTime < seg.startTime && !mobject.createdAtBeginning) {
         mobject.opacity = 0;
       }
     }

--- a/src/core/Mobject.ts
+++ b/src/core/Mobject.ts
@@ -52,6 +52,7 @@ export abstract class Mobject {
   position: THREE.Vector3;
   rotation: THREE.Euler;
   scaleVector: THREE.Vector3;
+  createdAtBeginning: boolean = false;
   protected _color: string = '#ffffff';
   get color(): string {
     return this._color;

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -349,6 +349,7 @@ export class Scene {
         // re-render when done. Recursively check children since MathTex objects
         // may be nested inside VGroup/Group containers.
         this._awaitAsyncRenders(mobject);
+        mobject.createdAtBeginning = true;
       }
     }
     if (this._autoRender) {


### PR DESCRIPTION
## Summary

#118 introduces a change that re-hides objects whose introducing segment has not yet started. But, consider this scenario:

```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>my-app</title>
  </head>
  <body>
    <div id="cycle" style="width: 1000px; height: 1000px"></div>
    <script type="module" src="./main.js"></script>
  </body>
</html>
```

```js
import { Arc, Circle, Dot, FadeIn, MoveAlongPath, Player } from 'manim-web';

const container = document.getElementById('container');

const player = new Player(container, {
  width: container.clientWidth,
  height: container.clientHeight,
  frameHeight: 8,
  frameWidth: 14,
  backgroundColor: 'BLACK',
  autoPlay: true,
  loop: true,
});

const dot = new Dot({
  point: [1, 0, 0],
  color: 'YELLOW',
  opacity: 1,
});

player.sequence(async (scene) => {
  scene.add(dot);
  const c = new Circle({ color: 'WHITE' });
  const q1 = new Arc({ angle: Math.PI / 2 });
  await scene.play(new FadeIn(c));
  await scene.play(new MoveAlongPath(dot, { path: q1 }));
});
```

The yellow dot is immediately added, so it has no segment. Later in the sequence, it gets an animation, getting a segment. That segment is incorrectly counted as the introducing segment, causing the dot to be hidden at the beginning becoming only visible when the MoveAlongPath animation is played, even when it should be visible at the beginning.

## Changes
This introduces a new `createdAtBeginning` flag to the `Mobject` class that gets applied when `add` is called. Then, during re-hiding, objects that were created immediately are skipped.

This is the easiest/least hacky way I fix this this.

Another alternative would be to create a new segment with start and end of (0,0) when objects are immediately added to the scene.

## Testing

- [x] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [x] Types check (`npm run typecheck`)
