### PR TITLE
refactor: rename setOpacity to setStrokeOpacity

### DIFF
--- a/src/animation/creation.test.ts
+++ b/src/animation/creation.test.ts
@@ -47,7 +47,7 @@ describe('Create', () => {
   describe('non-VMobject (opacity fallback)', () => {
     it('begin sets opacity to 0', () => {
       const m = new Mobject();
-      m.setOpacity(1);
+      m.setStrokeOpacity(1);
       const anim = new Create(m);
       anim.begin();
       expect(m.opacity).toBe(0);
@@ -80,8 +80,8 @@ describe('Create', () => {
       const group = new Group();
       const child1 = new Mobject();
       const child2 = new Mobject();
-      child1.setOpacity(1);
-      child2.setOpacity(0); // e.g. background line with opacity 0
+      child1.setStrokeOpacity(1);
+      child2.setStrokeOpacity(0); // e.g. background line with opacity 0
       group.add(child1);
       group.add(child2);
 
@@ -103,8 +103,8 @@ describe('Create', () => {
       const group = new Group();
       const child1 = new Mobject();
       const child2 = new Mobject();
-      child1.setOpacity(1);
-      child2.setOpacity(0.4);
+      child1.setStrokeOpacity(1);
+      child2.setStrokeOpacity(0.4);
       group.add(child1);
       group.add(child2);
 
@@ -238,7 +238,7 @@ describe('Uncreate', () => {
   describe('non-VMobject (opacity fallback)', () => {
     it('interpolate fades opacity from 1 to 0', () => {
       const m = new Mobject();
-      m.setOpacity(1);
+      m.setStrokeOpacity(1);
       const anim = new Uncreate(m);
       anim.begin();
       anim.interpolate(0);
@@ -251,7 +251,7 @@ describe('Uncreate', () => {
 
     it('finish sets opacity to 0', () => {
       const m = new Mobject();
-      m.setOpacity(1);
+      m.setStrokeOpacity(1);
       const anim = new Uncreate(m);
       anim.begin();
       anim.interpolate(0.5);
@@ -296,7 +296,7 @@ describe('Write', () => {
   describe('non-VMobject (opacity fallback)', () => {
     it('begin sets opacity to 0', () => {
       const m = new Mobject();
-      m.setOpacity(1);
+      m.setStrokeOpacity(1);
       const anim = new Write(m);
       anim.begin();
       expect(m.opacity).toBe(0);
@@ -304,7 +304,7 @@ describe('Write', () => {
 
     it('interpolate sets opacity proportional to alpha', () => {
       const m = new Mobject();
-      m.setOpacity(1);
+      m.setStrokeOpacity(1);
       const anim = new Write(m);
       anim.begin();
       anim.interpolate(0.5);
@@ -313,7 +313,7 @@ describe('Write', () => {
 
     it('finish restores opacity', () => {
       const m = new Mobject();
-      m.setOpacity(0.8);
+      m.setStrokeOpacity(0.8);
       const anim = new Write(m);
       anim.begin();
       anim.interpolate(0.5);
@@ -325,7 +325,7 @@ describe('Write', () => {
   describe('reverse mode (opacity fallback)', () => {
     it('reverse starts with full opacity and fades to 0', () => {
       const m = new Mobject();
-      m.setOpacity(1);
+      m.setStrokeOpacity(1);
       const anim = new Write(m, { reverse: true });
       anim.begin();
       // When reverse, begin should set opacity to original (not 0)

--- a/src/animation/creation/Create.ts
+++ b/src/animation/creation/Create.ts
@@ -152,7 +152,7 @@ export class Create extends Animation {
       // (e.g. NumberPlane background lines with opacity 0) are preserved
       this._savedOpacities = [];
       this._collectOpacities(this.mobject);
-      this.mobject.setOpacity(0);
+      this.mobject.setStrokeOpacity(0);
     }
   }
 
@@ -170,11 +170,11 @@ export class Create extends Animation {
 
   /**
    * Apply proportionally scaled opacities to all saved descendants.
-   * Uses Mobject.prototype.setOpacity to avoid Group propagation.
+   * Uses Mobject.prototype.setStrokeOpacity to avoid Group propagation.
    */
   private _applyScaledOpacities(factor: number): void {
     for (const [mob, origOpacity] of this._savedOpacities) {
-      Mobject.prototype.setOpacity.call(mob, origOpacity * factor);
+      Mobject.prototype.setStrokeOpacity.call(mob, origOpacity * factor);
     }
   }
 
@@ -437,7 +437,7 @@ export class Uncreate extends Animation {
         }
       });
     } else {
-      this.mobject.setOpacity(1 - alpha);
+      this.mobject.setStrokeOpacity(1 - alpha);
     }
   }
 
@@ -453,7 +453,7 @@ export class Uncreate extends Animation {
         }
       });
     } else {
-      this.mobject.setOpacity(0);
+      this.mobject.setStrokeOpacity(0);
     }
     super.finish();
   }
@@ -586,7 +586,7 @@ export class Write extends Animation {
         }
       });
     } else {
-      this.mobject.setOpacity(this._reverse ? this._originalOpacity : 0);
+      this.mobject.setStrokeOpacity(this._reverse ? this._originalOpacity : 0);
     }
   }
 
@@ -730,7 +730,7 @@ export class Write extends Animation {
         }
       });
     } else {
-      this.mobject.setOpacity(this._originalOpacity * effectiveAlpha);
+      this.mobject.setStrokeOpacity(this._originalOpacity * effectiveAlpha);
     }
   }
 
@@ -880,7 +880,7 @@ export class Write extends Animation {
           }
         });
       }
-      this.mobject.setOpacity(0);
+      this.mobject.setStrokeOpacity(0);
     } else {
       if (this._useDashReveal) {
         const threeObj = this.mobject.getThreeObject();
@@ -892,7 +892,7 @@ export class Write extends Animation {
           }
         });
       }
-      this.mobject.setOpacity(this._originalOpacity);
+      this.mobject.setStrokeOpacity(this._originalOpacity);
     }
     super.finish();
   }
@@ -910,7 +910,7 @@ export class Write extends Animation {
       if (this._textMesh) {
         this._textMesh.visible = false;
       }
-      this.mobject.setOpacity(0);
+      this.mobject.setStrokeOpacity(0);
     } else {
       // Write complete: show texture, hide glyphs
       if (this._textMesh) {
@@ -920,7 +920,7 @@ export class Write extends Animation {
           material.opacity = this._originalOpacity;
         }
       }
-      this.mobject.setOpacity(this._originalOpacity);
+      this.mobject.setStrokeOpacity(this._originalOpacity);
     }
 
     // Clean up skeleton VMobjects

--- a/src/animation/creation/CreationExtensions.ts
+++ b/src/animation/creation/CreationExtensions.ts
@@ -112,7 +112,7 @@ export class ShowIncreasingSubsets extends Animation {
     this._originalOpacities = this._submobjects.map((m) => m.opacity);
 
     // Hide all submobjects initially
-    this._submobjects.forEach((m) => m.setOpacity(0));
+    this._submobjects.forEach((m) => m.setStrokeOpacity(0));
   }
 
   interpolate(alpha: number): void {
@@ -120,20 +120,20 @@ export class ShowIncreasingSubsets extends Animation {
 
     for (let i = 0; i < this._submobjects.length; i++) {
       if (i < numToShow) {
-        this._submobjects[i].setOpacity(this._originalOpacities[i]);
+        this._submobjects[i].setStrokeOpacity(this._originalOpacities[i]);
       } else if (i === numToShow && alpha < 1) {
         // Partially show the current one
         const localAlpha = alpha * this._submobjects.length - numToShow;
-        this._submobjects[i].setOpacity(this._originalOpacities[i] * localAlpha);
+        this._submobjects[i].setStrokeOpacity(this._originalOpacities[i] * localAlpha);
       } else {
-        this._submobjects[i].setOpacity(0);
+        this._submobjects[i].setStrokeOpacity(0);
       }
     }
   }
 
   override finish(): void {
     // Show all submobjects
-    this._submobjects.forEach((m, i) => m.setOpacity(this._originalOpacities[i]));
+    this._submobjects.forEach((m, i) => m.setStrokeOpacity(this._originalOpacities[i]));
     super.finish();
   }
 }
@@ -222,7 +222,7 @@ export class ShowPartial extends Animation {
       });
     } else {
       // For non-VMobjects, use opacity
-      this.mobject.setOpacity(alpha);
+      this.mobject.setStrokeOpacity(alpha);
     }
   }
 
@@ -273,7 +273,7 @@ export class ShowSubmobjectsOneByOne extends Animation {
     this._originalOpacities = this._submobjects.map((m) => m.opacity);
 
     // Hide all submobjects initially
-    this._submobjects.forEach((m) => m.setOpacity(0));
+    this._submobjects.forEach((m) => m.setStrokeOpacity(0));
     this._currentIndex = -1;
   }
 
@@ -286,13 +286,13 @@ export class ShowSubmobjectsOneByOne extends Animation {
     if (newIndex !== this._currentIndex) {
       // Hide previous
       if (this._currentIndex >= 0 && this._currentIndex < this._submobjects.length) {
-        this._submobjects[this._currentIndex].setOpacity(0);
+        this._submobjects[this._currentIndex].setStrokeOpacity(0);
       }
 
       // Show current
       this._currentIndex = newIndex;
       if (this._currentIndex >= 0 && this._currentIndex < this._submobjects.length) {
-        this._submobjects[this._currentIndex].setOpacity(
+        this._submobjects[this._currentIndex].setStrokeOpacity(
           this._originalOpacities[this._currentIndex],
         );
       }
@@ -303,9 +303,9 @@ export class ShowSubmobjectsOneByOne extends Animation {
     // Show the last one (or restore all if that's the intended behavior)
     this._submobjects.forEach((m, i) => {
       if (i === this._submobjects.length - 1) {
-        m.setOpacity(this._originalOpacities[i]);
+        m.setStrokeOpacity(this._originalOpacities[i]);
       } else {
-        m.setOpacity(0);
+        m.setStrokeOpacity(0);
       }
     });
     super.finish();

--- a/src/animation/creation/creation-coverage.test.ts
+++ b/src/animation/creation/creation-coverage.test.ts
@@ -114,7 +114,7 @@ function makeParentWithChildren(n: number): Mobject {
   const parent = new Mobject();
   for (let i = 0; i < n; i++) {
     const child = new Mobject();
-    child.setOpacity(1);
+    child.setStrokeOpacity(1);
     parent.add(child);
   }
   return parent;
@@ -167,7 +167,7 @@ describe('DrawBorderThenFill - VMobject without Line2', () => {
 
   it('interpolate does nothing (no dash reveal)', () => {
     const v = makeVMobject();
-    v.setOpacity(0.8);
+    v.setStrokeOpacity(0.8);
     const anim = new DrawBorderThenFill(v);
     anim.begin();
     anim.interpolate(0.5);
@@ -300,9 +300,9 @@ describe('ShowIncreasingSubsets', () => {
   it('finish restores original opacities', () => {
     const parent = new Mobject();
     const c1 = new Mobject();
-    c1.setOpacity(0.5);
+    c1.setStrokeOpacity(0.5);
     const c2 = new Mobject();
-    c2.setOpacity(0.8);
+    c2.setStrokeOpacity(0.8);
     parent.add(c1, c2);
 
     const anim = new ShowIncreasingSubsets(parent);
@@ -399,7 +399,7 @@ describe('Write - VMobject opacity fallback', () => {
 
   it('finish sets opacity to original', () => {
     const v = new VMobject();
-    v.setOpacity(0.8);
+    v.setStrokeOpacity(0.8);
     const anim = new Write(v);
     anim.begin();
     anim.interpolate(0.5);
@@ -461,7 +461,7 @@ describe('Write - setRevealProgress path', () => {
 describe('Write - reverse mode', () => {
   it('starts from original opacity', () => {
     const v = new VMobject(); // empty = opacity fallback
-    v.setOpacity(1);
+    v.setStrokeOpacity(1);
     const anim = new Write(v, { reverse: true });
     anim.begin();
     // reverse=true, VMobject fallback: start at original opacity
@@ -470,7 +470,7 @@ describe('Write - reverse mode', () => {
 
   it('interpolate decreases opacity in reverse', () => {
     const v = new VMobject();
-    v.setOpacity(1);
+    v.setStrokeOpacity(1);
     const anim = new Write(v, { reverse: true });
     anim.begin();
     anim.interpolate(0.5);
@@ -494,7 +494,7 @@ describe('Write - remover mode (opacity)', () => {
 
   it('finish without remover sets opacity to original', () => {
     const v = new VMobject();
-    v.setOpacity(0.9);
+    v.setStrokeOpacity(0.9);
     const anim = new Write(v, { remover: false });
     anim.begin();
     anim.finish();
@@ -521,7 +521,7 @@ describe('Unwrite', () => {
 
   it('begin preserves current opacity', () => {
     const v = new VMobject(); // empty = opacity fallback
-    v.setOpacity(1);
+    v.setStrokeOpacity(1);
     const anim = new Unwrite(v);
     anim.begin();
     expect(v.opacity).toBe(1); // reverse=true starts at original
@@ -846,7 +846,7 @@ describe('Write - plain Mobject fallback', () => {
 
   it('finish restores opacity', () => {
     const m = new Mobject();
-    m.setOpacity(0.7);
+    m.setStrokeOpacity(0.7);
     const anim = new Write(m);
     anim.begin();
     anim.finish();

--- a/src/animation/indication/ShowCreationThenDestruction.ts
+++ b/src/animation/indication/ShowCreationThenDestruction.ts
@@ -58,7 +58,7 @@ export class ShowCreationThenDestruction extends Animation {
       });
     } else {
       // Non-line mobject: start invisible
-      this.mobject.setOpacity(0);
+      this.mobject.setStrokeOpacity(0);
     }
   }
 
@@ -84,7 +84,7 @@ export class ShowCreationThenDestruction extends Animation {
         }
       });
     } else {
-      this.mobject.setOpacity(effectiveAlpha);
+      this.mobject.setStrokeOpacity(effectiveAlpha);
     }
   }
 
@@ -101,7 +101,7 @@ export class ShowCreationThenDestruction extends Animation {
         }
       });
     } else {
-      this.mobject.setOpacity(0);
+      this.mobject.setStrokeOpacity(0);
     }
     super.finish();
   }

--- a/src/animation/transform/Transform.ts
+++ b/src/animation/transform/Transform.ts
@@ -146,7 +146,7 @@ export class Transform extends Animation {
           sourceObj.parent.add(targetObj);
         }
 
-        this.target.setOpacity(0);
+        this.target.setStrokeOpacity(0);
         this.target._syncToThree();
         return;
       }
@@ -212,7 +212,7 @@ export class Transform extends Animation {
       }
 
       // Start target invisible
-      this.target.setOpacity(0);
+      this.target.setStrokeOpacity(0);
       this.target._syncToThree();
     }
   }
@@ -293,8 +293,8 @@ export class Transform extends Animation {
   interpolate(alpha: number): void {
     if (this._useCrossFade) {
       // Cross-fade: source fades out, target fades in
-      this.mobject.setOpacity(this._startOpacity * (1 - alpha));
-      this.target.setOpacity(this._crossFadeTargetOpacity * alpha);
+      this.mobject.setStrokeOpacity(this._startOpacity * (1 - alpha));
+      this.target.setStrokeOpacity(this._crossFadeTargetOpacity * alpha);
 
       // Move source toward target position for a smooth transition
       this.mobject.position.lerpVectors(this._startPosition, this._targetPosition, alpha);
@@ -422,7 +422,7 @@ export class Transform extends Animation {
 
         // Position source at target location
         this.mobject.position.copy(this._targetPosition);
-        this.mobject.setOpacity(this._crossFadeTargetOpacity);
+        this.mobject.setStrokeOpacity(this._crossFadeTargetOpacity);
         this.mobject._markDirty();
 
         // Remove target from scene graph
@@ -430,8 +430,8 @@ export class Transform extends Animation {
         if (targetObj.parent) targetObj.parent.remove(targetObj);
       } else {
         // Non-Text cross-fade: reparent target under source
-        this.mobject.setOpacity(0);
-        this.target.setOpacity(this._crossFadeTargetOpacity);
+        this.mobject.setStrokeOpacity(0);
+        this.target.setStrokeOpacity(this._crossFadeTargetOpacity);
         this.target._syncToThree();
 
         const sourceObj = this.mobject.getThreeObject();

--- a/src/animation/utility/index.ts
+++ b/src/animation/utility/index.ts
@@ -355,7 +355,7 @@ export class Broadcast extends Animation {
       copy.scaleVector.copy(this._originalScale).multiplyScalar(Math.max(scaleFactor, 0));
 
       // Set initial opacity
-      copy.setOpacity(this.initialOpacity);
+      copy.setStrokeOpacity(this.initialOpacity);
       copy._markDirty();
 
       // Add the copy's Three.js object to the parent
@@ -401,7 +401,7 @@ export class Broadcast extends Animation {
       // Interpolate opacity: from initialOpacity to finalOpacity
       const currentOpacity =
         this.initialOpacity + (this.finalOpacity - this.initialOpacity) * localAlpha;
-      copy.setOpacity(currentOpacity);
+      copy.setStrokeOpacity(currentOpacity);
 
       copy._markDirty();
       // Sync Three.js object so visual updates are applied

--- a/src/core/Group.ts
+++ b/src/core/Group.ts
@@ -193,14 +193,14 @@ export class Group extends Mobject {
   }
 
   /**
-   * Set the opacity of all children.
+   * Set the stroke opacity of all children.
    * @param opacity - Opacity value (0-1)
    * @returns this for chaining
    */
-  override setOpacity(opacity: number): this {
-    super.setOpacity(opacity);
+  override setStrokeOpacity(opacity: number): this {
+    super.setStrokeOpacity(opacity);
     for (const child of this.children) {
-      child.setOpacity(opacity);
+      child.setStrokeOpacity(opacity);
     }
     return this;
   }

--- a/src/core/LinearTransformationScene.ts
+++ b/src/core/LinearTransformationScene.ts
@@ -117,7 +117,7 @@ export class LinearTransformationScene extends Scene {
         color: this._gridColor,
         strokeWidth: 1,
       });
-      line.setOpacity(0.5);
+      line.setStrokeOpacity(0.5);
       grid.add(line);
     }
 
@@ -130,7 +130,7 @@ export class LinearTransformationScene extends Scene {
         color: this._gridColor,
         strokeWidth: 1,
       });
-      line.setOpacity(0.5);
+      line.setStrokeOpacity(0.5);
       grid.add(line);
     }
 

--- a/src/core/Mobject.ts
+++ b/src/core/Mobject.ts
@@ -113,7 +113,7 @@ export abstract class Mobject {
   }
 
   set opacity(value: number) {
-    this.setOpacity(value);
+    this.setStrokeOpacity(value);
   }
 
   get style(): MobjectStyle {
@@ -142,7 +142,7 @@ export abstract class Mobject {
     return this;
   }
 
-  setOpacity(opacity: number): this {
+  setStrokeOpacity(opacity: number): this {
     const v = Math.max(0, Math.min(1, opacity));
     if (this._opacity !== v) {
       this._opacity = v;
@@ -185,6 +185,17 @@ export abstract class Mobject {
   set fillColor(color: string) {
     if (this._style.fillColor !== color) {
       this._style.fillColor = color;
+      this._markDirty();
+    }
+  }
+
+  get strokeColor(): string | undefined {
+    return this._style.strokeColor;
+  }
+
+  set strokeColor(color: string) {
+    if (this._style.strokeColor !== color) {
+      this._style.strokeColor = color;
       this._markDirty();
     }
   }

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -969,7 +969,7 @@ export class Scene {
    * scene.batch(() => {
    *   circle.setColor('red');
    *   circle.shift([1, 0, 0]);
-   *   square.setOpacity(0.5);
+   *   square.setStrokeOpacity(0.5);
    * });
    * ```
    */

--- a/src/core/StateManager.ts
+++ b/src/core/StateManager.ts
@@ -148,7 +148,7 @@ export function deserializeMobject(mob: Mobject, state: MobjectState): void {
 
   // Visual properties
   mob.color = state.color;
-  mob.setOpacity(state.opacity);
+  mob.setStrokeOpacity(state.opacity);
   mob.strokeWidth = state.strokeWidth;
   mob.fillOpacity = state.fillOpacity;
 

--- a/src/core/VGroup.ts
+++ b/src/core/VGroup.ts
@@ -267,10 +267,10 @@ export class VGroup extends VMobject {
    * @param opacity - Opacity value (0-1)
    * @returns this for chaining
    */
-  override setOpacity(opacity: number): this {
-    super.setOpacity(opacity);
+  override setStrokeOpacity(opacity: number): this {
+    super.setStrokeOpacity(opacity);
     for (const child of this.children) {
-      child.setOpacity(opacity);
+      child.setStrokeOpacity(opacity);
     }
     return this;
   }
@@ -339,7 +339,7 @@ export class VGroup extends VMobject {
           child.setStrokeWidth(width);
         }
         if (opacity !== undefined) {
-          child.setOpacity(opacity);
+          child.setStrokeOpacity(opacity);
         }
       }
     }

--- a/src/core/VMobject.ts
+++ b/src/core/VMobject.ts
@@ -651,7 +651,7 @@ export function getNthCurve(vmobject: VMobject, n: number): VMobject {
   curve.setPoints(curvePoints);
 
   curve.setColor(vmobject.color);
-  curve.setOpacity(vmobject.opacity);
+  curve.setStrokeOpacity(vmobject.opacity);
   curve.setStrokeWidth(vmobject.strokeWidth);
   curve.setFillOpacity(vmobject.fillOpacity);
 

--- a/src/core/VectorScene.ts
+++ b/src/core/VectorScene.ts
@@ -113,7 +113,7 @@ export class VectorScene extends Scene {
         color: isAxis ? axisColor : gridColor,
         strokeWidth: isAxis ? 2 : 1,
       });
-      if (!isAxis) line.setOpacity(0.5);
+      if (!isAxis) line.setStrokeOpacity(0.5);
       grid.add(line);
     }
 
@@ -127,7 +127,7 @@ export class VectorScene extends Scene {
         color: isAxis ? axisColor : gridColor,
         strokeWidth: isAxis ? 2 : 1,
       });
-      if (!isAxis) line.setOpacity(0.5);
+      if (!isAxis) line.setStrokeOpacity(0.5);
       grid.add(line);
     }
 

--- a/src/core/ZoomedScene.ts
+++ b/src/core/ZoomedScene.ts
@@ -434,7 +434,7 @@ export class ZoomedScene extends Scene {
     // Reset frame and display transforms for clean re-play
     this.zoomedCamera.frame.position.set(0, 0, 0);
     this.zoomedCamera.frame.scaleVector.set(1, 1, 1);
-    this.zoomedCamera.frame.setOpacity(1);
+    this.zoomedCamera.frame.setStrokeOpacity(1);
     this.zoomedCamera.frame._markDirty();
     this.zoomedDisplay.position.set(
       this._displayDefaultPos[0],
@@ -442,8 +442,8 @@ export class ZoomedScene extends Scene {
       this._displayDefaultPos[2],
     );
     this.zoomedDisplay.scaleVector.set(1, 1, 1);
-    this.zoomedDisplay.setOpacity(1);
-    this.zoomedDisplay.displayFrame.setOpacity(1);
+    this.zoomedDisplay.setStrokeOpacity(1);
+    this.zoomedDisplay.displayFrame.setStrokeOpacity(1);
     this.zoomedDisplay._markDirty();
 
     // Reset Line2 material dashed state left behind by Uncreate

--- a/src/core/core-coverage.test.ts
+++ b/src/core/core-coverage.test.ts
@@ -44,7 +44,7 @@ describe('saveMobjectState / restoreMobjectState functions', () => {
     const vm = makeVM();
     vm.position.set(1, 2, 3);
     vm.setColor('#ff0000');
-    vm.setOpacity(0.5);
+    vm.setStrokeOpacity(0.5);
 
     const state = saveMobjectState(vm);
     expect(state).toBeDefined();
@@ -364,7 +364,7 @@ describe('VDict - additional coverage', () => {
     const d = new VDict({ item: makeVM() });
     d.position.set(5, 6, 7);
     d.setColor('#ff0000');
-    d.setOpacity(0.5);
+    d.setStrokeOpacity(0.5);
 
     const clone = d.copy() as VDict;
     expect(clone.position.x).toBe(5);
@@ -550,8 +550,8 @@ describe('VMobject - interpolate style branches', () => {
   it('interpolate at alpha=0 keeps original values', () => {
     const v1 = makeVM();
     const v2 = makeVM();
-    v1.setOpacity(0.2);
-    v2.setOpacity(0.8);
+    v1.setStrokeOpacity(0.2);
+    v2.setStrokeOpacity(0.8);
     v1.position.set(0, 0, 0);
     v2.position.set(10, 0, 0);
 
@@ -563,8 +563,8 @@ describe('VMobject - interpolate style branches', () => {
   it('interpolate at alpha=1 reaches target values', () => {
     const v1 = makeVM();
     const v2 = makeVM();
-    v1.setOpacity(0.2);
-    v2.setOpacity(0.8);
+    v1.setStrokeOpacity(0.2);
+    v2.setStrokeOpacity(0.8);
     v1.fillOpacity = 0.1;
     v2.fillOpacity = 0.9;
     v1.strokeWidth = 2;

--- a/src/core/core-extra.test.ts
+++ b/src/core/core-extra.test.ts
@@ -179,7 +179,7 @@ describe('serializeMobject', () => {
     vm.rotation.set(0.1, 0.2, 0.3);
     vm.scaleVector.set(2, 3, 4);
     vm.setColor('#ff0000');
-    vm.setOpacity(0.7);
+    vm.setStrokeOpacity(0.7);
     const state = serializeMobject(vm);
     expect(state.position).toEqual([1, 2, 3]);
     expect(state.rotation[0]).toBeCloseTo(0.1);
@@ -254,14 +254,14 @@ describe('deserializeMobject', () => {
   it('restores style (color, opacity, strokeWidth, fillOpacity)', () => {
     const vm = new VMobject();
     vm.setColor('#00ff00');
-    vm.setOpacity(0.3);
+    vm.setStrokeOpacity(0.3);
     // Use setStrokeWidth/setFillOpacity to keep _style in sync
     vm.setStrokeWidth(8);
     vm.setFillOpacity(0.5);
     const state = serializeMobject(vm);
     // Reset the mobject
     vm.setColor('#ffffff');
-    vm.setOpacity(1);
+    vm.setStrokeOpacity(1);
     vm.setStrokeWidth(4);
     vm.setFillOpacity(0);
     deserializeMobject(vm, state);
@@ -287,7 +287,7 @@ describe('deserializeMobject', () => {
     vm.position.set(1, 2, 3);
     vm.scaleVector.set(2, 2, 2);
     vm.setColor('#abcdef');
-    vm.setOpacity(0.42);
+    vm.setStrokeOpacity(0.42);
     vm.setStrokeWidth(6);
     vm.setFillOpacity(0.8);
     const state = serializeMobject(vm);
@@ -645,21 +645,21 @@ describe('Mobject - extended coverage', () => {
     expect(vm._dirty).toBe(false); // should not mark dirty
   });
 
-  // setOpacity clamping and no-op
-  it('setOpacity clamps and is no-op when unchanged', () => {
+  // setStrokeOpacity clamping and no-op
+  it('setStrokeOpacity clamps and is no-op when unchanged', () => {
     const vm = new VMobject();
-    vm.setOpacity(0.5);
+    vm.setStrokeOpacity(0.5);
     expect(vm.opacity).toBe(0.5);
     vm._dirty = false;
-    vm.setOpacity(0.5);
+    vm.setStrokeOpacity(0.5);
     expect(vm._dirty).toBe(false);
   });
 
-  it('setOpacity clamps to [0, 1]', () => {
+  it('setStrokeOpacity clamps to [0, 1]', () => {
     const vm = new VMobject();
-    vm.setOpacity(-1);
+    vm.setStrokeOpacity(-1);
     expect(vm.opacity).toBe(0);
-    vm.setOpacity(5);
+    vm.setStrokeOpacity(5);
     expect(vm.opacity).toBe(1);
   });
 
@@ -849,7 +849,7 @@ describe('Mobject - extended coverage', () => {
     ]);
     vm.position.set(5, 5, 5);
     vm.setColor('#ff0000');
-    vm.setOpacity(0.5);
+    vm.setStrokeOpacity(0.5);
     vm.strokeWidth = 8;
     vm.fillOpacity = 0.7;
 
@@ -882,7 +882,7 @@ describe('Mobject - extended coverage', () => {
     const source = new VMobject();
     source.position.set(10, 20, 30);
     source.setColor('#00ff00');
-    source.setOpacity(0.3);
+    source.setStrokeOpacity(0.3);
     source.strokeWidth = 6;
     source.fillOpacity = 0.9;
     source.setPoints([
@@ -1316,7 +1316,7 @@ describe('Mobject - extended coverage', () => {
     const vm = new VMobject();
     vm.position.set(1, 2, 3);
     vm.setColor('#ff0000');
-    vm.setOpacity(0.5);
+    vm.setStrokeOpacity(0.5);
     vm.strokeWidth = 8;
     vm.fillOpacity = 0.7;
     vm.setPoints([
@@ -1330,7 +1330,7 @@ describe('Mobject - extended coverage', () => {
     // Modify
     vm.position.set(99, 99, 99);
     vm.setColor('#0000ff');
-    vm.setOpacity(1);
+    vm.setStrokeOpacity(1);
     vm.strokeWidth = 2;
     vm.fillOpacity = 0;
     vm.setPoints([[10, 10, 0]]);
@@ -1584,11 +1584,11 @@ describe('Group - extended coverage', () => {
     expect(b.color).toBe('#ff0000');
   });
 
-  it('setOpacity propagates to all children', () => {
+  it('setStrokeOpacity propagates to all children', () => {
     const a = new VMobject();
     const b = new VMobject();
     const g = new Group(a, b);
-    g.setOpacity(0.3);
+    g.setStrokeOpacity(0.3);
     expect(a.opacity).toBe(0.3);
     expect(b.opacity).toBe(0.3);
   });
@@ -1829,10 +1829,10 @@ describe('VGroup - extended coverage', () => {
     expect(b.color).toBe('#00ff00');
   });
 
-  it('setOpacity propagates to children', () => {
+  it('setStrokeOpacity propagates to children', () => {
     const a = new VMobject();
     const vg = new VGroup(a);
-    vg.setOpacity(0.5);
+    vg.setStrokeOpacity(0.5);
     expect(a.opacity).toBe(0.5);
   });
 
@@ -2112,7 +2112,7 @@ describe('VDict - extended coverage', () => {
     const d = new VDict({ a: va, b: vb });
     d.position.set(1, 2, 3);
     d.setColor('#ff0000');
-    d.setOpacity(0.5);
+    d.setStrokeOpacity(0.5);
 
     const clone = d.copy() as VDict;
     expect(clone.size).toBe(2);
@@ -2798,7 +2798,7 @@ describe('VMobject.copy', () => {
       [4, 5, 6],
     ]);
     v.setColor('#ff0000');
-    v.setOpacity(0.7);
+    v.setStrokeOpacity(0.7);
     v.fillOpacity = 0.3;
     v.strokeWidth = 8;
     const c = v.copy() as VMobject;
@@ -3117,7 +3117,7 @@ describe('getNthCurve', () => {
       [3, 0, 0],
     ]);
     v.setColor('#ff0000');
-    v.setOpacity(0.5);
+    v.setStrokeOpacity(0.5);
     v.setStrokeWidth(8);
     v.setFillOpacity(0.3);
     const c = getNthCurve(v, 0);
@@ -3389,11 +3389,11 @@ describe('VMobject._interpolatePointList3D (via alignPoints)', () => {
 });
 
 describe('VMobject style optimization (no-op dirty checks)', () => {
-  it('setOpacity does not mark dirty if value unchanged', () => {
+  it('setStrokeOpacity does not mark dirty if value unchanged', () => {
     const v = new VMobject();
-    v.setOpacity(0.5);
+    v.setStrokeOpacity(0.5);
     v._dirty = false;
-    v.setOpacity(0.5);
+    v.setStrokeOpacity(0.5);
     expect(v._dirty).toBe(false);
   });
 
@@ -3494,8 +3494,8 @@ describe('VMobject chaining (all methods)', () => {
     expect(new VMobject().setColor('#ff0000')).toBeInstanceOf(VMobject);
   });
 
-  it('setOpacity returns this', () => {
-    expect(new VMobject().setOpacity(0.5)).toBeInstanceOf(VMobject);
+  it('setStrokeOpacity returns this', () => {
+    expect(new VMobject().setStrokeOpacity(0.5)).toBeInstanceOf(VMobject);
   });
 
   it('setStrokeWidth returns this', () => {
@@ -3528,7 +3528,7 @@ describe('VMobject become', () => {
       [20, 20, 0],
     ]);
     v2.setColor('#ff0000');
-    v2.setOpacity(0.3);
+    v2.setStrokeOpacity(0.3);
     v2.strokeWidth = 12;
     v2.fillOpacity = 0.7;
     v2.position.set(5, 6, 7);
@@ -3553,11 +3553,11 @@ describe('VMobject saveState / restoreState', () => {
     ]);
     v.position.set(1, 2, 3);
     v.setColor('#ff0000');
-    v.setOpacity(0.5);
+    v.setStrokeOpacity(0.5);
     v.saveState();
     v.position.set(99, 99, 99);
     v.setColor('#00ff00');
-    v.setOpacity(1);
+    v.setStrokeOpacity(1);
     v.setPoints([[5, 5, 5]]);
     expect(v.restoreState()).toBe(true);
     expect(v.position.x).toBe(1);

--- a/src/interaction/Hoverable.ts
+++ b/src/interaction/Hoverable.ts
@@ -160,7 +160,7 @@ export class Hoverable {
       this._mobject.setColor(this._options.hoverColor);
     }
     if (this._options.hoverOpacity !== undefined && this._options.hoverOpacity !== null) {
-      this._mobject.setOpacity(this._options.hoverOpacity);
+      this._mobject.setStrokeOpacity(this._options.hoverOpacity);
     }
 
     this._options.onHoverStart?.(this._mobject);
@@ -178,7 +178,7 @@ export class Hoverable {
       this._originalScale[2],
     );
     this._mobject.setColor(this._originalColor);
-    this._mobject.setOpacity(this._originalOpacity);
+    this._mobject.setStrokeOpacity(this._originalOpacity);
     this._mobject._markDirty();
 
     this._options.onHoverEnd?.(this._mobject);

--- a/src/interaction/interaction.test.ts
+++ b/src/interaction/interaction.test.ts
@@ -40,7 +40,7 @@ function createMockMobject(
     setColor: vi.fn(function (this: any, c: string) {
       this.color = c;
     }),
-    setOpacity: vi.fn(function (this: any, o: number) {
+    setStrokeOpacity: vi.fn(function (this: any, o: number) {
       this.opacity = o;
     }),
     scale: vi.fn(),
@@ -358,7 +358,7 @@ describe('Hoverable', () => {
     const canvas = scene.getCanvas();
 
     fireMouseEvent(canvas, 'mousemove', { clientX: 400, clientY: 300 });
-    expect(mob.setOpacity).toHaveBeenCalledWith(0.5);
+    expect(mob.setStrokeOpacity).toHaveBeenCalledWith(0.5);
   });
 
   it('restores original color/opacity on hover end', () => {
@@ -379,7 +379,7 @@ describe('Hoverable', () => {
 
     // Should restore original values
     expect(mob.setColor).toHaveBeenLastCalledWith('#00ff00');
-    expect(mob.setOpacity).toHaveBeenLastCalledWith(0.8);
+    expect(mob.setStrokeOpacity).toHaveBeenLastCalledWith(0.8);
   });
 
   it('makeHoverable factory returns a Hoverable instance', () => {
@@ -1295,7 +1295,7 @@ describe('Edge cases', () => {
     expect(hoverable.isHovering).toBe(false);
     // Original values should be restored
     expect(mob.setColor).toHaveBeenLastCalledWith('#00ff00');
-    expect(mob.setOpacity).toHaveBeenLastCalledWith(0.7);
+    expect(mob.setStrokeOpacity).toHaveBeenLastCalledWith(0.7);
   });
 
   it('SelectionManager selectAll with empty scene does nothing', () => {

--- a/src/mobjects/geometry/DashedLine.ts
+++ b/src/mobjects/geometry/DashedLine.ts
@@ -244,12 +244,12 @@ export class DashedLine extends VMobject {
   }
 
   /**
-   * Override setOpacity to propagate to dashes
+   * Override setStrokeOpacity to propagate to dashes
    */
-  override setOpacity(opacity: number): this {
-    super.setOpacity(opacity);
+  override setStrokeOpacity(opacity: number): this {
+    super.setStrokeOpacity(opacity);
     for (const dash of this._dashes) {
-      dash.setOpacity(opacity);
+      dash.setStrokeOpacity(opacity);
     }
     return this;
   }

--- a/src/mobjects/geometry/geometry-extra.test.ts
+++ b/src/mobjects/geometry/geometry-extra.test.ts
@@ -721,7 +721,7 @@ describe('Line', () => {
 });
 
 // ---------------------------------------------------------------------------
-// DashedLine - coverage for setColor, setStrokeWidth, setOpacity, _createCopy
+// DashedLine - coverage for setColor, setStrokeWidth, setStrokeOpacity, _createCopy
 // ---------------------------------------------------------------------------
 describe('DashedLine - propagation and copy', () => {
   it('setColor propagates to all dash children', () => {
@@ -745,9 +745,9 @@ describe('DashedLine - propagation and copy', () => {
     }
   });
 
-  it('setOpacity propagates to all dash children', () => {
+  it('setStrokeOpacity propagates to all dash children', () => {
     const dl = new DashedLine({ start: [0, 0, 0], end: [2, 0, 0] });
-    dl.setOpacity(0.3);
+    dl.setStrokeOpacity(0.3);
     expect(dl.opacity).toBeCloseTo(0.3, 10);
     for (const dash of dl.getDashes()) {
       expect(dash.opacity).toBeCloseTo(0.3, 10);
@@ -766,9 +766,9 @@ describe('DashedLine - propagation and copy', () => {
     expect(ret).toBe(dl);
   });
 
-  it('setOpacity returns this for chaining', () => {
+  it('setStrokeOpacity returns this for chaining', () => {
     const dl = new DashedLine();
-    const ret = dl.setOpacity(0.5);
+    const ret = dl.setStrokeOpacity(0.5);
     expect(ret).toBe(dl);
   });
 

--- a/src/mobjects/graphing/ComplexPlane.ts
+++ b/src/mobjects/graphing/ComplexPlane.ts
@@ -602,7 +602,7 @@ export class PolarPlane extends Group {
         color: this._gridColor,
         strokeWidth: this._gridStrokeWidth,
       });
-      circle.setOpacity(this._gridOpacity);
+      circle.setStrokeOpacity(this._gridOpacity);
       this._concentricCircles.add(circle);
     }
 
@@ -619,7 +619,7 @@ export class PolarPlane extends Group {
         color: this._gridColor,
         strokeWidth: this._gridStrokeWidth,
       });
-      line.setOpacity(this._gridOpacity);
+      line.setStrokeOpacity(this._gridOpacity);
       this._radialLines.add(line);
     }
   }

--- a/src/mobjects/graphing/NumberPlane.ts
+++ b/src/mobjects/graphing/NumberPlane.ts
@@ -158,7 +158,7 @@ export class NumberPlane extends Axes {
           color: color!,
           strokeWidth: strokeWidth!,
         });
-        line.setOpacity(this._calculateLineOpacity(roundedX, 0, opacity!));
+        line.setStrokeOpacity(this._calculateLineOpacity(roundedX, 0, opacity!));
         this._backgroundLines.add(line);
       }
     }
@@ -176,7 +176,7 @@ export class NumberPlane extends Axes {
           color: color!,
           strokeWidth: strokeWidth!,
         });
-        line.setOpacity(this._calculateLineOpacity(0, roundedY, opacity!));
+        line.setStrokeOpacity(this._calculateLineOpacity(0, roundedY, opacity!));
         this._backgroundLines.add(line);
       }
     }
@@ -206,7 +206,7 @@ export class NumberPlane extends Axes {
               color: fadedColor!,
               strokeWidth: fadedStrokeWidth!,
             });
-            line.setOpacity(fadedOpacity!);
+            line.setStrokeOpacity(fadedOpacity!);
             this._backgroundLines.add(line);
           }
         }
@@ -227,7 +227,7 @@ export class NumberPlane extends Axes {
               color: fadedColor!,
               strokeWidth: fadedStrokeWidth!,
             });
-            line.setOpacity(fadedOpacity!);
+            line.setStrokeOpacity(fadedOpacity!);
             this._backgroundLines.add(line);
           }
         }

--- a/src/mobjects/graphing/VectorField.ts
+++ b/src/mobjects/graphing/VectorField.ts
@@ -428,7 +428,7 @@ export class ArrowVectorField extends VectorField {
         tipLength: Math.min(this._tipLength, arrowLength * 0.4),
         tipWidth: Math.min(this._tipLength * 0.6, arrowLength * 0.25),
       });
-      arrow.setOpacity(this._opacity);
+      arrow.setStrokeOpacity(this._opacity);
 
       this.add(arrow);
     }
@@ -886,7 +886,7 @@ export class StreamLines extends VectorField {
       );
 
       streamline.setColor(color);
-      streamline.setOpacity(this._opacity);
+      streamline.setStrokeOpacity(this._opacity);
       streamline.fillOpacity = 0;
 
       // Variable width based on magnitude
@@ -939,7 +939,7 @@ export class StreamLines extends VectorField {
             tipLength: arrowLen * 0.5,
             tipWidth: arrowLen * 0.3,
           });
-          arrow.setOpacity(this._opacity);
+          arrow.setStrokeOpacity(this._opacity);
           this.add(arrow);
 
           lastArrowDist = distanceAccum;
@@ -1098,7 +1098,7 @@ export class StreamLines extends VectorField {
         lower = Math.max(lower, 0);
 
         if (upper <= lower || alpha <= 0) {
-          vmob.setOpacity(0);
+          vmob.setStrokeOpacity(0);
           vmob._markDirty();
           continue;
         }
@@ -1106,13 +1106,13 @@ export class StreamLines extends VectorField {
         // Use pointwise_become_partial equivalent
         const partialPoints = getPartialBezierPoints(origPoints, lower, upper);
         if (partialPoints.length < 4) {
-          vmob.setOpacity(0);
+          vmob.setStrokeOpacity(0);
           vmob._markDirty();
           continue;
         }
 
         vmob.setPoints3D(partialPoints);
-        vmob.setOpacity(this._opacity);
+        vmob.setStrokeOpacity(this._opacity);
         vmob._markDirty();
       }
     };
@@ -1148,7 +1148,7 @@ export class StreamLines extends VectorField {
         }
       }
 
-      vmob.setOpacity(this._opacity);
+      vmob.setStrokeOpacity(this._opacity);
       vmob._markDirty();
     }
 

--- a/src/mobjects/point/PGroup.ts
+++ b/src/mobjects/point/PGroup.ts
@@ -140,10 +140,10 @@ export class PGroup extends Mobject {
    * @param opacity - Opacity value (0-1)
    * @returns this for chaining
    */
-  override setOpacity(opacity: number): this {
-    super.setOpacity(opacity);
+  override setStrokeOpacity(opacity: number): this {
+    super.setStrokeOpacity(opacity);
     for (const child of this.children) {
-      child.setOpacity(opacity);
+      child.setStrokeOpacity(opacity);
     }
     return this;
   }

--- a/src/mobjects/point/PMobject.ts
+++ b/src/mobjects/point/PMobject.ts
@@ -187,8 +187,8 @@ export class PMobject extends Mobject {
    * @param opacity - Opacity value (0-1)
    * @returns this for chaining
    */
-  override setOpacity(opacity: number): this {
-    super.setOpacity(opacity);
+  override setStrokeOpacity(opacity: number): this {
+    super.setStrokeOpacity(opacity);
     for (const point of this._points) {
       point.opacity = opacity;
     }

--- a/src/mobjects/point/point.test.ts
+++ b/src/mobjects/point/point.test.ts
@@ -135,11 +135,11 @@ describe('PMobject', () => {
     expect(pts[1].color).toBe('#ff0000');
   });
 
-  it('setOpacity updates opacity of all existing points', () => {
+  it('setStrokeOpacity updates opacity of all existing points', () => {
     const pm = new PMobject({
       points: [{ position: [0, 0, 0] }, { position: [1, 0, 0] }],
     });
-    pm.setOpacity(0.3);
+    pm.setStrokeOpacity(0.3);
     const pts = pm.getPoints();
     expect(pts[0].opacity).toBe(0.3);
     expect(pts[1].opacity).toBe(0.3);
@@ -877,11 +877,11 @@ describe('PGroup', () => {
     expect(p2.getPoints()[0].color).toBe('#00ff00');
   });
 
-  it('setOpacity cascades to all children', () => {
+  it('setStrokeOpacity cascades to all children', () => {
     const p1 = new PMobject({ points: [{ position: [0, 0, 0] }] });
     const p2 = new PMobject({ points: [{ position: [1, 0, 0] }] });
     const g = new PGroup({ pmobjects: [p1, p2] });
-    g.setOpacity(0.5);
+    g.setStrokeOpacity(0.5);
     expect(p1.getPoints()[0].opacity).toBe(0.5);
     expect(p2.getPoints()[0].opacity).toBe(0.5);
   });

--- a/src/mobjects/text/MathTex.ts
+++ b/src/mobjects/text/MathTex.ts
@@ -260,13 +260,13 @@ export class MathTex extends Mobject {
   }
 
   /**
-   * Override setOpacity to propagate to multi-part children.
+   * Override setStrokeOpacity to propagate to multi-part children.
    */
-  override setOpacity(opacity: number): this {
-    super.setOpacity(opacity);
+  override setStrokeOpacity(opacity: number): this {
+    super.setStrokeOpacity(opacity);
     if (this._isMultiPart) {
       for (const part of this._parts) {
-        part.setOpacity(opacity);
+        part.setStrokeOpacity(opacity);
       }
     }
     return this;

--- a/src/mobjects/text/mathtex-coverage.test.ts
+++ b/src/mobjects/text/mathtex-coverage.test.ts
@@ -320,18 +320,18 @@ describe('MathTex (additional coverage)', () => {
   });
 
   // -----------------------------------------------------------------
-  // setColor / setOpacity on single-part
+  // setColor / setStrokeOpacity on single-part
   // -----------------------------------------------------------------
-  describe('setColor / setOpacity on single-part', () => {
+  describe('setColor / setStrokeOpacity on single-part', () => {
     it('setColor should not propagate when not multi-part', () => {
       const tex = new MathTex({ latex: 'x' });
       tex.setColor('#00ff00');
       expect(tex.color).toBe('#00ff00');
     });
 
-    it('setOpacity should not propagate when not multi-part', () => {
+    it('setStrokeOpacity should not propagate when not multi-part', () => {
       const tex = new MathTex({ latex: 'x' });
-      tex.setOpacity(0.7);
+      tex.setStrokeOpacity(0.7);
       const internal = tex as unknown as { _opacity: number };
       expect(internal._opacity).toBeCloseTo(0.7);
     });
@@ -648,7 +648,7 @@ describe('Code (additional coverage)', () => {
       const obj = c.getThreeObject();
       const mesh = obj.children.find((ch) => ch.type === 'Mesh') as THREE.Mesh;
 
-      c.setOpacity(0.5);
+      c.setStrokeOpacity(0.5);
       c._syncToThree();
 
       const mat = mesh.material as THREE.MeshBasicMaterial;

--- a/src/mobjects/text/mathtex.test.ts
+++ b/src/mobjects/text/mathtex.test.ts
@@ -296,18 +296,18 @@ describe('MathTex', () => {
   });
 
   // -----------------------------------------------------------
-  // setOpacity (multi-part propagation)
+  // setStrokeOpacity (multi-part propagation)
   // -----------------------------------------------------------
-  describe('setOpacity', () => {
+  describe('setStrokeOpacity', () => {
     it('should return this for chaining', () => {
       const tex = new MathTex({ latex: 'a' });
-      const result = tex.setOpacity(0.5);
+      const result = tex.setStrokeOpacity(0.5);
       expect(result).toBe(tex);
     });
 
     it('should propagate opacity to multi-part children', () => {
       const tex = new MathTex({ latex: ['a', 'b'] });
-      tex.setOpacity(0.3);
+      tex.setStrokeOpacity(0.3);
       // Children should also have updated opacity
       const partA = tex.getPart(0);
       const partB = tex.getPart(1);
@@ -506,7 +506,7 @@ describe('MathTex', () => {
 
     it('should have correct mesh material with opacity and color', () => {
       const tex = new MathTex({ latex: 'y', color: '#ff0000' });
-      tex.setOpacity(0.5);
+      tex.setStrokeOpacity(0.5);
       const obj = tex.getThreeObject();
       const mesh = obj.children.find((c) => c.type === 'Mesh') as THREE.Mesh;
       expect(mesh).toBeDefined();
@@ -532,7 +532,7 @@ describe('MathTex', () => {
       const obj = tex.getThreeObject();
       const mesh = obj.children.find((c) => c.type === 'Mesh') as THREE.Mesh;
 
-      tex.setOpacity(0.3);
+      tex.setStrokeOpacity(0.3);
       tex._syncToThree();
 
       const material = mesh.material as THREE.MeshBasicMaterial;

--- a/src/utils/utils-system.test.ts
+++ b/src/utils/utils-system.test.ts
@@ -313,10 +313,10 @@ describe('saveMobjectState / restoreMobjectState', () => {
   it('restores from saved state', () => {
     const vm = makeVM();
     vm.position.set(5, 6, 7);
-    vm.setOpacity(0.5);
+    vm.setStrokeOpacity(0.5);
     saveMobjectState(vm);
     vm.position.set(0, 0, 0);
-    vm.setOpacity(1);
+    vm.setStrokeOpacity(1);
     expect(restoreMobjectState(vm)).toBe(true);
     expect(vm.position.x).toBe(5);
     expect(vm.position.y).toBe(6);

--- a/tools/py2ts.cjs
+++ b/tools/py2ts.cjs
@@ -258,7 +258,7 @@ const METHOD_MAP = {
   'set_color': 'setColor',
   'set_fill': 'setFill',
   'set_stroke': 'setStroke',
-  'set_opacity': 'setOpacity',
+  'set_opacity': 'setStrokeOpacity',
   'set_style': 'setStyle',
   'get_center': 'getCenter',
   'get_top': 'getTop',


### PR DESCRIPTION
- Rename setOpacity to setStrokeOpacity across all mobject classes
- Add strokeColor getter/setter to Mobject.ts for proper style access
- Update py2ts.cjs mapping for Python-TS translation
- Update all test files to use new method name

## Summary
Brief description of changes.

## Changes
- ...

## Testing
- [ x] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types check (`npm run typecheck`)
