### PR TITLE
feat: implement ApplyComplexFunction animation

### DIFF
--- a/docs/docs/examples/animations.mdx
+++ b/docs/docs/examples/animations.mdx
@@ -21,6 +21,7 @@ import RotationUpdaterExample from '@site/src/components/examples/RotationUpdate
 import PointWithTraceExample from '@site/src/components/examples/PointWithTraceExample';
 import SineCurveUnitCircleExample from '@site/src/components/examples/SineCurveUnitCircleExample';
 import ApplyMatrixArrowsExample from '@site/src/components/examples/ApplyMatrixArrowsExample';
+import ApplyComplexFunctionExample from '@site/src/components/examples/ApplyComplexFunctionExample';
 import RateFunctionsComparisonExample from '@site/src/components/examples/RateFunctionsComparisonExample';
 import EasingFunctionsShowcaseExample from '@site/src/components/examples/EasingFunctionsShowcaseExample';
 
@@ -1169,6 +1170,57 @@ await scene.wait(2);
 </details>
 
 **Learn More:** [**Arrow**](/api/classes/Arrow) · [**NumberPlane**](/api/classes/NumberPlane) · [**ApplyMatrix**](/api/classes/ApplyMatrix)
+
+---
+
+## Apply Complex Function
+
+Applies a complex function to a NumberPlane, treating each point's (x, y) coordinates as a complex number z = x + iy. Here, the function z => z^2 bends the grid into parabolic curves, visualizing how complex squaring maps the plane.
+
+<ApplyComplexFunctionExample />
+
+<details>
+<summary>Source Code</summary>
+
+```typescript
+import {
+  Scene,
+  NumberPlane,
+  Create,
+  ApplyComplexFunction,
+  BLACK,
+} from 'manim-web';
+
+const scene = new Scene(document.getElementById('container'), {
+  width: 800,
+  height: 450,
+  backgroundColor: BLACK,
+});
+
+// Create a number plane grid
+const grid = new NumberPlane();
+grid.prepareForNonlinearTransform();
+scene.add(grid);
+await scene.play(new Create(grid, { duration: 2, lagRatio: 0.1 }));
+await scene.wait(0.5);
+
+// Apply z => z^2: squares every complex number
+// This maps the grid non-linearly, bending lines into parabolic curves
+await scene.play(
+  new ApplyComplexFunction(grid, {
+    func: (z) => ({
+      re: z.re * z.re - z.im * z.im,
+      im: 2 * z.re * z.im,
+    }),
+    duration: 3,
+  }),
+);
+await scene.wait(1);
+```
+
+</details>
+
+**Learn More:** [**ApplyComplexFunction**](/api/classes/ApplyComplexFunction) · [**NumberPlane**](/api/classes/NumberPlane) · [**Create**](/api/classes/Create)
 
 ---
 

--- a/docs/src/components/examples/ApplyComplexFunctionExample.tsx
+++ b/docs/src/components/examples/ApplyComplexFunctionExample.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import ManimExample from '../ManimExample';
+
+async function animate(scene: any) {
+  const { NumberPlane, Create, ApplyComplexFunction, BLACK } = await import('manim-web');
+
+  // Create a number plane grid
+  const grid = new NumberPlane();
+  grid.prepareForNonlinearTransform();
+  scene.add(grid);
+  await scene.play(new Create(grid, { duration: 2, lagRatio: 0.1 }));
+  await scene.wait(0.5);
+
+  // Apply z => z^2: squares every complex number
+  // This maps the grid non-linearly, bending lines into parabolic curves
+  await scene.play(
+    new ApplyComplexFunction(grid, {
+      func: (z: { re: number; im: number }) => ({
+        re: z.re * z.re - z.im * z.im,
+        im: 2 * z.re * z.im,
+      }),
+      duration: 3,
+    }),
+  );
+  await scene.wait(1);
+}
+
+export default function ApplyComplexFunctionExample() {
+  return <ManimExample animationFn={animate} />;
+}

