### PR TITLE
feat: support aboutPoint and aboutEdge for more transforms

### DIFF
--- a/src/animation/aboutEdgeAnimations.test.ts
+++ b/src/animation/aboutEdgeAnimations.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { VMobject } from '../core/VMobject';
+import { Rotate } from './movement/Rotate';
+import { Scale } from './movement/Scale';
+import { Rotating } from './utility/index';
+
+function makeUnitSquare(): VMobject {
+  const vm = new VMobject();
+  vm.setPoints([
+    [-1, -1, 0],
+    [-1, 1, 0],
+    [1, 1, 0],
+    [1, -1, 0],
+  ]);
+  return vm;
+}
+
+describe('Rotate animation with aboutEdge (#218)', () => {
+  it('accepts aboutEdge option', () => {
+    const vm = makeUnitSquare();
+    const anim = new Rotate(vm, { angle: Math.PI / 2, aboutEdge: [1, 0, 0] });
+    // aboutEdge [1,0,0] should resolve to the right edge center [1,0,0]
+    expect(anim.aboutPoint).toBeDefined();
+    expect(anim.aboutPoint![0]).toBeCloseTo(1);
+    expect(anim.aboutPoint![1]).toBeCloseTo(0);
+    expect(anim.aboutPoint![2]).toBeCloseTo(0);
+  });
+
+  it('throws when both aboutPoint and aboutEdge are provided', () => {
+    const vm = makeUnitSquare();
+    expect(
+      () =>
+        new Rotate(vm, {
+          angle: Math.PI / 2,
+          aboutPoint: [0, 0, 0],
+          aboutEdge: [1, 0, 0],
+        }),
+    ).toThrow();
+  });
+});
+
+describe('Scale animation with aboutEdge (#218)', () => {
+  it('accepts aboutEdge option', () => {
+    const vm = makeUnitSquare();
+    const anim = new Scale(vm, { scaleFactor: 2, aboutEdge: [0, 1, 0] });
+    // aboutEdge [0,1,0] should resolve to top edge center [0,1,0]
+    expect(anim.aboutPoint).toBeDefined();
+    expect(anim.aboutPoint![0]).toBeCloseTo(0);
+    expect(anim.aboutPoint![1]).toBeCloseTo(1);
+    expect(anim.aboutPoint![2]).toBeCloseTo(0);
+  });
+
+  it('throws when both aboutPoint and aboutEdge are provided', () => {
+    const vm = makeUnitSquare();
+    expect(
+      () =>
+        new Scale(vm, {
+          scaleFactor: 2,
+          aboutPoint: [0, 0, 0],
+          aboutEdge: [1, 0, 0],
+        }),
+    ).toThrow();
+  });
+});
+
+describe('Rotating animation with aboutEdge (#218)', () => {
+  it('accepts aboutEdge option', () => {
+    const vm = makeUnitSquare();
+    const anim = new Rotating(vm, { aboutEdge: [1, 0, 0] });
+    // aboutEdge [1,0,0] should resolve to the right edge center [1,0,0]
+    expect(anim.aboutPoint).toBeDefined();
+    expect(anim.aboutPoint![0]).toBeCloseTo(1);
+    expect(anim.aboutPoint![1]).toBeCloseTo(0);
+    expect(anim.aboutPoint![2]).toBeCloseTo(0);
+  });
+
+  it('throws when both aboutPoint and aboutEdge are provided', () => {
+    const vm = makeUnitSquare();
+    expect(
+      () =>
+        new Rotating(vm, {
+          aboutPoint: [0, 0, 0],
+          aboutEdge: [1, 0, 0],
+        }),
+    ).toThrow();
+  });
+});

--- a/src/animation/movement/Rotate.ts
+++ b/src/animation/movement/Rotate.ts
@@ -5,7 +5,7 @@
 import * as THREE from 'three';
 import { Mobject, Vector3Tuple } from '../../core/Mobject';
 import { Animation, AnimationOptions } from '../Animation';
