### PR TITLE
chore(release): 0.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.3.12](https://github.com/maloyan/manim-web/compare/v0.3.11...v0.3.12) (2026-03-09)
+
 ### [0.3.11](https://github.com/maloyan/manim-js/compare/v0.3.10...v0.3.11) (2026-03-07)
 
 ### [0.3.10](https://github.com/maloyan/manim-js/compare/v0.3.9...v0.3.10) (2026-03-06)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manim-web",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manim-web",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "license": "MIT",
       "dependencies": {
         "earcut": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manim-web",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Manim-like mathematical animation library for the web",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.3.12
- Includes fix: mobjects that are immediately added via add are incorrectly hidden (#124)
- Dependency updates: katex, lint-staged, eslint, happy-dom, knip