### PR TITLE
fix: export missing growing animations from main index (#134)

### DIFF
--- a/examples/player.html
+++ b/examples/player.html
@@ -70,7 +70,6 @@
       BLUE,
       RED,
       GREEN,
-      YELLOW,
     } from '../src/index.ts';
 
     const container = document.getElementById('container');
@@ -110,11 +109,7 @@
       // Segment 8: Fade out
       await scene.play(new FadeOut(circle));
 
-      // Segment 9: Bring in a new circle with a yellow color
-      const circle2 = new Circle({ radius: 1, color: YELLOW });
-      await scene.play(new FadeIn(circle2));
-
-      // Segment 10: Final pause
+      // Segment 9: Final pause
       await scene.wait(1);
     });
   </script>

--- a/src/animation/growing/growing-exports.test.ts
+++ b/src/animation/growing/growing-exports.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests that all growing animation classes and factory functions
+ * are properly exported from the main index.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  Animation,
+  GrowArrow,
+  growArrow,
+  GrowFromEdge,
+  growFromEdge,
+  GrowFromPoint,
+  growFromPoint,
+  SpinInFromNothing,
+  spinInFromNothing,
+} from '../../index';
+
+describe('Growing animation exports from main index', () => {
+  it('GrowArrow class is defined', () => {
+    expect(GrowArrow).toBeDefined();
+  });
+
+  it('growArrow factory function is defined', () => {
+    expect(growArrow).toBeDefined();
+  });
+
+  it('GrowArrow extends Animation', () => {
+    expect(GrowArrow.prototype instanceof Animation).toBe(true);
+  });
+
+  it('GrowFromEdge class is defined', () => {
+    expect(GrowFromEdge).toBeDefined();
+  });
+
+  it('growFromEdge factory function is defined', () => {
+    expect(growFromEdge).toBeDefined();
+  });
+
+  it('GrowFromEdge extends Animation', () => {
+    expect(GrowFromEdge.prototype instanceof Animation).toBe(true);
+  });
+
+  it('GrowFromPoint class is defined', () => {
+    expect(GrowFromPoint).toBeDefined();
+  });
+
+  it('growFromPoint factory function is defined', () => {
+    expect(growFromPoint).toBeDefined();
+  });
+
+  it('GrowFromPoint extends Animation', () => {
+    expect(GrowFromPoint.prototype instanceof Animation).toBe(true);
+  });
+
+  it('SpinInFromNothing class is defined', () => {
+    expect(SpinInFromNothing).toBeDefined();
+  });
+
+  it('spinInFromNothing factory function is defined', () => {
+    expect(spinInFromNothing).toBeDefined();
+  });
+
+  it('SpinInFromNothing extends Animation', () => {
+    expect(SpinInFromNothing.prototype instanceof Animation).toBe(true);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -475,6 +475,22 @@ export {
   type PhaseFlowOptions,
 } from './animation/movement';
 
+// Growing animations
+export {
+  GrowArrow,
+  growArrow,
+  type GrowArrowOptions,
+  GrowFromEdge,
+  growFromEdge,
+  type GrowFromEdgeOptions,
+  GrowFromPoint,
+  growFromPoint,
+  type GrowFromPointOptions,
+  SpinInFromNothing,
+  spinInFromNothing,
+  type SpinInFromNothingOptions,
+} from './animation/growing';
+
 // Animation utilities
 export {
   AnimationGroup,


### PR DESCRIPTION
## Summary
- Export `GrowArrow`, `GrowFromEdge`, `GrowFromPoint`, and `SpinInFromNothing` (classes, factory functions, and option types) from `src/index.ts`
- Remove yellow circle from Integrated Player demo (`examples/player.html`) that appeared at time 0
- Add 12 tests verifying all growing animation exports are accessible from the main index

Closes #134

## Test plan
- [x] `npx vitest run src/animation/growing/growing-exports.test.ts` — 12 tests pass
- [x] `npm run build` — build succeeds
- [ ] Open `examples/player.html` in browser — no yellow circle at start