-import { resolveAboutPoint } from '../../core/MobjectState';
+import { resolveExtremalPoint } from '../../core/MobjectState';
 
 export interface RotateOptions extends AnimationOptions {
   /** Angle to rotate in radians */
@@ -44,7 +44,7 @@ export class Rotate extends Animation {
     super(mobject, options);
     this.angle = options.angle;
     this.axis = options.axis ?? [0, 0, 1];
-    const resolved = resolveAboutPoint(mobject, options);
+    const resolved = resolveExtremalPoint(mobject, options);
     this.aboutPoint = resolved ?? null;
   }
 

--- a/src/animation/movement/Rotate.ts
+++ b/src/animation/movement/Rotate.ts
@@ -5,6 +5,7 @@
 import * as THREE from 'three';
 import { Mobject, Vector3Tuple } from '../../core/Mobject';
 import { Animation, AnimationOptions } from '../Animation';
+import { resolveAboutPoint } from '../../core/MobjectState';
 
 export interface RotateOptions extends AnimationOptions {
   /** Angle to rotate in radians */
@@ -13,6 +14,8 @@ export interface RotateOptions extends AnimationOptions {
   axis?: Vector3Tuple;
   /** Point to rotate about, defaults to mobject center */
   aboutPoint?: Vector3Tuple;
+  /** Edge to rotate about, resolved via bounding box. Mutually exclusive with aboutPoint. */
+  aboutEdge?: Vector3Tuple;
 }
 
 export class Rotate extends Animation {
@@ -41,7 +44,8 @@ export class Rotate extends Animation {
     super(mobject, options);
     this.angle = options.angle;
     this.axis = options.axis ?? [0, 0, 1];
-    this.aboutPoint = options.aboutPoint ?? null;
+    const resolved = resolveAboutPoint(mobject, options);
+    this.aboutPoint = resolved ?? null;
   }
 
   /**

--- a/src/animation/movement/Scale.ts
+++ b/src/animation/movement/Scale.ts
@@ -5,7 +5,7 @@
 import * as THREE from 'three';
 import { Mobject, Vector3Tuple } from '../../core/Mobject';
 import { Animation, AnimationOptions } from '../Animation';
-import { resolveAboutPoint } from '../../core/MobjectState';
+import { resolveExtremalPoint } from '../../core/MobjectState';
 
 export interface ScaleOptions extends AnimationOptions {
   /** Scale factor: number for uniform scale, tuple for per-axis scale */
@@ -45,7 +45,7 @@ export class Scale extends Animation {
   constructor(mobject: Mobject, options: ScaleOptions) {
     super(mobject, options);
     this.scaleFactor = options.scaleFactor;
-    const resolved = resolveAboutPoint(mobject, options);
+    const resolved = resolveExtremalPoint(mobject, options);
     this.aboutPoint = resolved ?? null;
   }
 

--- a/src/animation/movement/Scale.ts
+++ b/src/animation/movement/Scale.ts
@@ -5,12 +5,15 @@
 import * as THREE from 'three';
 import { Mobject, Vector3Tuple } from '../../core/Mobject';
 import { Animation, AnimationOptions } from '../Animation';
+import { resolveAboutPoint } from '../../core/MobjectState';
 
 export interface ScaleOptions extends AnimationOptions {
   /** Scale factor: number for uniform scale, tuple for per-axis scale */
   scaleFactor: number | Vector3Tuple;
   /** Point to scale about, defaults to mobject center */
   aboutPoint?: Vector3Tuple;
+  /** Edge to scale about, resolved via bounding box. Mutually exclusive with aboutPoint. */
+  aboutEdge?: Vector3Tuple;
 }
 
 /**
@@ -42,7 +45,8 @@ export class Scale extends Animation {
   constructor(mobject: Mobject, options: ScaleOptions) {
     super(mobject, options);
     this.scaleFactor = options.scaleFactor;
-    this.aboutPoint = options.aboutPoint ?? null;
+    const resolved = resolveAboutPoint(mobject, options);
+    this.aboutPoint = resolved ?? null;
   }
 
   /**

--- a/src/animation/utility/index.ts
+++ b/src/animation/utility/index.ts
@@ -12,6 +12,7 @@ import * as THREE from 'three';
 import { Mobject, Vector3Tuple } from '../../core/Mobject';
 import { Animation, AnimationOptions } from '../Animation';
 import { linear } from '../../rate-functions';
+import { resolveAboutPoint } from '../../core/MobjectState';
 
 // ============================================================================
 // Add Animation
@@ -149,6 +150,8 @@ export interface RotatingOptions extends AnimationOptions {
   axis?: Vector3Tuple;
   /** Point to rotate about. Default: mobject center */
   aboutPoint?: Vector3Tuple;
+  /** Edge to rotate about, resolved via bounding box. Mutually exclusive with aboutPoint. */
+  aboutEdge?: Vector3Tuple;
 }
 
 /**
@@ -185,7 +188,8 @@ export class Rotating extends Animation {
     });
     this.angle = options.angle ?? 2 * Math.PI; // Default: TAU (full revolution)
     this.axis = options.axis ?? [0, 0, 1];
-    this.aboutPoint = options.aboutPoint ?? null;
+    const resolved = resolveAboutPoint(mobject, options);
+    this.aboutPoint = resolved ?? null;
   }
 
   /**

--- a/src/animation/utility/index.ts
+++ b/src/animation/utility/index.ts
@@ -12,7 +12,7 @@ import * as THREE from 'three';
 import { Mobject, Vector3Tuple } from '../../core/Mobject';
 import { Animation, AnimationOptions } from '../Animation';
 import { linear } from '../../rate-functions';
-import { resolveAboutPoint } from '../../core/MobjectState';
+import { resolveExtremalPoint } from '../../core/MobjectState';
 
 // ============================================================================
 // Add Animation
@@ -188,7 +188,7 @@ export class Rotating extends Animation {
     });
     this.angle = options.angle ?? 2 * Math.PI; // Default: TAU (full revolution)
     this.axis = options.axis ?? [0, 0, 1];
-    const resolved = resolveAboutPoint(mobject, options);
+    const resolved = resolveExtremalPoint(mobject, options);
     this.aboutPoint = resolved ?? null;
   }
 

--- a/src/core/Mobject.ts
+++ b/src/core/Mobject.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import * as THREE from 'three';
 import { type Vector3Tuple, type MobjectStyle, UP, DOWN, LEFT, RIGHT } from './MobjectTypes';
 import {
@@ -15,6 +16,7 @@ import {
   applyFunctionImpl,
   applyMatrixImpl,
   prepareForNonlinearTransformImpl,
+  resolveAboutPoint,
 } from './MobjectState';
 // AnimateProxy registers itself here to break the circular dependency:
 // Mobject -> AnimateProxy -> Transform -> VGroup -> Mobject
@@ -229,13 +231,21 @@ export abstract class Mobject {
   }
 
   /**
-   * Rotate the mobject around an axis.
-   * Delegates to rotateMobject for the heavy lifting.
+   * Rotate the mobject by angle around an axis.
+   * Accepts aboutPoint or aboutEdge to specify the rotation center.
    */
   rotate(
     angle: number,
-    axisOrOptions?: Vector3Tuple | { axis?: Vector3Tuple; aboutPoint?: Vector3Tuple },
+    axisOrOptions?:
+      | Vector3Tuple
+      | { axis?: Vector3Tuple; aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
   ): this {
+    if (axisOrOptions && !Array.isArray(axisOrOptions)) {
+      const resolved = resolveAboutPoint(this, axisOrOptions);
+      if (resolved) {
+        axisOrOptions = { axis: axisOrOptions.axis, aboutPoint: resolved };
+      }
+    }
     rotateMobject(this, angle, axisOrOptions);
     return this;
   }
@@ -244,7 +254,25 @@ export abstract class Mobject {
     return this.rotate(angle, { axis, aboutPoint: [0, 0, 0] });
   }
 
-  flip(axis: Vector3Tuple = [1, 0, 0]): this {
+  flip(
+    axis: Vector3Tuple = [1, 0, 0],
+    options?: { aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
+  ): this {
+    const aboutPt = resolveAboutPoint(this, options);
+    if (aboutPt) {
+      applyFunctionImpl(
+        this,
+        (p) => {
+          return [
+            axis[0] !== 0 ? -p[0] : p[0],
+            axis[1] !== 0 ? -p[1] : p[1],
+            axis[2] !== 0 ? -p[2] : p[2],
+          ];
+        },
+        { aboutPoint: aboutPt },
+      );
+      return this;
+    }
     if (axis[0] !== 0) this.scaleVector.x *= -1;
     if (axis[1] !== 0) this.scaleVector.y *= -1;
     if (axis[2] !== 0) this.scaleVector.z *= -1;
@@ -252,7 +280,22 @@ export abstract class Mobject {
     return this;
   }
 
-  scale(factor: number | Vector3Tuple): this {
+  scale(
+    factor: number | Vector3Tuple,
+    options?: { aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
+  ): this {
+    const aboutPt = resolveAboutPoint(this, options);
+    if (aboutPt) {
+      const f = typeof factor === 'number' ? [factor, factor, factor] : factor;
+      applyFunctionImpl(
+        this,
+        (p) => {
+          return [p[0] * f[0], p[1] * f[1], p[2] * (f[2] === 0 ? 1 : f[2])];
+        },
+        { aboutPoint: aboutPt },
+      );
+      return this;
+    }
     if (typeof factor === 'number') {
       this.scaleVector.multiplyScalar(factor);
     } else {
@@ -262,6 +305,23 @@ export abstract class Mobject {
     }
     this._markDirty();
     return this;
+  }
+
+  stretch(
+    factor: number,
+    dim: number,
+    options?: { aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
+  ): this {
+    if (dim < 0 || dim > 2 || !Number.isInteger(dim)) {
+      throw new Error(`stretch dim must be 0, 1, or 2, got ${dim}`);
+    }
+    const scaleFactors: Vector3Tuple = [1, 1, 1];
+    scaleFactors[dim] = factor;
+    // Always scale about a point so the underlying points are modified
+    // (non-uniform scaling via scaleVector would not affect getPoints()).
+    const opts =
+      options?.aboutPoint || options?.aboutEdge ? options : { aboutPoint: this.getCenter() };
+    return this.scale(scaleFactors, opts);
   }
 
   // ── Hierarchy ────────────────────────────────────────────────────
@@ -544,8 +604,11 @@ export abstract class Mobject {
 
   // ── Point-wise Transforms ────────────────────────────────────────
 
-  applyFunction(fn: (point: number[]) => number[]): this {
-    applyFunctionImpl(this, fn);
+  applyFunction(
+    fn: (point: number[]) => number[],
+    options?: { aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
+  ): this {
+    applyFunctionImpl(this, fn, options);
     return this;
   }
 

--- a/src/core/Mobject.ts
+++ b/src/core/Mobject.ts
@@ -16,7 +16,7 @@ import {
   applyFunctionImpl,
   applyMatrixImpl,
   prepareForNonlinearTransformImpl,
-  resolveAboutPoint,
+  resolveExtremalPoint,
 } from './MobjectState';
 // AnimateProxy registers itself here to break the circular dependency:
 // Mobject -> AnimateProxy -> Transform -> VGroup -> Mobject
@@ -241,7 +241,7 @@ export abstract class Mobject {
       | { axis?: Vector3Tuple; aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
   ): this {
     if (axisOrOptions && !Array.isArray(axisOrOptions)) {
-      const resolved = resolveAboutPoint(this, axisOrOptions);
+      const resolved = resolveExtremalPoint(this, axisOrOptions);
       if (resolved) {
         axisOrOptions = { axis: axisOrOptions.axis, aboutPoint: resolved };
       }
@@ -258,7 +258,7 @@ export abstract class Mobject {
     axis: Vector3Tuple = [1, 0, 0],
     options?: { aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
   ): this {
-    const aboutPt = resolveAboutPoint(this, options);
+    const aboutPt = resolveExtremalPoint(this, options);
     if (aboutPt) {
       applyFunctionImpl(
         this,
@@ -284,7 +284,7 @@ export abstract class Mobject {
     factor: number | Vector3Tuple,
     options?: { aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
   ): this {
-    const aboutPt = resolveAboutPoint(this, options);
+    const aboutPt = resolveExtremalPoint(this, options);
     if (aboutPt) {
       const f = typeof factor === 'number' ? [factor, factor, factor] : factor;
       applyFunctionImpl(

--- a/src/core/MobjectState.ts
+++ b/src/core/MobjectState.ts
@@ -125,10 +125,95 @@ export function replaceMobjectImpl(mob: MobjectLike, target: MobjectLike, stretc
 }
 
 /**
+ * Compute bounding box from raw control points of all family members.
+ * Falls back to mob.getCenter()/getBoundingBox() when no points are available.
+ */
+function pointsBoundingBox(mob: MobjectLike): {
+  center: Vector3Tuple;
+  width: number;
+  height: number;
+  depth: number;
+} {
+  let minX = Infinity,
+    minY = Infinity,
+    minZ = Infinity;
+  let maxX = -Infinity,
+    maxY = -Infinity,
+    maxZ = -Infinity;
+  let hasPoints = false;
+
+  for (const m of mob.getFamily()) {
+    const asAny = m as unknown as { getPoints?: () => number[][] };
+    if (typeof asAny.getPoints === 'function') {
+      for (const p of asAny.getPoints()) {
+        hasPoints = true;
+        if (p[0] < minX) minX = p[0];
+        if (p[0] > maxX) maxX = p[0];
+        if (p[1] < minY) minY = p[1];
+        if (p[1] > maxY) maxY = p[1];
+        if (p[2] < minZ) minZ = p[2];
+        if (p[2] > maxZ) maxZ = p[2];
+      }
+    }
+  }
+
+  if (!hasPoints) {
+    const center = mob.getCenter();
+    const bounds = mob.getBoundingBox();
+    return { center, ...bounds };
+  }
+
+  return {
+    center: [(minX + maxX) / 2, (minY + maxY) / 2, (minZ + maxZ) / 2],
+    width: maxX - minX,
+    height: maxY - minY,
+    depth: maxZ - minZ,
+  };
+}
+
+/**
+ * Resolve aboutPoint from options, converting aboutEdge to an actual point
+ * using the mobject's bounding box when needed.
+ */
+export function resolveAboutPoint(
+  mob: MobjectLike,
+  options?: { aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
+): Vector3Tuple | undefined {
+  if (options?.aboutPoint && options?.aboutEdge) {
+    throw new Error('Cannot specify both aboutPoint and aboutEdge');
+  }
+  if (options?.aboutPoint) return options.aboutPoint;
+  if (options?.aboutEdge) {
+    const bb = pointsBoundingBox(mob);
+    return [
+      bb.center[0] + (Math.sign(options.aboutEdge[0]) * bb.width) / 2,
+      bb.center[1] + (Math.sign(options.aboutEdge[1]) * bb.height) / 2,
+      bb.center[2] + (Math.sign(options.aboutEdge[2]) * bb.depth) / 2,
+    ];
+  }
+  return undefined;
+}
+
+/**
  * Apply a point-wise function to every VMobject descendant's control points.
+ * When aboutPoint or aboutEdge is provided, points are translated so the anchor
+ * is at the origin before applying fn, then translated back.
  * Uses duck-type check for getPoints/setPoints to avoid circular imports.
  */
-export function applyFunctionImpl(mob: MobjectLike, fn: (point: number[]) => number[]): void {
+export function applyFunctionImpl(
+  mob: MobjectLike,
+  fn: (point: number[]) => number[],
+  options?: { aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
+): void {
+  const aboutPt = resolveAboutPoint(mob, options);
+  const wrappedFn = aboutPt
+    ? (p: number[]) => {
+        const translated = [p[0] - aboutPt[0], p[1] - aboutPt[1], p[2] - aboutPt[2]];
+        const result = fn(translated);
+        return [result[0] + aboutPt[0], result[1] + aboutPt[1], result[2] + aboutPt[2]];
+      }
+    : fn;
+
   for (const m of mob.getFamily()) {
     const asAny = m as unknown as {
       getPoints?: () => number[][];
@@ -137,7 +222,7 @@ export function applyFunctionImpl(mob: MobjectLike, fn: (point: number[]) => num
     if (typeof asAny.getPoints === 'function' && typeof asAny.setPoints === 'function') {
       const pts = asAny.getPoints();
       if (pts.length > 0) {
-        asAny.setPoints(pts.map((p) => fn([...p])));
+        asAny.setPoints(pts.map((p) => wrappedFn([...p])));
       }
     }
   }
@@ -152,21 +237,10 @@ export function applyMatrixImpl(
   matrix: number[][],
   options?: { aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
 ): void {
-  let aboutPoint: Vector3Tuple;
-  if (options?.aboutPoint) {
-    aboutPoint = options.aboutPoint;
-  } else if (options?.aboutEdge) {
-    const center = mob.getCenter();
-    const bounds = mob.getBoundingBox();
-    aboutPoint = [
-      center[0] + (Math.sign(options.aboutEdge[0]) * bounds.width) / 2,
-      center[1] + (Math.sign(options.aboutEdge[1]) * bounds.height) / 2,
-      center[2] + (Math.sign(options.aboutEdge[2]) * bounds.depth) / 2,
-    ];
-  } else {
-    aboutPoint = [0, 0, 0];
-  }
+  const aboutPoint: Vector3Tuple = resolveAboutPoint(mob, options) ?? [0, 0, 0];
 
+  // aboutPoint is baked into the transform function — do NOT pass options
+  // to applyFunctionImpl, or the translation would be applied twice.
   applyFunctionImpl(mob, (point) => transformPointByMatrix(point, matrix, aboutPoint));
 }
 

--- a/src/core/MobjectState.ts
+++ b/src/core/MobjectState.ts
@@ -175,7 +175,7 @@ function pointsBoundingBox(mob: MobjectLike): {
  * Resolve aboutPoint from options, converting aboutEdge to an actual point
  * using the mobject's bounding box when needed.
  */
-export function resolveAboutPoint(
+export function resolveExtremalPoint(
   mob: MobjectLike,
   options?: { aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
 ): Vector3Tuple | undefined {
@@ -205,7 +205,7 @@ export function applyFunctionImpl(
   fn: (point: number[]) => number[],
   options?: { aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
 ): void {
-  const aboutPt = resolveAboutPoint(mob, options);
+  const aboutPt = resolveExtremalPoint(mob, options);
   const wrappedFn = aboutPt
     ? (p: number[]) => {
         const translated = [p[0] - aboutPt[0], p[1] - aboutPt[1], p[2] - aboutPt[2]];
@@ -237,7 +237,7 @@ export function applyMatrixImpl(
   matrix: number[][],
   options?: { aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
 ): void {
-  const aboutPoint: Vector3Tuple = resolveAboutPoint(mob, options) ?? [0, 0, 0];
+  const aboutPoint: Vector3Tuple = resolveExtremalPoint(mob, options) ?? [0, 0, 0];
 
   // aboutPoint is baked into the transform function — do NOT pass options
   // to applyFunctionImpl, or the translation would be applied twice.

--- a/src/core/aboutEdge.test.ts
+++ b/src/core/aboutEdge.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest';
+import { VMobject } from './VMobject';
+
+/**
+ * Tests for aboutPoint / aboutEdge support across Mobject transform methods.
+ * See https://github.com/maloyan/manim-web/issues/218
+ */
+
+function makeUnitSquare(): VMobject {
+  const vm = new VMobject();
+  // A 2×2 square centered at origin: corners at (±1, ±1)
+  vm.setPoints([
+    [-1, -1, 0],
+    [-1, 1, 0],
+    [1, 1, 0],
+    [1, -1, 0],
+  ]);
+  return vm;
+}
+
+describe('scale with aboutPoint and aboutEdge (#218)', () => {
+  it('scales about a specific point', () => {
+    const vm = makeUnitSquare();
+    // Scale by 2 about the right edge center [1, 0, 0]
+    // Point [-1,-1,0]: (-1-1)*2+1 = -3, (-1-0)*2+0 = -2
+    vm.scale(2, { aboutPoint: [1, 0, 0] });
+    const pts = vm.getPoints();
+    expect(pts[0][0]).toBeCloseTo(-3);
+    expect(pts[0][1]).toBeCloseTo(-2);
+    // Point [1,-1,0]: (1-1)*2+1 = 1, (-1-0)*2+0 = -2
+    expect(pts[3][0]).toBeCloseTo(1);
+    expect(pts[3][1]).toBeCloseTo(-2);
+  });
+
+  it('scales about an edge (RIGHT)', () => {
+    const vm = makeUnitSquare();
+    // aboutEdge [1,0,0] resolves to right edge center [1,0,0]
+    vm.scale(2, { aboutEdge: [1, 0, 0] });
+    const pts = vm.getPoints();
+    expect(pts[0][0]).toBeCloseTo(-3);
+    expect(pts[0][1]).toBeCloseTo(-2);
+    expect(pts[3][0]).toBeCloseTo(1);
+    expect(pts[3][1]).toBeCloseTo(-2);
+  });
+
+  it('scales about an edge (UP)', () => {
+    const vm = makeUnitSquare();
+    // aboutEdge [0,1,0] resolves to top edge center [0,1,0]
+    vm.scale(3, { aboutEdge: [0, 1, 0] });
+    const pts = vm.getPoints();
+    // [-1,-1,0]: (-1-0)*3+0 = -3, (-1-1)*3+1 = -5
+    expect(pts[0][0]).toBeCloseTo(-3);
+    expect(pts[0][1]).toBeCloseTo(-5);
+    // [1,1,0]: (1-0)*3+0 = 3, (1-1)*3+1 = 1 (fixed along y)
+    expect(pts[2][0]).toBeCloseTo(3);
+    expect(pts[2][1]).toBeCloseTo(1);
+  });
+});
+
+describe('stretch with aboutPoint and aboutEdge (#218)', () => {
+  it('stretches along x axis', () => {
+    const vm = makeUnitSquare();
+    vm.stretch(2, 0);
+    const pts = vm.getPoints();
+    // x doubles, y unchanged
+    expect(pts[0][0]).toBeCloseTo(-2);
+    expect(pts[0][1]).toBeCloseTo(-1);
+    expect(pts[2][0]).toBeCloseTo(2);
+    expect(pts[2][1]).toBeCloseTo(1);
+  });
+
+  it('stretches along y axis about a point', () => {
+    const vm = makeUnitSquare();
+    // Stretch y by 3 about top edge [0,1,0]
+    vm.stretch(3, 1, { aboutPoint: [0, 1, 0] });
+    const pts = vm.getPoints();
+    // [-1,-1,0]: y = (-1-1)*3+1 = -5
+    expect(pts[0][1]).toBeCloseTo(-5);
+    // [1,1,0]: y = (1-1)*3+1 = 1 (fixed)
+    expect(pts[2][1]).toBeCloseTo(1);
+    // x unchanged
+    expect(pts[0][0]).toBeCloseTo(-1);
+  });
+
+  it('stretches about an edge', () => {
+    const vm = makeUnitSquare();
+    // Stretch x by 2 about right edge [1,0,0] -> resolves to [1,0,0]
+    vm.stretch(2, 0, { aboutEdge: [1, 0, 0] });
+    const pts = vm.getPoints();
+    // [-1,-1,0]: x = (-1-1)*2+1 = -3, y unchanged = -1
+    expect(pts[0][0]).toBeCloseTo(-3);
+    expect(pts[0][1]).toBeCloseTo(-1);
+    // [1,1,0]: x = (1-1)*2+1 = 1 (fixed), y unchanged = 1
+    expect(pts[2][0]).toBeCloseTo(1);
+    expect(pts[2][1]).toBeCloseTo(1);
+  });
+
+  it('throws when both aboutPoint and aboutEdge are specified', () => {
+    const vm = makeUnitSquare();
+    expect(() => vm.stretch(2, 0, { aboutPoint: [0, 0, 0], aboutEdge: [1, 0, 0] })).toThrow();
+  });
+
+  it('throws for invalid dim', () => {
+    const vm = makeUnitSquare();
+    expect(() => vm.stretch(2, 3)).toThrow();
+    expect(() => vm.stretch(2, -1)).toThrow();
+    expect(() => vm.stretch(2, 1.5)).toThrow();
+  });
+
+  it('handles empty options object same as no options', () => {
+    const vm1 = makeUnitSquare();
+    const vm2 = makeUnitSquare();
+    vm1.stretch(2, 0);
+    vm2.stretch(2, 0, {});
+    const pts1 = vm1.getPoints();
+    const pts2 = vm2.getPoints();
+    for (let i = 0; i < pts1.length; i++) {
+      expect(pts2[i][0]).toBeCloseTo(pts1[i][0]);
+      expect(pts2[i][1]).toBeCloseTo(pts1[i][1]);
+    }
+  });
+});
+
+describe('rotate with aboutEdge (#218)', () => {
+  it('rotates about an edge (RIGHT)', () => {
+    const vm = makeUnitSquare();
+    // aboutEdge [1,0,0] resolves to right edge center [1,0,0]
+    // Rotate 90 degrees CCW about [1,0,0]
+    vm.rotate(Math.PI / 2, { aboutEdge: [1, 0, 0] });
+    const pts = vm.getPoints();
+    // [-1,-1,0] relative to [1,0,0]: (-2,-1) -> rotated 90 CCW: (1,-2) -> absolute: (2,-2)
+    expect(pts[0][0]).toBeCloseTo(2);
+    expect(pts[0][1]).toBeCloseTo(-2);
+  });
+});
+
+describe('flip with aboutPoint and aboutEdge (#218)', () => {
+  it('flips about a specific point along x-axis', () => {
+    const vm = new VMobject();
+    vm.setPoints([
+      [2, 0, 0],
+      [3, 0, 0],
+      [4, 0, 0],
+      [5, 0, 0],
+    ]);
+    // Flip x about point [2,0,0]: reflects x around x=2
+    // [2,0,0] -> 2, [3,0,0] -> 1, [4,0,0] -> 0, [5,0,0] -> -1
+    vm.flip([1, 0, 0], { aboutPoint: [2, 0, 0] });
+    const pts = vm.getPoints();
+    expect(pts[0][0]).toBeCloseTo(2);
+    expect(pts[1][0]).toBeCloseTo(1);
+    expect(pts[2][0]).toBeCloseTo(0);
+    expect(pts[3][0]).toBeCloseTo(-1);
+  });
+
+  it('flips about an edge', () => {
+    const vm = makeUnitSquare();
+    // aboutEdge [1,0,0] -> right edge center [1,0,0]
+    // Flip x about x=1: point [-1,y,0] -> 2*1-(-1) = 3
+    vm.flip([1, 0, 0], { aboutEdge: [1, 0, 0] });
+    const pts = vm.getPoints();
+    expect(pts[0][0]).toBeCloseTo(3); // was -1
+    expect(pts[2][0]).toBeCloseTo(1); // was 1, stays
+  });
+});
+
+describe('aboutPoint and aboutEdge conflict (#218)', () => {
+  it('throws when both aboutPoint and aboutEdge are specified', () => {
+    const vm = makeUnitSquare();
+    expect(() => vm.scale(2, { aboutPoint: [0, 0, 0], aboutEdge: [1, 0, 0] })).toThrow();
+    expect(() => vm.rotate(Math.PI / 2, { aboutPoint: [0, 0, 0], aboutEdge: [1, 0, 0] })).toThrow();
+    expect(() => vm.flip([1, 0, 0], { aboutPoint: [0, 0, 0], aboutEdge: [1, 0, 0] })).toThrow();
+    expect(() =>
+      vm.applyFunction((p) => p, { aboutPoint: [0, 0, 0], aboutEdge: [1, 0, 0] }),
+    ).toThrow();
+    expect(() =>
+      vm.applyMatrix(
+        [
+          [1, 0, 0],
+          [0, 1, 0],
+          [0, 0, 1],
+        ],
+        { aboutPoint: [0, 0, 0], aboutEdge: [1, 0, 0] },
+      ),
+    ).toThrow();
+  });
+});
+
+describe('applyFunction with aboutPoint and aboutEdge (#218)', () => {
+  it('applies function about a specific point', () => {
+    const vm = new VMobject();
+    vm.setPoints([
+      [1, 0, 0],
+      [2, 0, 0],
+      [3, 0, 0],
+      [4, 0, 0],
+    ]);
+    // Scale x by 2 about point [1,0,0]
+    vm.applyFunction((p) => [p[0] * 2, p[1], p[2]], { aboutPoint: [1, 0, 0] });
+    const pts = vm.getPoints();
+    // [1,0,0] -> translate to [0,0,0], apply *2 -> [0,0,0], translate back -> [1,0,0]
+    expect(pts[0][0]).toBeCloseTo(1);
+    // [4,0,0] -> translate to [3,0,0], apply *2 -> [6,0,0], translate back -> [7,0,0]
+    expect(pts[3][0]).toBeCloseTo(7);
+  });
+
+  it('applies function about an edge', () => {
+    const vm = makeUnitSquare();
+    // aboutEdge [1,0,0] -> right edge center [1,0,0]
+    // Scale x by 2 about [1,0,0]
+    vm.applyFunction((p) => [p[0] * 2, p[1], p[2]], { aboutEdge: [1, 0, 0] });
+    const pts = vm.getPoints();
+    // [-1,-1,0]: translate -> [-2,-1,0], apply -> [-4,-1,0], translate back -> [-3,-1,0]
+    expect(pts[0][0]).toBeCloseTo(-3);
+    // [1,-1,0]: translate -> [0,-1,0], apply -> [0,-1,0], translate back -> [1,-1,0]
+    expect(pts[3][0]).toBeCloseTo(1);
+  });
+});

--- a/src/mobjects/graphing/ComplexPlane.ts
+++ b/src/mobjects/graphing/ComplexPlane.ts
@@ -7,7 +7,7 @@ import { Line } from '../geometry';
 import { Circle } from '../geometry';
 import { Text } from '../text';
 import { WHITE } from '../../constants';
-import { resolveAboutPoint } from '../../core/MobjectState';
+import { resolveExtremalPoint } from '../../core/MobjectState';
 
 /**
  * Complex number representation
@@ -329,7 +329,7 @@ export class ComplexPlane extends NumberPlane {
     func: (z: Complex) => Complex,
     options?: { aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
   ): this {
-    const aboutPt = resolveAboutPoint(this, options);
+    const aboutPt = resolveExtremalPoint(this, options);
 
     const transformPoint = (point: number[]): number[] => {
       let p = point;

--- a/src/mobjects/graphing/ComplexPlane.ts
+++ b/src/mobjects/graphing/ComplexPlane.ts
@@ -7,6 +7,7 @@ import { Line } from '../geometry';
 import { Circle } from '../geometry';
 import { Text } from '../text';
 import { WHITE } from '../../constants';
+import { resolveAboutPoint } from '../../core/MobjectState';
 
 /**
  * Complex number representation
@@ -324,11 +325,26 @@ export class ComplexPlane extends NumberPlane {
    * @param func - A function mapping one complex number to another
    * @returns this for chaining
    */
-  applyComplexFunction(func: (z: Complex) => Complex): this {
+  applyComplexFunction(
+    func: (z: Complex) => Complex,
+    options?: { aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
+  ): this {
+    const aboutPt = resolveAboutPoint(this, options);
+
     const transformPoint = (point: number[]): number[] => {
-      const z = this.p2n(point as [number, number, number]);
+      let p = point;
+      if (aboutPt) {
+        p = [point[0] - aboutPt[0], point[1] - aboutPt[1], point[2] - aboutPt[2]];
+      }
+      const z = this.p2n(p as [number, number, number]);
       const w = func(z);
-      return [...this.n2p(w)];
+      const result = [...this.n2p(w)];
+      if (aboutPt) {
+        result[0] += aboutPt[0];
+        result[1] += aboutPt[1];
+        result[2] += aboutPt[2];
+      }
+      return result;
     };
 
     // Transform all VMobject children recursively


### PR DESCRIPTION
## Summary

Closes #218

- Add `aboutPoint`/`aboutEdge` options to `scale`, `rotate`, `flip`, `stretch` (new), `applyFunction`, and `applyComplexFunction` on Mobject
- Add `aboutEdge` to `Rotate`, `Scale`, and `Rotating` animation classes (already had `aboutPoint`)
- Extract shared `resolveAboutPoint` helper that converts `aboutEdge` to a point via bounding box
- Throw when both `aboutPoint` and `aboutEdge` are provided (per Manim Python behavior)
- Add `stretch(factor, dim, options?)` convenience method matching Python Manim API
- Validate `dim` parameter in `stretch` (must be 0, 1, or 2)

## Test plan

- [x] 15 tests in `src/core/aboutEdge.test.ts` — Mobject methods (scale, stretch, rotate, flip, applyFunction with aboutPoint/aboutEdge, conflict detection, dim validation)
- [x] 6 tests in `src/animation/aboutEdgeAnimations.test.ts` — Animation classes (Rotate, Scale, Rotating with aboutEdge, conflict detection)
- [x] Existing `src/core/applyMatrix.test.ts` still passes (8 tests)
- [x] Full suite: 5734 tests pass, 0 regressions

cc @rambip for review