### PR TITLE
feat: add slides mode toggle button to Player UI

### DIFF
--- a/docs/docs/examples.mdx
+++ b/docs/docs/examples.mdx
@@ -45,7 +45,7 @@ Interactive examples showing what you can build with manim-web. Each example inc
 
 ## Integrated Player
 
-A full-featured playback controller with play/pause, segment navigation, timeline scrubbing, speed control, fullscreen, and export. This example uses `slidesMode: true`, so each <kbd>&rarr;</kbd> press plays one segment then pauses — like a presentation. Use <kbd>Space</kbd> to play/pause, <kbd>&larr;</kbd>/<kbd>&rarr;</kbd> for segments, <kbd>Shift+&larr;/&rarr;</kbd> to scrub, and <kbd>F</kbd> for fullscreen.
+A full-featured playback controller with play/pause, segment navigation, timeline scrubbing, speed control, fullscreen, and export. Toggle slides mode with the slides button or <kbd>S</kbd> key — when active, each <kbd>&rarr;</kbd> press plays one segment then pauses, like a presentation. Use <kbd>Space</kbd> to play/pause, <kbd>&larr;</kbd>/<kbd>&rarr;</kbd> for segments, <kbd>Shift+&larr;/&rarr;</kbd> to scrub, and <kbd>F</kbd> for fullscreen.
 
 <PlayerExample />
 
@@ -75,7 +75,6 @@ const player = new Player(document.getElementById('container'), {
   width: 800,
   height: 450,
   backgroundColor: BLACK,
-  slidesMode: true,
 });
 
 player.sequence(async (scene) => {

--- a/docs/src/components/examples/PlayerExample.tsx
+++ b/docs/src/components/examples/PlayerExample.tsx
@@ -64,7 +64,6 @@ function PlayerExampleInner() {
         width,
         height,
         backgroundColor: BLACK,
-        slidesMode: true,
       });
 
       if (disposed) {

--- a/src/player/Player.ts
+++ b/src/player/Player.ts
@@ -169,11 +169,15 @@ export class Player {
         onSpeedChange: (r) => this.setPlaybackRate(r),
         onFullscreen: () => this.toggleFullscreen(),
         onExport: (format) => this.exportAs(format),
+        onSlidesToggle: (enabled) => this.setSlidesMode(enabled),
       },
       {
         autoHideMs: options.autoHideMs,
       },
     );
+
+    // Sync initial slides mode state
+    this._ui.setSlidesMode(this._slidesMode);
 
     // Enable scroll-to-scrub
     this._ui.enableScrollScrub(() => this._masterTimeline.getCurrentTime());
@@ -185,6 +189,7 @@ export class Player {
       onNext: () => this.nextSegment(),
       onSeek: (t) => this.seek(t),
       onFullscreen: () => this.toggleFullscreen(),
+      onSlidesToggle: () => this.setSlidesMode(!this._slidesMode),
       getCurrentTime: () => this._masterTimeline.getCurrentTime(),
       getDuration: () => this._masterTimeline.getDuration(),
     });