--- a/examples/apply_complex_function.html
+++ b/examples/apply_complex_function.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ManimWeb - ApplyComplexFunction</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #1a1a2e;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+    }
+    #container {
+      border: 2px solid #333;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .controls {
+      margin-top: 20px;
+      display: flex;
+      gap: 10px;
+    }
+    button {
+      padding: 10px 20px;
+      background: #e94560;
+      border: none;
+      border-radius: 4px;
+      color: white;
+      cursor: pointer;
+      font-size: 14px;
+    }
+    button:hover { background: #ff6b6b; }
+    button:disabled { background: #666; cursor: not-allowed; }
+    h1 { color: #eee; margin-bottom: 20px; font-size: 24px; }
+    p { color: #aaa; margin-top: 10px; font-size: 14px; }
+  </style>
+</head>
+<body>
+  <h1>ApplyComplexFunction Demo</h1>
+  <div id="container"></div>
+  <div class="controls">
+    <button id="playBtn">Play z => z^2</button>
+    <button id="play2Btn">Play z => 1/z</button>
+    <button id="resetBtn">Reset</button>
+  </div>
+  <p>Applies complex functions to a NumberPlane, treating (x, y) as complex numbers</p>
+
+  <script type="module">
+    import {
+      Scene,
+      NumberPlane,
+      Circle,
+      Create,
+      FadeIn,
+      ApplyComplexFunction,
+      BLACK,
+      BLUE,
+      YELLOW,
+    } from '../src/index.ts';
+
+    const container = document.getElementById('container');
+    const scene = new Scene(container, {
+      width: 800,
+      height: 450,
+      backgroundColor: BLACK,
+    });
+
+    let isAnimating = false;
+
+    async function setupGrid() {
+      scene.clear();
+      const grid = new NumberPlane();
+      grid.prepareForNonlinearTransform();
+      scene.add(grid);
+      await scene.play(new Create(grid, { duration: 1.5, lagRatio: 0.1 }));
+      return grid;
+    }
+
+    // z => z^2: squares every complex number
+    document.getElementById('playBtn').addEventListener('click', async () => {
+      if (isAnimating) return;
+      isAnimating = true;
+      document.getElementById('playBtn').disabled = true;
+      document.getElementById('play2Btn').disabled = true;
+
+      const grid = await setupGrid();
+      await scene.wait(0.5);
+      await scene.play(new ApplyComplexFunction(grid, {
+        func: (z) => ({
+          re: z.re * z.re - z.im * z.im,
+          im: 2 * z.re * z.im,
+        }),
+        duration: 3,
+      }));
+      await scene.wait(1);
+
+      isAnimating = false;
+      document.getElementById('playBtn').disabled = false;
+      document.getElementById('play2Btn').disabled = false;
+    });
+
+    // z => 1/z (inversion): maps circles through origin to lines and vice versa
+    document.getElementById('play2Btn').addEventListener('click', async () => {
+      if (isAnimating) return;
+      isAnimating = true;
+      document.getElementById('playBtn').disabled = true;
+      document.getElementById('play2Btn').disabled = true;
+
+      const grid = await setupGrid();
+      await scene.wait(0.5);
+      await scene.play(new ApplyComplexFunction(grid, {
+        func: (z) => {
+          const denom = z.re * z.re + z.im * z.im;
+          if (denom < 0.001) return { re: z.re, im: z.im };
+          return { re: z.re / denom, im: -z.im / denom };
+        },
+        duration: 3,
+      }));
+      await scene.wait(1);
+
+      isAnimating = false;
+      document.getElementById('playBtn').disabled = false;
+      document.getElementById('play2Btn').disabled = false;
+    });
+
+    document.getElementById('resetBtn').addEventListener('click', () => {
+      scene.clear();
+      isAnimating = false;
+      document.getElementById('playBtn').disabled = false;
+      document.getElementById('play2Btn').disabled = false;
+    });
+  </script>
+</body>
+</html>

--- a/src/animation/animation-apply-complex-function.test.ts
+++ b/src/animation/animation-apply-complex-function.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { VMobject } from '../core/VMobject';
+import { ApplyComplexFunction, applyComplexFunction } from './transform/ApplyTransforms';
+import type { Complex } from './movement/Homotopy';
+
+// Helpers
+function vm(pts: number[][]): VMobject {
+  const v = new VMobject();
+  v.setPoints(pts);
+  return v;
+}
+
+describe('ApplyComplexFunction', () => {
+  it('stores func, mobject, and default duration', () => {
+    const fn = (z: Complex) => ({ re: z.re * 2, im: z.im * 2 });
+    const v = vm([[1, 2, 0]]);
+    const anim = new ApplyComplexFunction(v, { func: fn });
+    expect(anim.func).toBe(fn);
+    expect(anim.mobject).toBe(v);
+    expect(anim.duration).toBe(1);
+  });
+
+  it('applies z => z^2 correctly', () => {
+    // z = 1+i => z^2 = (1+i)^2 = 1 + 2i - 1 = 2i => (0, 2)
+    const v = vm([[1, 1, 0]]);
+    const anim = new ApplyComplexFunction(v, {
+      func: (z) => ({ re: z.re * z.re - z.im * z.im, im: 2 * z.re * z.im }),
+    });
+    anim.begin();
+    anim.interpolate(1);
+    const pts = v.getPoints();
+    expect(pts[0][0]).toBeCloseTo(0, 5);
+    expect(pts[0][1]).toBeCloseTo(2, 5);
+    expect(pts[0][2]).toBeCloseTo(0, 5); // z preserved
+  });
+
+  it('interpolates linearly between start and target', () => {
+    // z = 2+0i, func: z => z*2 = 4+0i
+    const v = vm([[2, 0, 0]]);
+    const anim = new ApplyComplexFunction(v, {
+      func: (z) => ({ re: z.re * 2, im: z.im * 2 }),
+    });
+    anim.begin();
+
+    anim.interpolate(0);
+    expect(v.getPoints()[0][0]).toBeCloseTo(2, 5); // start
+
+    anim.interpolate(0.5);
+    expect(v.getPoints()[0][0]).toBeCloseTo(3, 5); // midpoint: lerp(2, 4, 0.5) = 3
+
+    anim.interpolate(1);
+    expect(v.getPoints()[0][0]).toBeCloseTo(4, 5); // end
+  });
+
+  it('preserves z coordinate', () => {
+    const v = vm([[1, 0, 5]]);
+    const anim = new ApplyComplexFunction(v, {
+      func: (z) => ({ re: z.re + 10, im: z.im }),
+    });
+    anim.begin();
+    anim.interpolate(1);
+    expect(v.getPoints()[0][2]).toBeCloseTo(5, 5);
+  });
+
+  it('handles multiple points', () => {
+    const v = vm([
+      [1, 0, 0],
+      [0, 1, 0],
+      [-1, 0, 0],
+    ]);
+    // z => z * i = (-im, re)
+    const anim = new ApplyComplexFunction(v, {
+      func: (z) => ({ re: -z.im, im: z.re }),
+    });
+    anim.begin();
+    anim.interpolate(1);
+    const pts = v.getPoints();
+    expect(pts[0][0]).toBeCloseTo(0, 5); // 1+0i => 0+1i
+    expect(pts[0][1]).toBeCloseTo(1, 5);
+    expect(pts[1][0]).toBeCloseTo(-1, 5); // 0+1i => -1+0i
+    expect(pts[1][1]).toBeCloseTo(0, 5);
+    expect(pts[2][0]).toBeCloseTo(0, 5); // -1+0i => 0-1i
+    expect(pts[2][1]).toBeCloseTo(-1, 5);
+  });
+
+  it('finish sets final points exactly', () => {
+    const v = vm([[3, 4, 0]]);
+    const anim = new ApplyComplexFunction(v, {
+      func: (z) => ({ re: z.re * 2, im: z.im * 2 }),
+    });
+    anim.begin();
+    anim.finish();
+    const pts = v.getPoints();
+    expect(pts[0][0]).toBeCloseTo(6, 5);
+    expect(pts[0][1]).toBeCloseTo(8, 5);
+  });
+
+  it('identity function preserves points', () => {
+    const v = vm([[1, 2, 3]]);
+    const anim = new ApplyComplexFunction(v, {
+      func: (z) => z,
+    });
+    anim.begin();
+    anim.interpolate(1);
+    const pts = v.getPoints();
+    expect(pts[0][0]).toBeCloseTo(1, 5);
+    expect(pts[0][1]).toBeCloseTo(2, 5);
+    expect(pts[0][2]).toBeCloseTo(3, 5);
+  });
+
+  it('factory creates ApplyComplexFunction', () => {
+    const fn = (z: Complex) => z;
+    const v = vm([[0, 0, 0]]);
+    expect(applyComplexFunction(v, fn)).toBeInstanceOf(ApplyComplexFunction);
+  });
+
+  it('complex conjugate function works', () => {
+    // z => conj(z) = (re, -im)
+    const v = vm([[3, 4, 0]]);
+    const anim = new ApplyComplexFunction(v, {
+      func: (z) => ({ re: z.re, im: -z.im }),
+    });
+    anim.begin();
+    anim.interpolate(1);
+    expect(v.getPoints()[0][0]).toBeCloseTo(3, 5);
+    expect(v.getPoints()[0][1]).toBeCloseTo(-4, 5);
+  });
+
+  it('works with custom duration', () => {
+    const v = vm([[0, 0, 0]]);
+    const anim = new ApplyComplexFunction(v, {
+      func: (z) => z,
+      duration: 3,
+    });
+    expect(anim.duration).toBe(3);
+  });
+});

--- a/src/animation/index.ts
+++ b/src/animation/index.ts
@@ -3,28 +3,16 @@ export { Animation, type AnimationOptions } from './Animation';
 export { Timeline, type PositionParam } from './Timeline';
 
 // Animation utilities
-export {
-  AnimationGroup,
-  animationGroup,
-  type AnimationGroupOptions
-} from './AnimationGroup';
-export {
-  LaggedStart,
-  laggedStart,
-  type LaggedStartOptions
-} from './LaggedStart';
-export {
-  Succession,
-  succession,
-  type SuccessionOptions
-} from './Succession';
+export { AnimationGroup, animationGroup, type AnimationGroupOptions } from './AnimationGroup';
+export { LaggedStart, laggedStart, type LaggedStartOptions } from './LaggedStart';
+export { Succession, succession, type SuccessionOptions } from './Succession';
 
 // Composition animations
 export {
   LaggedStartMap,
   laggedStartMap,
   type LaggedStartMapOptions,
-  type AnimationClass
+  type AnimationClass,
 } from './composition';
 
 // Fading animations
@@ -88,6 +76,9 @@ export {
   ApplyMatrix,
   applyMatrix,
   type ApplyMatrixOptions,
+  ApplyComplexFunction,
+  applyComplexFunction,
+  type ApplyComplexFunctionOptions,
   FadeTransform,
   fadeTransform,
   type FadeTransformOptions,

--- a/src/animation/transform/ApplyTransforms.ts
+++ b/src/animation/transform/ApplyTransforms.ts
@@ -10,6 +10,7 @@ import { Animation, AnimationOptions } from '../Animation';
 import { Transform } from './Transform';
 import { lerpPoint } from '../../utils/math';
 import { Arrow, DoubleArrow } from '../../mobjects/geometry/Arrow';
+import type { Complex } from '../movement/Homotopy';
 
 // ============================================================================
 // Shared VMobjectLike duck-type (mirrors ApplyPointwiseFunction)
@@ -132,6 +133,109 @@ export function applyFunction(
   options?: Omit<ApplyFunctionOptions, 'func'>,
 ): ApplyFunction {
   return new ApplyFunction(mobject, { ...options, func });
+}
+
+// ============================================================================
+// ApplyComplexFunction
+// ============================================================================
+
+export interface ApplyComplexFunctionOptions extends AnimationOptions {
+  /** Complex function to apply to each point, treating (x, y) as (re, im) */
+  func: (z: Complex) => Complex;
+}
+
+/**
+ * ApplyComplexFunction animation - applies a complex function to mobject points.
+ * Treats each point's (x, y) as (Re, Im) of a complex number, applies the function,
+ * and preserves the z coordinate.
+ * Supports both VMobject and Group (walks the family tree).
+ */
+export class ApplyComplexFunction extends Animation {
+  readonly func: (z: Complex) => Complex;
+  private _snapshots: ChildSnapshot[] = [];
+
+  constructor(mobject: Mobject, options: ApplyComplexFunctionOptions) {
+    super(mobject, options);
+    this.func = options.func;
+  }
+
+  override begin(): void {
+    super.begin();
+
+    this._snapshots = [];
+    const _v = new THREE.Vector3();
+
+    for (const mob of this.mobject.getFamily()) {
+      if (isVMobjectLike(mob)) {
+        const startPoints = mob.getPoints();
+        if (startPoints.length === 0) continue;
+
+        const threeObj = (mob as Mobject)._threeObject;
+        let worldMatrix: THREE.Matrix4 | null = null;
+        let inverseWorld: THREE.Matrix4 | null = null;
+
+        if (threeObj) {
+          threeObj.updateWorldMatrix(true, false);
+          worldMatrix = threeObj.matrixWorld;
+          inverseWorld = worldMatrix.clone().invert();
+        }
+
+        let targetPoints: number[][];
+        if (worldMatrix && inverseWorld) {
+          targetPoints = startPoints.map((p) => {
+            _v.set(p[0], p[1], p[2]).applyMatrix4(worldMatrix!);
+            const z: Complex = { re: _v.x, im: _v.y };
+            const result = this.func(z);
+            _v.set(result.re, result.im, _v.z).applyMatrix4(inverseWorld!);
+            return [_v.x, _v.y, _v.z];
+          });
+        } else {
+          targetPoints = startPoints.map((p) => {
+            const z: Complex = { re: p[0], im: p[1] };
+            const result = this.func(z);
+            return [result.re, result.im, p[2]];
+          });
+        }
+
+        this._snapshots.push({ mob, startPoints, targetPoints });
+      }
+    }
+  }
+
+  interpolate(alpha: number): void {
+    for (const snap of this._snapshots) {
+      const interpolated: number[][] = [];
+      for (let i = 0; i < snap.startPoints.length; i++) {
+        interpolated.push(lerpPoint(snap.startPoints[i], snap.targetPoints[i], alpha));
+      }
+      snap.mob.setPoints(interpolated);
+    }
+    _reconstructArrowTips(this.mobject);
+    this.mobject._markDirtyUpward();
+  }
+
+  override finish(): void {
+    for (const snap of this._snapshots) {
+      snap.mob.setPoints(snap.targetPoints);
+    }
+    _reconstructArrowTips(this.mobject);
+    this.mobject._markDirtyUpward();
+    super.finish();
+  }
+}
+
+/**
+ * Create an ApplyComplexFunction animation.
+ * @param mobject The Mobject to transform (VMobject or Group)
+ * @param func Complex function to apply: (z: Complex) => Complex
+ * @param options Animation options
+ */
+export function applyComplexFunction(
+  mobject: Mobject,
+  func: (z: Complex) => Complex,
+  options?: Omit<ApplyComplexFunctionOptions, 'func'>,
+): ApplyComplexFunction {
+  return new ApplyComplexFunction(mobject, { ...options, func });
 }
 
 // ============================================================================

--- a/src/animation/transform/index.ts
+++ b/src/animation/transform/index.ts
@@ -23,6 +23,11 @@ export {
   ApplyMatrix,
   applyMatrix,
   type ApplyMatrixOptions,
+
+  // ApplyComplexFunction
+  ApplyComplexFunction,
+  applyComplexFunction,
+  type ApplyComplexFunctionOptions,
 } from './ApplyTransforms';
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -436,6 +436,11 @@ export {
 export { ApplyPointwiseFunction, applyPointwiseFunction } from './animation/transform';
 export { ApplyFunction, applyFunction, type ApplyFunctionOptions } from './animation/transform';
 export { ApplyMatrix, applyMatrix, type ApplyMatrixOptions } from './animation/transform';
+export {
+  ApplyComplexFunction,
+  applyComplexFunction,
+  type ApplyComplexFunctionOptions,
+} from './animation/transform';
 export { FadeToColor, fadeToColor, type FadeToColorOptions } from './animation/transform';
 export { Restore, restore } from './animation/transform';
 export { ScaleInPlace, type ScaleInPlaceOptions } from './animation/transform';


### PR DESCRIPTION
## Summary
- Implements `ApplyComplexFunction` animation class that applies a complex function to all points of a mobject, treating `(x, y)` as `(Re, Im)` — closes #139
- Follows the same `ChildSnapshot` + world-space pattern as `ApplyFunction` and `ApplyMatrix`
- Includes 10 unit tests, an interactive HTML demo (`examples/apply_complex_function.html`), and a docs example on the Animations page

## Test plan
- [x] 10 unit tests pass (`npx vitest run src/animation/animation-apply-complex-function.test.ts`)
- [x] Existing 116 transform tests still pass
- [x] Build succeeds (`npm run build`)
- [x] Verified `z => z^2` and `z => 1/z` animations visually on localhost
- [x] Docs example renders correctly on Docusaurus dev server