### PR TITLE
feat: enable slidesMode in docs Player example

### DIFF
--- a/docs/docs/examples.mdx
+++ b/docs/docs/examples.mdx
@@ -45,7 +45,7 @@ Interactive examples showing what you can build with manim-web. Each example inc
 
 ## Integrated Player
 
-A full-featured playback controller with play/pause, segment navigation, timeline scrubbing, speed control, fullscreen, and export. Use <kbd>Space</kbd> to play/pause, <kbd>&larr;</kbd>/<kbd>&rarr;</kbd> for segments, <kbd>Shift+&larr;/&rarr;</kbd> to scrub, and <kbd>F</kbd> for fullscreen.
+A full-featured playback controller with play/pause, segment navigation, timeline scrubbing, speed control, fullscreen, and export. This example uses `slidesMode: true`, so each <kbd>&rarr;</kbd> press plays one segment then pauses — like a presentation. Use <kbd>Space</kbd> to play/pause, <kbd>&larr;</kbd>/<kbd>&rarr;</kbd> for segments, <kbd>Shift+&larr;/&rarr;</kbd> to scrub, and <kbd>F</kbd> for fullscreen.
 
 <PlayerExample />
 
@@ -75,6 +75,7 @@ const player = new Player(document.getElementById('container'), {
   width: 800,
   height: 450,
   backgroundColor: BLACK,
+  slidesMode: true,
 });
 
 player.sequence(async (scene) => {

--- a/docs/src/components/examples/PlayerExample.tsx
+++ b/docs/src/components/examples/PlayerExample.tsx
@@ -64,6 +64,7 @@ function PlayerExampleInner() {
         width,
         height,
         backgroundColor: BLACK,
+        slidesMode: true,
       });
 
       if (disposed) {


### PR DESCRIPTION
## Summary
- Enables `slidesMode: true` in the Integrated Player example on the docs site
- Updates the description text to explain the slides mode behavior
- Visitors can now see presentation-style playback (arrow keys play one segment then pause) in action

Relates to #215, #216

## Test plan
- [ ] Visit docs examples page, press → to advance one slide at a time
- [ ] Verify the player pauses at each segment boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)