@@ -336,6 +341,12 @@ export class Player {
   /** Set the playback speed multiplier. */
   setPlaybackRate(rate: number): void {
     this._playbackRate = rate;
+  }
+
+  /** Enable or disable slides (presentation) mode at runtime. */
+  setSlidesMode(enabled: boolean): void {
+    this._slidesMode = enabled;
+    this._ui.setSlidesMode(enabled);
   }
 
   /** Export the animation in the given format (gif, webm, mp4). */

--- a/src/player/PlayerController.ts
+++ b/src/player/PlayerController.ts
@@ -9,6 +9,7 @@ export interface PlayerControllerCallbacks {
   onNext: () => void;
   onSeek: (time: number) => void;
   onFullscreen: () => void;
+  onSlidesToggle: () => void;
   getCurrentTime: () => number;
   getDuration: () => number;
 }
@@ -81,6 +82,11 @@ export class PlayerController {
       case 'F':
         e.preventDefault();
         this._callbacks.onFullscreen();
+        break;
+      case 's':
+      case 'S':
+        e.preventDefault();
+        this._callbacks.onSlidesToggle();
         break;
       case 'Home':
         e.preventDefault();

--- a/src/player/PlayerUI.ts
+++ b/src/player/PlayerUI.ts
@@ -14,6 +14,7 @@ export interface PlayerUICallbacks {
   onSpeedChange: (rate: number) => void;
   onFullscreen: () => void;
   onExport: (format: string) => void;
+  onSlidesToggle: (enabled: boolean) => void;
 }
 
 export interface PlayerUIOptions {
@@ -33,6 +34,8 @@ export class PlayerUI {
   private _timeDisplay: HTMLElement;
   private _speedSelect: HTMLSelectElement;
   private _fullscreenBtn: HTMLButtonElement;
+  private _slidesBtn: HTMLButtonElement;
+  private _slidesActive: boolean = false;
   private _exportBtn: HTMLButtonElement;
   private _exportMenu: HTMLElement | null = null;
   private _exportMenuBackdrop: HTMLElement | null = null;
@@ -76,6 +79,7 @@ export class PlayerUI {
     this._timeDisplay = this._createTimeDisplay();
     this._speedSelect = this._createSpeedSelect();
     this._fullscreenBtn = this._createFullscreenBtn();
+    this._slidesBtn = this._createSlidesBtn();
     this._exportBtn = this._createExportBtn();
 
     // Assemble
@@ -95,6 +99,7 @@ export class PlayerUI {
     });
     rightGroup.appendChild(this._timeDisplay);
     rightGroup.appendChild(this._speedSelect);
+    rightGroup.appendChild(this._slidesBtn);
     // Export button is wrapped in a positioned container for the dropdown menu
     rightGroup.appendChild(this._exportBtnWrapper!);
     rightGroup.appendChild(this._fullscreenBtn);
@@ -164,6 +169,13 @@ export class PlayerUI {
     if (playing) {
       this._scheduleHide();
     }
+  }
+
+  setSlidesMode(enabled: boolean): void {
+    this._slidesActive = enabled;
+    this._slidesBtn.style.opacity = enabled ? '1' : '0.4';
+    this._slidesBtn.style.background = enabled ? 'rgba(74,158,255,0.25)' : 'none';
+    this._slidesBtn.title = `Slides mode ${enabled ? 'on' : 'off'} (S)`;
   }
 
   setSegments(timeline: MasterTimeline): void {
@@ -489,6 +501,29 @@ export class PlayerUI {
     }
   }
 
+  private _createSlidesBtn(): HTMLButtonElement {
+    const btn = document.createElement('button');
+    btn.innerHTML = SLIDES_ICON;
+    btn.title = 'Slides mode off (S)';
+    applyBtnStyle(btn, '28px', '28px');
+    btn.style.opacity = '0.4';
+    btn.addEventListener('click', () => {
+      this._slidesActive = !this._slidesActive;
+      this.setSlidesMode(this._slidesActive);
+      this._callbacks.onSlidesToggle(this._slidesActive);
+    });
+    // Override the default hover to preserve active background
+    btn.addEventListener('mouseenter', () => {
+      btn.style.background = this._slidesActive
+        ? 'rgba(74,158,255,0.35)'
+        : 'rgba(255,255,255,0.15)';
+    });
+    btn.addEventListener('mouseleave', () => {
+      btn.style.background = this._slidesActive ? 'rgba(74,158,255,0.25)' : 'none';
+    });
+    return btn;
+  }
+
   private _createFullscreenBtn(): HTMLButtonElement {
     const btn = document.createElement('button');
     btn.innerHTML = FULLSCREEN_ICON;
@@ -664,5 +699,7 @@ const PREV_ICON = `<svg width="16" height="16" viewBox="0 0 16 16" fill="current
 const NEXT_ICON = `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><rect x="12" y="3" width="2" height="10"/><path d="M2 3l8 5-8 5V3z"/></svg>`;
 
 const EXPORT_ICON = `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1L8 10M8 10L5 7M8 10L11 7" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/><path d="M3 12v1h10v-1" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round"/></svg>`;
+
+const SLIDES_ICON = `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="2" width="14" height="10" rx="1.5" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M5 14h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M6 6l5 3-5 3V6z"/></svg>`;
 
 const FULLSCREEN_ICON = `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M2 2h4v2H4v2H2V2zm8 0h4v4h-2V4h-2V2zM2 10h2v2h2v2H2v-4zm10 2h-2v2h4v-4h-2v2z"/></svg>`;


### PR DESCRIPTION
## Summary
- Adds a toggle button in the Player controls bar to switch between normal and slides mode at runtime
- Press `S` key or click the button to toggle
- Button shows blue highlight when active, dimmed when inactive
- Removes hardcoded `slidesMode: true` from docs example (users can now toggle it themselves)

## Test plan
- [ ] Open Player example, click the slides toggle button — it highlights blue
- [ ] Press → to play one segment, verify it pauses at segment boundary
- [ ] Click toggle again to disable, press → to jump to next segment instantly
- [ ] Press S key to toggle slides mode on/off
- [ ] All 75 Player tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)