### PR TITLE
feat: add slidesMode to Player for presentation-style playback

### DIFF
--- a/examples/slides_mode.html
+++ b/examples/slides_mode.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ManimWeb - Slides Mode Demo</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #1a1a2e;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+      color: #ccc;
+    }
+    h1 {
+      margin-bottom: 16px;
+      font-size: 20px;
+      font-weight: 400;
+      color: #fff;
+    }
+    #container {
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .info {
+      margin-top: 20px;
+      font-size: 13px;
+      opacity: 0.6;
+      text-align: center;
+      line-height: 1.6;
+    }
+    kbd {
+      background: #333;
+      border: 1px solid #555;
+      border-radius: 3px;
+      padding: 1px 6px;
+      font-size: 12px;
+      font-family: monospace;
+    }
+    .highlight {
+      color: #6cf;
+      opacity: 1;
+      font-weight: 500;
+    }
+  </style>
+</head>
+<body>
+  <h1>Slides Mode Demo</h1>
+  <div id="container"></div>
+  <div class="info">
+    <p class="highlight">slidesMode: true - each arrow press plays one segment, then pauses</p>
+    <br>
+    <kbd>&rarr;</kbd> Play next segment &nbsp;
+    <kbd>&larr;</kbd> Go to previous segment &nbsp;
+    <kbd>Space</kbd> Play/Pause &nbsp;
+    <kbd>F</kbd> Fullscreen
+  </div>
+
+  <script type="module">
+    import {
+      Player,
+      Circle,
+      Square,
+      Triangle,
+      Create,
+      Transform,
+      FadeIn,
+      FadeOut,
+      Indicate,
+      Rotate,
+      BLACK,
+      BLUE,
+      RED,
+      GREEN,
+    } from '../src/index.ts';
+
+    const container = document.getElementById('container');
+    const player = new Player(container, {
+      width: 800,
+      height: 450,
+      backgroundColor: BLACK,
+      slidesMode: true,
+    });
+
+    player.sequence(async (scene) => {
+      // Slide 1: Create a blue circle
+      const circle = new Circle({ radius: 1.5, color: BLUE });
+      await scene.play(new Create(circle));
+
+      // Slide 2: Brief pause
+      await scene.wait(0.5);
+
+      // Slide 3: Transform to red square
+      const square = new Square({ sideLength: 3, color: RED });
+      await scene.play(new Transform(circle, square));
+
+      // Slide 4: Indicate
+      await scene.play(new Indicate(circle));
+
+      // Slide 5: Transform to green triangle
+      const triangle = new Triangle({ color: GREEN });
+      triangle.scale(2);
+      await scene.play(new Transform(circle, triangle));
+
+      // Slide 6: Rotate
+      await scene.play(new Rotate(circle, { angle: Math.PI }));
+
+      // Slide 7: Fade out
+      await scene.play(new FadeOut(circle));
+
+      // Slide 8: Final pause
+      await scene.wait(1);
+    });
+  </script>
+</body>
+</html>

--- a/src/player/Player.test.ts
+++ b/src/player/Player.test.ts
@@ -354,6 +354,80 @@ describe('Player', () => {
     expect(player.isPlaying).toBe(false);
   });
 
