### PR TITLE
fix: export missing graphing classes from main index

### DIFF
--- a/src/exports-graphing.test.ts
+++ b/src/exports-graphing.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+
+describe('Issue #131: Missing graphing exports from main index', () => {
+  it('should export VectorField from main index', async () => {
+    const mod = await import('./index');
+    expect(mod.VectorField).toBeDefined();
+  });
+
+  it('should export ArrowVectorField from main index', async () => {
+    const mod = await import('./index');
+    expect(mod.ArrowVectorField).toBeDefined();
+  });
+
+  it('should export StreamLines from main index', async () => {
+    const mod = await import('./index');
+    expect(mod.StreamLines).toBeDefined();
+  });
+
+  it('should export ComplexPlane from main index', async () => {
+    const mod = await import('./index');
+    expect(mod.ComplexPlane).toBeDefined();
+  });
+
+  it('should export PolarPlane from main index', async () => {
+    const mod = await import('./index');
+    expect(mod.PolarPlane).toBeDefined();
+  });
+
+  it('should export UnitInterval from main index', async () => {
+    const mod = await import('./index');
+    expect(mod.UnitInterval).toBeDefined();
+  });
+
+  it('should export BarChart from main index', async () => {
+    const mod = await import('./index');
+    expect(mod.BarChart).toBeDefined();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,8 @@ export {
 export {
   NumberLine,
   type NumberLineOptions,
+  UnitInterval,
+  type UnitIntervalOptions,
   Axes,
   type AxesOptions,
   NumberPlane,
@@ -170,6 +172,20 @@ export {
   type ParametricFunctionOptions,
   VectorFieldVector,
   type VectorFieldVectorOptions,
+  ComplexPlane,
+  type ComplexPlaneOptions,
+  PolarPlane,
+  type PolarPlaneOptions,
+  BarChart,
+  type BarChartOptions,
+  VectorField,
+  ArrowVectorField,
+  StreamLines,
+  type VectorFunction,
+  type ColorFunction,
+  type VectorFieldBaseOptions,
+  type ArrowVectorFieldOptions,
+  type StreamLinesOptions,
 } from './mobjects/graphing';
 
 // Text and LaTeX


### PR DESCRIPTION
## Summary
- Exports `VectorField`, `ArrowVectorField`, `StreamLines`, `ComplexPlane`, `PolarPlane`, `UnitInterval`, `BarChart` and their associated types from `src/index.ts`
- These were already exported from `src/mobjects/graphing/index.ts` but missing from the main package entry point

Closes #131

## Test plan
- [x] Added `src/exports-graphing.test.ts` verifying all 7 classes are importable from the main index
- [x] `npm run build` passes without errors