+  // ---- slidesMode option ----
+
+  it('accepts slidesMode option', () => {
+    player.dispose();
+    container.remove();
+    const { player: p, container: c } = createPlayer({ slidesMode: true });
+    expect((p as unknown as { _slidesMode: boolean })._slidesMode).toBe(true);
+    p.dispose();
+    c.remove();
+    const result = createPlayer();
+    player = result.player;
+    container = result.container;
+  });
+
+  it('slidesMode defaults to false', () => {
+    expect((player as unknown as { _slidesMode: boolean })._slidesMode).toBe(false);
+  });
+
+  it('nextSegment in slidesMode plays from current position instead of jumping', async () => {
+    player.dispose();
+    container.remove();
+    const { player: p, container: c } = createPlayer({ slidesMode: true });
+    player = p;
+    container = c;
+
+    await player.sequence(async (scene) => {
+      await scene.wait(1);
+      await scene.wait(1);
+      await scene.wait(1);
+    });
+
+    // In slides mode, nextSegment should start playing (not jump)
+    player.nextSegment();
+    expect(player.isPlaying).toBe(true);
+    // Should still be at 0 (playing, not jumped)
+    expect(player.timeline.getCurrentTime()).toBeCloseTo(0);
+  });
+
+  it('nextSegment in slidesMode does nothing at end of timeline', async () => {
+    player.dispose();
+    container.remove();
+    const { player: p, container: c } = createPlayer({ slidesMode: true });
+    player = p;
+    container = c;
+
+    await player.sequence(async (scene) => {
+      await scene.wait(1);
+    });
+
+    // Seek to end
+    player.seek(1);
+    player.nextSegment();
+    expect(player.isPlaying).toBe(false);
+  });
+
+  it('prevSegment in slidesMode seeks to previous segment and pauses', async () => {
+    player.dispose();
+    container.remove();
+    const { player: p, container: c } = createPlayer({ slidesMode: true });
+    player = p;
+    container = c;
+
+    await player.sequence(async (scene) => {
+      await scene.wait(1);
+      await scene.wait(1);
+    });
+
+    // Seek 0.8s into second segment (>0.5 threshold -> goes to start of current)
+    player.seek(1.8);
+    player.prevSegment();
+    expect(player.isPlaying).toBe(false);
+    expect(player.timeline.getCurrentTime()).toBeCloseTo(1.0);
+  });
+
   // ---- loop option ----
 
   it('accepts loop option without error', () => {
@@ -565,6 +639,45 @@ describe('Player _startLoop render loop', () => {
     flushRaf(20);
 
     expect(mockMob.update).toHaveBeenCalled();
+  });
+
+  it('_startLoop auto-pauses at segment boundary in slidesMode', async () => {
+    player.dispose();
+    container.remove();
+    const result = createPlayer({ slidesMode: true });
+    player = result.player;
+    container = result.container;
+
+    await player.sequence(async (scene) => {
+      await scene.wait(0.5);
+      await scene.wait(0.5);
+    });
+
+    player.play();
+
+    // Flush past the first segment boundary (500ms + buffer)
+    flushRaf(600);
+
+    // In slides mode, should auto-pause at the segment boundary
+    expect(player.isPlaying).toBe(false);
+    // Time should be clamped to the end of the first segment
+    expect(player.timeline.getCurrentTime()).toBeCloseTo(0.5);
+  });
+
+  it('_startLoop does NOT auto-pause at segment boundary without slidesMode', async () => {
+    await player.sequence(async (scene) => {
+      await scene.wait(0.5);
+      await scene.wait(0.5);
+    });
+
+    player.play();
+
+    // Flush past the first segment boundary
+    flushRaf(600);
+
+    // Without slides mode, should keep playing (or finish naturally)
+    // The timeline total is 1s, 600ms elapsed means it's still going
+    expect(player.isPlaying).toBe(true);
   });
 
   it('_startLoop applies playback rate to dt', async () => {

--- a/src/player/Player.ts
+++ b/src/player/Player.ts
@@ -36,6 +36,8 @@ export interface PlayerOptions extends SceneOptions {
   autoPlay?: boolean;
   /** Loop playback. Default false. */
   loop?: boolean;
+  /** Slides mode: arrows play/pause at segment boundaries like a presentation. Default false. */
+  slidesMode?: boolean;
 }
 
 /**
@@ -138,6 +140,8 @@ export class Player {
   private _container: HTMLElement;
   private _loop: boolean;
   private _autoPlay: boolean;
+  private _slidesMode: boolean;
+  private _slidesTargetSegmentIndex: number = -1;
   private _origWidth: number = 0;
   private _origHeight: number = 0;
   private _onFullscreenChange: () => void;
@@ -146,6 +150,7 @@ export class Player {
     this._container = container;
     this._loop = options.loop ?? false;
     this._autoPlay = options.autoPlay ?? false;
+    this._slidesMode = options.slidesMode ?? false;
 
     // Create the underlying scene
     this._scene = new Scene(container, options);
@@ -257,6 +262,12 @@ export class Player {
     this._isPlaying = true;
     this._masterTimeline.play();
     this._ui.setPlaying(true);
+    if (this._slidesMode && this._slidesTargetSegmentIndex < 0) {
+      const current = this._masterTimeline.getCurrentSegment();
+      if (current) {
+        this._slidesTargetSegmentIndex = current.index;
+      }
+    }
     this._startLoop();
   }
 
@@ -284,8 +295,19 @@ export class Player {
     this._ui.updateTime(this._masterTimeline.getCurrentTime(), this._masterTimeline.getDuration());
   }
 
-  /** Jump to the next segment. Pauses playback (YouTube-style). */
+  /** Jump to the next segment. In slidesMode, plays current segment instead. */
   nextSegment(): void {
+    if (this._slidesMode) {
+      const current = this._masterTimeline.getCurrentSegment();
+      if (!current) return;
+      const nextIdx = current.index + 1;
+      // If already at last segment and past its end, do nothing
+      if (nextIdx >= this._masterTimeline.segmentCount && this._masterTimeline.isFinished()) return;
+      // Set the target: pause when we reach the end of the current segment
+      this._slidesTargetSegmentIndex = current.index;
+      if (!this._isPlaying) this.play();
+      return;
+    }
     if (this._isPlaying) this.pause();
     const seg = this._masterTimeline.nextSegment();
     if (seg) {
@@ -297,9 +319,10 @@ export class Player {
     }
   }
 
-  /** Jump to the previous segment. Pauses playback (YouTube-style). */
+  /** Jump to the previous segment. Pauses playback. */
   prevSegment(): void {
     if (this._isPlaying) this.pause();
+    this._slidesTargetSegmentIndex = -1;
     const prev = this._masterTimeline.prevSegment();
     if (prev) {
       this._scene.render();
@@ -400,6 +423,26 @@ export class Player {
         this._masterTimeline.getCurrentTime(),
         this._masterTimeline.getDuration(),
       );
+
+      // In slides mode, auto-pause at the target segment boundary
+      if (this._slidesMode && this._slidesTargetSegmentIndex >= 0) {
+        const segments = this._masterTimeline.getSegments();
+        const targetSeg = segments[this._slidesTargetSegmentIndex];
+        if (targetSeg && this._masterTimeline.getCurrentTime() >= targetSeg.endTime) {
+          this._masterTimeline.seek(targetSeg.endTime);
+          this._scene.render();
+          this._ui.updateTime(
+            this._masterTimeline.getCurrentTime(),
+            this._masterTimeline.getDuration(),
+          );
+          this._slidesTargetSegmentIndex = -1;
+          this._isPlaying = false;
+          this._masterTimeline.pause();
+          this._ui.setPlaying(false);
+          this._stopLoop();
+          return;
+        }
+      }
 
       // Check if finished
       if (this._masterTimeline.isFinished()) {


### PR DESCRIPTION
## Summary
- Adds `slidesMode` option to `PlayerOptions` — when enabled, arrow keys play one segment at a time and auto-pause at each segment boundary, like a slide presentation
- In slides mode, `nextSegment()` starts playback instead of jumping, and the render loop auto-pauses when crossing the target segment's end time
- Includes 7 new tests and an example page (`examples/slides_mode.html`)

Closes #215

## Test plan
- [x] All 75 Player tests pass (7 new slides mode tests)
- [x] Full suite: 5686 tests pass, 0 failures
- [ ] Manual: open `examples/slides_mode.html`, press right arrow to advance one slide at a time
- [ ] Manual: compare with `examples/player.html` to see normal (non-slides) behavior