### PR TITLE
fix: await async MathTex renders before animating

### DIFF
--- a/docs/docs/examples.mdx
+++ b/docs/docs/examples.mdx
@@ -45,7 +45,7 @@ Interactive examples showing what you can build with manim-web. Each example inc
 
 ## Integrated Player
 
-A full-featured playback controller with play/pause, segment navigation, timeline scrubbing, speed control, fullscreen, and export. Toggle slides mode with the slides button or <kbd>S</kbd> key — when active, each <kbd>&rarr;</kbd> press plays one segment then pauses, like a presentation. Use <kbd>Space</kbd> to play/pause, <kbd>&larr;</kbd>/<kbd>&rarr;</kbd> for segments, <kbd>Shift+&larr;/&rarr;</kbd> to scrub, and <kbd>F</kbd> for fullscreen.
+A full-featured playback controller with play/pause, segment navigation, timeline scrubbing, speed control, fullscreen, and export. Use <kbd>Space</kbd> to play/pause, <kbd>&larr;</kbd>/<kbd>&rarr;</kbd> for segments, <kbd>Shift+&larr;/&rarr;</kbd> to scrub, and <kbd>F</kbd> for fullscreen.
 
 <PlayerExample />
 
@@ -129,7 +129,7 @@ Creates the Manim Community Edition logo using a large blackboard-bold M, a circ
 import {
   Circle,
   LEFT,
-  MathTex,
+  MathTexImage,
   ORIGIN,
   RIGHT,
   Scene,
@@ -151,7 +151,7 @@ const logoGreen = '#87c2a5';
 const logoBlue = '#525893';
 const logoRed = '#e07a5f';
 const logoBlack = '#343434';
-const dsM = new MathTex({ latex: '\\mathbb{M}', fillColor: logoBlack });
+const dsM = new MathTexImage({ latex: '\\mathbb{M}', fillColor: logoBlack });
 await dsM.waitForRender();
 dsM.scale(7);
 dsM.shift(addVec(scaleVec(2.25, LEFT), scaleVec(1.5, UP)));
@@ -364,7 +364,7 @@ await scene.play(new FadeIn(difference_text));
 
 ## Mathtex Svg
 
-Demonstrates vector-based LaTeX rendering with MathTexSVG. Shows Create (stroke-draw reveal), DrawBorderThenFill, FadeIn, and multi-part expressions with per-part coloring. Unlike raster MathTex, MathTexSVG produces real VMobject paths that support path-based animations.
+Demonstrates vector-based LaTeX rendering with MathTex. Shows Create (stroke-draw reveal), DrawBorderThenFill, FadeIn, and multi-part expressions with per-part coloring. MathTex produces real VMobject paths that support path-based animations.
 
 <MathtexSvgExample />
 
@@ -374,7 +374,7 @@ Demonstrates vector-based LaTeX rendering with MathTexSVG. Shows Create (stroke-
 ```typescript
 import {
   Scene,
-  MathTexSVG,
+  MathTex,
   Create,
   DrawBorderThenFill,
   FadeIn,
@@ -394,27 +394,27 @@ const scene = new Scene(document.getElementById('container'), {
 });
 
 // Pre-create all equations
-const equation1 = new MathTexSVG({
+const equation1 = new MathTex({
   latex: '\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}',
   color: WHITE,
   fontSize: 2,
 });
-const equation2 = new MathTexSVG({
+const equation2 = new MathTex({
   latex: 'e^{i\\pi} + 1 = 0',
   color: YELLOW,
   fontSize: 2.5,
 });
-const multiPart = new MathTexSVG({
+const multiPart = new MathTex({
   latex: ['E', '=', 'mc^2'],
   color: WHITE,
   fontSize: 3,
 });
-const equation3 = new MathTexSVG({
+const equation3 = new MathTex({
   latex: '\\sum_{k=1}^{n} k = \\frac{n(n+1)}{2}',
   color: GREEN,
   fontSize: 2,
 });
-const matrix = new MathTexSVG({
+const matrix = new MathTex({
   latex: 'A = \\begin{pmatrix} a_{11} & a_{12} \\\\ a_{21} & a_{22} \\end{pmatrix}',
   color: WHITE,
   fontSize: 2,
@@ -460,7 +460,7 @@ await scene.wait(2);
 
 </details>
 
-**Learn More:** [**MathTexSVG**](/api/classes/MathTexSVG) · [**Create**](/api/classes/Create) · [**DrawBorderThenFill**](/api/classes/DrawBorderThenFill) · [**FadeIn**](/api/classes/FadeIn) · [**FadeOut**](/api/classes/FadeOut)
+**Learn More:** [**MathTex**](/api/classes/MathTex) · [**Create**](/api/classes/Create) · [**DrawBorderThenFill**](/api/classes/DrawBorderThenFill) · [**FadeIn**](/api/classes/FadeIn) · [**FadeOut**](/api/classes/FadeOut)
 
 ---
 
@@ -579,7 +579,7 @@ import {
   FadeToColor,
   LEFT,
   Line,
-  MathTex,
+  MathTexImage,
   RED,
   RIGHT,
   SMALL_BUFF,
@@ -603,7 +603,7 @@ const line_moving = new Line({ start: LEFT, end: RIGHT });
 const line_ref = line_moving.copy();
 line_moving.rotate(theta_tracker.getValue() * (Math.PI / 180), { aboutPoint: rotation_center });
 const a = new Angle({ line1: line1, line2: line_moving }, { radius: 0.5, otherAngle: false });
-const tex = new MathTex({ latex: '\\theta', color: WHITE });
+const tex = new MathTexImage({ latex: '\\theta', color: WHITE });
 await tex.waitForRender();
 tex.moveTo(
   new Angle(
@@ -753,7 +753,7 @@ Renders a multi-part LaTeX equation (the product rule), then highlights individu
 ```typescript
 import {
   Create,
-  MathTex,
+  MathTexImage,
   ReplacementTransform,
   Scene,
   SurroundingRectangle,
@@ -765,7 +765,7 @@ const scene = new Scene(document.getElementById('container'), {
   backgroundColor: '#000000',
 });
 
-const text = new MathTex({
+const text = new MathTexImage({
   latex: ['\\frac{d}{dx}f(x)g(x)=', 'f(x)\\frac{d}{dx}g(x)', '+', 'g(x)\\frac{d}{dx}f(x)'],
 });
 await text.waitForRender();
@@ -887,7 +887,7 @@ import {
   Dot,
   Line,
   VGroup,
-  MathTex,
+  MathTexImage,
   BLACK,
   BLUE,
   RED,
@@ -912,10 +912,10 @@ scene.add(xAxis, yAxis);
 
 // --- X labels ---
 const xLabels = [
-  new MathTex({ latex: '\\pi' }),
-  new MathTex({ latex: '2\\pi' }),
-  new MathTex({ latex: '3\\pi' }),
-  new MathTex({ latex: '4\\pi' }),
+  new MathTexImage({ latex: '\\pi' }),
+  new MathTexImage({ latex: '2\\pi' }),
+  new MathTexImage({ latex: '3\\pi' }),
+  new MathTexImage({ latex: '4\\pi' }),
 ];
 for (let i = 0; i < xLabels.length; i++) {
   xLabels[i].nextTo([-1 + 2 * i, 0, 0], DOWN, 0.4);
@@ -1087,13 +1087,7 @@ Demonstrates the applyMatrix method on Mobject for instant matrix transformation
 <summary>Source Code</summary>
 
 ```typescript
-import {
-  Scene,
-  Square,
-  applyMatrix,
-  BLUE,
-  YELLOW,
-} from 'manim-web';
+import { Scene, Square, applyMatrix, BLUE } from 'manim-web';
 
 const scene = new Scene(document.getElementById('container'), {
   width: 800,
@@ -1107,11 +1101,15 @@ await scene.wait(1);
 
 // Animate the shear transformation
 await scene.play(
-  applyMatrix(square, [
-    [1, 0.5, 0],
-    [0, 1, 0],
-    [0, 0, 1],
-  ], { duration: 2 }),
+  applyMatrix(
+    square,
+    [
+      [1, 0.5, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+    ],
+    { duration: 2 },
+  ),
 );
 
 await scene.wait(2);
@@ -2316,7 +2314,7 @@ import {
   Transform,
   ApplyPointwiseFunction,
   Text,
-  MathTex,
+  MathTexImage,
   NumberPlane,
   VGroup,
   UP,
@@ -2340,7 +2338,9 @@ const title = new Text({
   color: WHITE,
   fontUrl: FONT_URL,
 });
-const basel = new MathTex({ latex: '\\sum_{n=1}^\\infty \\frac{1}{n^2} = \\frac{\\pi^2}{6}' });
+const basel = new MathTexImage({
+  latex: '\\sum_{n=1}^\\infty \\frac{1}{n^2} = \\frac{\\pi^2}{6}',
+});
 await basel.waitForRender?.();
 
 new VGroup(title, basel).arrange(DOWN);

--- a/docs/docs/examples/animations.mdx
+++ b/docs/docs/examples/animations.mdx
@@ -462,7 +462,7 @@ await scene.play(new FadeIn(difference_text));
 
 ## Mathtex Svg
 
-Demonstrates vector-based LaTeX rendering with MathTexSVG. Shows Create (stroke-draw reveal), DrawBorderThenFill, FadeIn, and multi-part expressions with per-part coloring. Unlike raster MathTex, MathTexSVG produces real VMobject paths that support path-based animations.
+Demonstrates vector-based LaTeX rendering with MathTex. Shows Create (stroke-draw reveal), DrawBorderThenFill, FadeIn, and multi-part expressions with per-part coloring. MathTex produces real VMobject paths that support path-based animations.
 
 <MathtexSvgExample />
 
@@ -472,7 +472,7 @@ Demonstrates vector-based LaTeX rendering with MathTexSVG. Shows Create (stroke-
 ```typescript
 import {
   Scene,
-  MathTexSVG,
+  MathTex,
   Create,
   DrawBorderThenFill,
   FadeIn,
@@ -492,27 +492,27 @@ const scene = new Scene(document.getElementById('container'), {
 });
 
 // Pre-create all equations
-const equation1 = new MathTexSVG({
+const equation1 = new MathTex({
   latex: '\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}',
   color: WHITE,
   fontSize: 2,
 });
-const equation2 = new MathTexSVG({
+const equation2 = new MathTex({
   latex: 'e^{i\\pi} + 1 = 0',
   color: YELLOW,
   fontSize: 2.5,
 });
-const multiPart = new MathTexSVG({
+const multiPart = new MathTex({
   latex: ['E', '=', 'mc^2'],
   color: WHITE,
   fontSize: 3,
 });
-const equation3 = new MathTexSVG({
+const equation3 = new MathTex({
   latex: '\\sum_{k=1}^{n} k = \\frac{n(n+1)}{2}',
   color: GREEN,
   fontSize: 2,
 });
-const matrix = new MathTexSVG({
+const matrix = new MathTex({
   latex: 'A = \\begin{pmatrix} a_{11} & a_{12} \\\\ a_{21} & a_{22} \\end{pmatrix}',
   color: WHITE,
   fontSize: 2,
@@ -558,7 +558,7 @@ await scene.wait(2);
 
 </details>
 
-**Learn More:** [**MathTexSVG**](/api/classes/MathTexSVG) · [**Create**](/api/classes/Create) · [**DrawBorderThenFill**](/api/classes/DrawBorderThenFill) · [**FadeIn**](/api/classes/FadeIn) · [**FadeOut**](/api/classes/FadeOut)
+**Learn More:** [**MathTex**](/api/classes/MathTex) · [**Create**](/api/classes/Create) · [**DrawBorderThenFill**](/api/classes/DrawBorderThenFill) · [**FadeIn**](/api/classes/FadeIn) · [**FadeOut**](/api/classes/FadeOut)
 
 ---
 

--- a/docs/src/components/examples/ApplyMatrixMethodExample.tsx
+++ b/docs/src/components/examples/ApplyMatrixMethodExample.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ManimExample from '../ManimExample';
 
 async function animate(scene: any) {
-  const { Scene, Square, applyMatrix, BLUE, YELLOW } = await import('manim-web');
+  const { Scene, Square, applyMatrix, BLUE } = await import('manim-web');
 
   const square = new Square({ sideLength: 2, color: BLUE, fillOpacity: 0.5 });
   scene.add(square);

--- a/docs/src/components/examples/ManimCeLogoExample.tsx
+++ b/docs/src/components/examples/ManimCeLogoExample.tsx
@@ -3,13 +3,26 @@ import React from 'react';
 import ManimExample from '../ManimExample';
 
 async function animate(scene: any) {
-  const { Circle, LEFT, MathTex, ORIGIN, RIGHT, Scene, Square, Triangle, UP, VGroup, addVec, scaleVec } = await import('manim-web');
+  const {
+    Circle,
+    LEFT,
+    MathTexImage,
+    ORIGIN,
+    RIGHT,
+    Scene,
+    Square,
+    Triangle,
+    UP,
+    VGroup,
+    addVec,
+    scaleVec,
+  } = await import('manim-web');
 
   const logoGreen = '#87c2a5';
   const logoBlue = '#525893';
   const logoRed = '#e07a5f';
   const logoBlack = '#343434';
-  const dsM = new MathTex({ latex: '\\mathbb{M}', fillColor: logoBlack });
+  const dsM = new MathTexImage({ latex: '\\mathbb{M}', fillColor: logoBlack });
   await dsM.waitForRender();
   dsM.scale(7);
   dsM.shift(addVec(scaleVec(2.25, LEFT), scaleVec(1.5, UP)));

--- a/docs/src/components/examples/MathTexPartExample.tsx
+++ b/docs/src/components/examples/MathTexPartExample.tsx
@@ -6,19 +6,19 @@ async function animate(scene: any) {
     await import('manim-web');
 
   // Create individually colored equation parts
-  const xSq = new MathTex({ latex: 'x^2', color: RED, fontSize: 48 });
+  const xSq = new MathTex({ latex: 'x^2', color: RED, fontSize: 1 });
   xSq.moveTo([-2.2, 0, 0]);
 
-  const plus = new MathTex({ latex: '+', color: WHITE, fontSize: 48 });
+  const plus = new MathTex({ latex: '+', color: WHITE, fontSize: 1 });
   plus.moveTo([-1, 0, 0]);
 
-  const ySq = new MathTex({ latex: 'y^2', color: BLUE, fontSize: 48 });
+  const ySq = new MathTex({ latex: 'y^2', color: BLUE, fontSize: 1 });
   ySq.moveTo([0.2, 0, 0]);
 
-  const eq = new MathTex({ latex: '=', color: WHITE, fontSize: 48 });
+  const eq = new MathTex({ latex: '=', color: WHITE, fontSize: 1 });
   eq.moveTo([1.4, 0, 0]);
 
-  const rSq = new MathTex({ latex: 'r^2', color: GREEN, fontSize: 48 });
+  const rSq = new MathTex({ latex: 'r^2', color: GREEN, fontSize: 1 });
   rSq.moveTo([2.6, 0, 0]);
 
   await scene.play(new Create(xSq, { duration: 0.6 }));

--- a/docs/src/components/examples/MathTexPartExample.tsx
+++ b/docs/src/components/examples/MathTexPartExample.tsx
@@ -5,33 +5,26 @@ async function animate(scene: any) {
   const { MathTex, Create, FadeIn, Indicate, WHITE, RED, BLUE, GREEN, YELLOW } =
     await import('manim-web');
 
-  // Create individually colored equation parts
-  const xSq = new MathTex({ latex: 'x^2', color: RED, fontSize: 1 });
-  xSq.moveTo([-2.2, 0, 0]);
+  // Render as a single equation with multi-part coloring
+  const equation = new MathTex({
+    latex: ['x^2', '+', 'y^2', '=', 'r^2'],
+    color: WHITE,
+    fontSize: 1.5,
+  });
+  await equation.waitForRender();
 
-  const plus = new MathTex({ latex: '+', color: WHITE, fontSize: 1 });
-  plus.moveTo([-1, 0, 0]);
+  // Color individual parts
+  equation.getPart(0).setColor(RED);
+  equation.getPart(2).setColor(BLUE);
+  equation.getPart(4).setColor(GREEN);
 
-  const ySq = new MathTex({ latex: 'y^2', color: BLUE, fontSize: 1 });
-  ySq.moveTo([0.2, 0, 0]);
-
-  const eq = new MathTex({ latex: '=', color: WHITE, fontSize: 1 });
-  eq.moveTo([1.4, 0, 0]);
-
-  const rSq = new MathTex({ latex: 'r^2', color: GREEN, fontSize: 1 });
-  rSq.moveTo([2.6, 0, 0]);
-
-  await scene.play(new Create(xSq, { duration: 0.6 }));
-  await scene.play(new FadeIn(plus, { duration: 0.2 }));
-  await scene.play(new Create(ySq, { duration: 0.6 }));
-  await scene.play(new FadeIn(eq, { duration: 0.2 }));
-  await scene.play(new Create(rSq, { duration: 0.6 }));
-  await scene.wait(0.3);
+  await scene.play(new Create(equation, { duration: 2 }));
+  await scene.wait(0.5);
 
   // Highlight individual parts
-  await scene.play(new Indicate(xSq, { color: YELLOW, duration: 0.6 }));
-  await scene.play(new Indicate(ySq, { color: YELLOW, duration: 0.6 }));
-  await scene.play(new Indicate(rSq, { color: YELLOW, duration: 0.6 }));
+  await scene.play(new Indicate(equation.getPart(0), { color: YELLOW, duration: 0.6 }));
+  await scene.play(new Indicate(equation.getPart(2), { color: YELLOW, duration: 0.6 }));
+  await scene.play(new Indicate(equation.getPart(4), { color: YELLOW, duration: 0.6 }));
   await scene.wait(1);
 }
 

--- a/docs/src/components/examples/MathtexSvgExample.tsx
+++ b/docs/src/components/examples/MathtexSvgExample.tsx
@@ -5,7 +5,7 @@ import ManimExample from '../ManimExample';
 async function animate(scene: any) {
   const {
     Scene,
-    MathTexSVG,
+    MathTex,
     Create,
     DrawBorderThenFill,
     FadeIn,
@@ -19,27 +19,27 @@ async function animate(scene: any) {
   } = await import('manim-web');
 
   // Pre-create all equations
-  const equation1 = new MathTexSVG({
+  const equation1 = new MathTex({
     latex: '\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}',
     color: WHITE,
     fontSize: 2,
   });
-  const equation2 = new MathTexSVG({
+  const equation2 = new MathTex({
     latex: 'e^{i\\pi} + 1 = 0',
     color: YELLOW,
     fontSize: 2.5,
   });
-  const multiPart = new MathTexSVG({
+  const multiPart = new MathTex({
     latex: ['E', '=', 'mc^2'],
     color: WHITE,
     fontSize: 3,
   });
-  const equation3 = new MathTexSVG({
+  const equation3 = new MathTex({
     latex: '\\sum_{k=1}^{n} k = \\frac{n(n+1)}{2}',
     color: GREEN,
     fontSize: 2,
   });
-  const matrix = new MathTexSVG({
+  const matrix = new MathTex({
     latex: 'A = \\begin{pmatrix} a_{11} & a_{12} \\\\ a_{21} & a_{22} \\end{pmatrix}',
     color: WHITE,
     fontSize: 2,

--- a/docs/src/components/examples/MatrixHelpersExample.tsx
+++ b/docs/src/components/examples/MatrixHelpersExample.tsx
@@ -6,39 +6,47 @@ async function animate(scene: any) {
     await import('manim-web');
 
   // --- Part 1: MatrixExamples - 4 matrix types in a 2x2 grid ---
-  // Matching Python Manim's MatrixExamples reference image
 
-  // Top-left: Matrix with square brackets [π, 0; -1, 1]
   const m0 = new MathTex({
     latex: '\\begin{bmatrix} \\pi & 0 \\\\ -1 & 1 \\end{bmatrix}',
     color: WHITE,
     fontSize: 1,
   });
-  m0.moveTo([-3, 1.3, 0]);
 
-  // Top-right: IntegerMatrix with parentheses (2, 0; 12, -1)
   const m1 = new MathTex({
     latex: '\\begin{pmatrix} 2 & 0 \\\\ 12 & -1 \\end{pmatrix}',
     color: WHITE,
     fontSize: 1,
   });
-  m1.moveTo([3, 1.3, 0]);
 
-  // Bottom-left: DecimalMatrix with curly braces {3.46, 2.12; 33.22, 12.33}
   const m2 = new MathTex({
     latex: '\\left\\{ \\begin{matrix} 3.46 & 2.12 \\\\ 33.22 & 12.33 \\end{matrix} \\right\\}',
     color: WHITE,
     fontSize: 1,
   });
+
+  const piTex = new MathTex({ latex: '\\pi', color: TEAL_A, fontSize: 1 });
+  const leftAngle = new MathTex({ latex: '\\Bigg\\langle', color: WHITE, fontSize: 1 });
+  const rightAngle = new MathTex({ latex: '\\Bigg\\rangle', color: WHITE, fontSize: 1 });
+
+  // Wait for all MathTex renders before positioning
+  await Promise.all([
+    m0.waitForRender(),
+    m1.waitForRender(),
+    m2.waitForRender(),
+    piTex.waitForRender(),
+    leftAngle.waitForRender(),
+    rightAngle.waitForRender(),
+  ]);
+
+  m0.moveTo([-3, 1.3, 0]);
+  m1.moveTo([3, 1.3, 0]);
   m2.moveTo([-3, -1.3, 0]);
 
-  // Bottom-right: MobjectMatrix with angle brackets and colored shapes
-  // Use MathTex for angle brackets (VMobject auto-closes paths into polygons)
-  // and overlay actual geometric Mobjects for the matrix entries
+  // Bottom-right: shapes with angle brackets
   const spacing = 1.1;
   const cellGroup = new VGroup();
 
-  // Row 0: Circle (red), Square (white)
   const circle = new Circle({ radius: 0.3, color: RED, fillOpacity: 0 });
   circle.moveTo([-spacing / 2, spacing / 2, 0]);
   cellGroup.add(circle);
@@ -47,34 +55,16 @@ async function animate(scene: any) {
   square.moveTo([spacing / 2, spacing / 2, 0]);
   cellGroup.add(square);
 
-  // Row 1: π (teal), Star (teal)
-  const piTex = new MathTex({ latex: '\\pi', color: TEAL_A, fontSize: 1 });
   piTex.moveTo([-spacing / 2, -spacing / 2, 0]);
   cellGroup.add(piTex);
 
-  const star = new Star({
-    outerRadius: 0.35,
-    innerRadius: 0.14,
-    color: TEAL_A,
-    fillOpacity: 0,
-  });
+  const star = new Star({ outerRadius: 0.35, innerRadius: 0.14, color: TEAL_A, fillOpacity: 0 });
   star.moveTo([spacing / 2, -spacing / 2, 0]);
   cellGroup.add(star);
 
-  // Angle brackets sized with \Bigg (no phantom content to avoid visible artifacts)
-  const leftAngle = new MathTex({
-    latex: '\\Bigg\\langle',
-    color: WHITE,
-    fontSize: 1,
-  });
   leftAngle.moveTo([-(spacing / 2 + 0.8), 0, 0]);
   cellGroup.add(leftAngle);
 
-  const rightAngle = new MathTex({
-    latex: '\\Bigg\\rangle',
-    color: WHITE,
-    fontSize: 1,
-  });
   rightAngle.moveTo([spacing / 2 + 0.8, 0, 0]);
   cellGroup.add(rightAngle);
 
@@ -92,13 +82,12 @@ async function animate(scene: any) {
   await scene.play(new FadeOut(m2, { duration: 0.3 }));
   await scene.play(new FadeOut(cellGroup, { duration: 0.3 }));
 
-  // det([2, 0; -1, 1]) = 3
   const detTex = new MathTex({
     latex: '\\text{det} \\left( \\begin{bmatrix} 2 & 0 \\\\ -1 & 1 \\end{bmatrix} \\right) = 3',
     color: WHITE,
     fontSize: 1,
   });
-  detTex.moveTo([0, 0, 0]);
+  await detTex.waitForRender();
   await scene.play(new FadeIn(detTex, { duration: 1.5 }));
   await scene.wait(3);
 }

--- a/docs/src/components/examples/MatrixHelpersExample.tsx
+++ b/docs/src/components/examples/MatrixHelpersExample.tsx
@@ -12,7 +12,7 @@ async function animate(scene: any) {
   const m0 = new MathTex({
     latex: '\\begin{bmatrix} \\pi & 0 \\\\ -1 & 1 \\end{bmatrix}',
     color: WHITE,
-    fontSize: 40,
+    fontSize: 1,
   });
   m0.moveTo([-3, 1.3, 0]);
 
@@ -20,7 +20,7 @@ async function animate(scene: any) {
   const m1 = new MathTex({
     latex: '\\begin{pmatrix} 2 & 0 \\\\ 12 & -1 \\end{pmatrix}',
     color: WHITE,
-    fontSize: 40,
+    fontSize: 1,
   });
   m1.moveTo([3, 1.3, 0]);
 
@@ -28,7 +28,7 @@ async function animate(scene: any) {
   const m2 = new MathTex({
     latex: '\\left\\{ \\begin{matrix} 3.46 & 2.12 \\\\ 33.22 & 12.33 \\end{matrix} \\right\\}',
     color: WHITE,
-    fontSize: 40,
+    fontSize: 1,
   });
   m2.moveTo([-3, -1.3, 0]);
 
@@ -48,7 +48,7 @@ async function animate(scene: any) {
   cellGroup.add(square);
 
   // Row 1: π (teal), Star (teal)
-  const piTex = new MathTex({ latex: '\\pi', color: TEAL_A, fontSize: 80 });
+  const piTex = new MathTex({ latex: '\\pi', color: TEAL_A, fontSize: 1 });
   piTex.moveTo([-spacing / 2, -spacing / 2, 0]);
   cellGroup.add(piTex);
 
@@ -65,7 +65,7 @@ async function animate(scene: any) {
   const leftAngle = new MathTex({
     latex: '\\Bigg\\langle',
     color: WHITE,
-    fontSize: 40,
+    fontSize: 1,
   });
   leftAngle.moveTo([-(spacing / 2 + 0.8), 0, 0]);
   cellGroup.add(leftAngle);
@@ -73,7 +73,7 @@ async function animate(scene: any) {
   const rightAngle = new MathTex({
     latex: '\\Bigg\\rangle',
     color: WHITE,
-    fontSize: 40,
+    fontSize: 1,
   });
   rightAngle.moveTo([spacing / 2 + 0.8, 0, 0]);
   cellGroup.add(rightAngle);
@@ -96,7 +96,7 @@ async function animate(scene: any) {
   const detTex = new MathTex({
     latex: '\\text{det} \\left( \\begin{bmatrix} 2 & 0 \\\\ -1 & 1 \\end{bmatrix} \\right) = 3',
     color: WHITE,
-    fontSize: 48,
+    fontSize: 1,
   });
   detTex.moveTo([0, 0, 0]);
   await scene.play(new FadeIn(detTex, { duration: 1.5 }));

--- a/docs/src/components/examples/MovingAngleExample.tsx
+++ b/docs/src/components/examples/MovingAngleExample.tsx
@@ -3,7 +3,20 @@ import React from 'react';
 import ManimExample from '../ManimExample';
 
 async function animate(scene: any) {
-  const { Angle, FadeToColor, LEFT, Line, MathTex, RED, RIGHT, SMALL_BUFF, Scene, ValueTracker, BLACK, WHITE } = await import('manim-web');
+  const {
+    Angle,
+    FadeToColor,
+    LEFT,
+    Line,
+    MathTexImage,
+    RED,
+    RIGHT,
+    SMALL_BUFF,
+    Scene,
+    ValueTracker,
+    BLACK,
+    WHITE,
+  } = await import('manim-web');
 
   const rotation_center = LEFT;
 
@@ -13,7 +26,7 @@ async function animate(scene: any) {
   const line_ref = line_moving.copy();
   line_moving.rotate(theta_tracker.getValue() * (Math.PI / 180), { aboutPoint: rotation_center });
   const a = new Angle({ line1: line1, line2: line_moving }, { radius: 0.5, otherAngle: false });
-  const tex = new MathTex({ latex: '\\theta', color: WHITE });
+  const tex = new MathTexImage({ latex: '\\theta', color: WHITE });
   await tex.waitForRender();
   tex.moveTo(
     new Angle(

--- a/docs/src/components/examples/MovingFrameBoxExample.tsx
+++ b/docs/src/components/examples/MovingFrameBoxExample.tsx
@@ -3,9 +3,10 @@ import React from 'react';
 import ManimExample from '../ManimExample';
 
 async function animate(scene: any) {
-  const { Create, MathTex, ReplacementTransform, Scene, SurroundingRectangle, Write } = await import('manim-web');
+  const { Create, MathTexImage, ReplacementTransform, Scene, SurroundingRectangle, Write } =
+    await import('manim-web');
 
-  const text = new MathTex({
+  const text = new MathTexImage({
     latex: ['\\frac{d}{dx}f(x)g(x)=', 'f(x)\\frac{d}{dx}g(x)', '+', 'g(x)\\frac{d}{dx}f(x)'],
   });
   await text.waitForRender();

--- a/docs/src/components/examples/OpeningManimExample.tsx
+++ b/docs/src/components/examples/OpeningManimExample.tsx
@@ -3,7 +3,23 @@ import React from 'react';
 import ManimExample from '../ManimExample';
 
 async function animate(scene: any) {
-  const { Scene, Create, FadeIn, FadeOut, Transform, ApplyPointwiseFunction, Text, MathTex, NumberPlane, VGroup, UP, DOWN, UL, BLACK, WHITE } = await import('manim-web');
+  const {
+    Scene,
+    Create,
+    FadeIn,
+    FadeOut,
+    Transform,
+    ApplyPointwiseFunction,
+    Text,
+    MathTexImage,
+    NumberPlane,
+    VGroup,
+    UP,
+    DOWN,
+    UL,
+    BLACK,
+    WHITE,
+  } = await import('manim-web');
 
   const FONT_URL = 'https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/fonts/KaTeX_Main-Regular.ttf';
 
@@ -14,7 +30,9 @@ async function animate(scene: any) {
     color: WHITE,
     fontUrl: FONT_URL,
   });
-  const basel = new MathTex({ latex: '\\sum_{n=1}^\\infty \\frac{1}{n^2} = \\frac{\\pi^2}{6}' });
+  const basel = new MathTexImage({
+    latex: '\\sum_{n=1}^\\infty \\frac{1}{n^2} = \\frac{\\pi^2}{6}',
+  });
   await basel.waitForRender?.();
 
   new VGroup(title, basel).arrange(DOWN);

--- a/docs/src/components/examples/SineCurveUnitCircleExample.tsx
+++ b/docs/src/components/examples/SineCurveUnitCircleExample.tsx
@@ -9,7 +9,7 @@ async function animate(scene: any) {
     Dot,
     Line,
     VGroup,
-    MathTex,
+    MathTexImage,
     BLACK,
     BLUE,
     RED,
@@ -28,10 +28,10 @@ async function animate(scene: any) {
 
   // --- X labels ---
   const xLabels = [
-    new MathTex({ latex: '\\pi' }),
-    new MathTex({ latex: '2\\pi' }),
-    new MathTex({ latex: '3\\pi' }),
-    new MathTex({ latex: '4\\pi' }),
+    new MathTexImage({ latex: '\\pi' }),
+    new MathTexImage({ latex: '2\\pi' }),
+    new MathTexImage({ latex: '3\\pi' }),
+    new MathTexImage({ latex: '4\\pi' }),
   ];
   for (let i = 0; i < xLabels.length; i++) {
     xLabels[i].nextTo([-1 + 2 * i, 0, 0], DOWN, 0.4);

--- a/docs/src/components/examples/TexTemplateExample.tsx
+++ b/docs/src/components/examples/TexTemplateExample.tsx
@@ -17,6 +17,7 @@ async function animate(scene: any) {
     color: WHITE,
     fontSize: 1,
   });
+  await tex1.waitForRender();
   tex1.moveTo([0.5, 1.2, 0]);
   await scene.play(new Create(tex1, { duration: 1.5 }));
 
@@ -29,6 +30,7 @@ async function animate(scene: any) {
     color: BLUE,
     fontSize: 1,
   });
+  await tex2.waitForRender();
   tex2.moveTo([0.5, -0.5, 0]);
   await scene.play(new Create(tex2, { duration: 1.5 }));
   await scene.wait(1.5);

--- a/docs/src/components/examples/TexTemplateExample.tsx
+++ b/docs/src/components/examples/TexTemplateExample.tsx
@@ -15,7 +15,7 @@ async function animate(scene: any) {
   const tex1 = new MathTex({
     latex: '\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}',
     color: WHITE,
-    fontSize: 36,
+    fontSize: 1,
   });
   tex1.moveTo([0.5, 1.2, 0]);
   await scene.play(new Create(tex1, { duration: 1.5 }));
@@ -27,7 +27,7 @@ async function animate(scene: any) {
   const tex2 = new MathTex({
     latex: '\\sum_{n=1}^{N} \\frac{1}{n^2} = \\frac{\\pi^2}{6}',
     color: BLUE,
-    fontSize: 36,
+    fontSize: 1,
   });
   tex2.moveTo([0.5, -0.5, 0]);
   await scene.play(new Create(tex2, { duration: 1.5 }));

--- a/scripts/generate-example-docs.mjs
+++ b/scripts/generate-example-docs.mjs
@@ -147,8 +147,8 @@ const EXAMPLE_META = {
   },
   mathtex_svg: {
     description:
-      'Demonstrates vector-based LaTeX rendering with MathTexSVG. Shows Create (stroke-draw reveal), DrawBorderThenFill, FadeIn, and multi-part expressions with per-part coloring. Unlike raster MathTex, MathTexSVG produces real VMobject paths that support path-based animations.',
-    learnMore: ['MathTexSVG', 'Create', 'DrawBorderThenFill', 'FadeIn', 'FadeOut'],
+      'Demonstrates vector-based LaTeX rendering with MathTex. Shows Create (stroke-draw reveal), DrawBorderThenFill, FadeIn, and multi-part expressions with per-part coloring. MathTex produces real VMobject paths that support path-based animations.',
+    learnMore: ['MathTex', 'Create', 'DrawBorderThenFill', 'FadeIn', 'FadeOut'],
   },
   opening_manim: {
     description:

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -500,6 +500,26 @@ export class Scene {
     // AnimationGroup.begin() handles calling begin() on its own children.
     const allAnimations = this._collectAllAnimations(animations);
 
+    // Wait for any async renders (e.g. SVG-based MathTex) to complete before
+    // starting animations. Without this, Create/DrawBorderThenFill would
+    // animate an empty mobject because SVG paths haven't loaded yet.
+    const renderPromises: Promise<void>[] = [];
+    const collectRenders = (mobject: Mobject) => {
+      const asyncMob = mobject as Mobject & { waitForRender?: () => Promise<void> };
+      if (typeof asyncMob.waitForRender === 'function') {
+        renderPromises.push(asyncMob.waitForRender().catch(() => {}));
+      }
+      for (const child of mobject.children) {
+        collectRenders(child);
+      }
+    };
+    for (const anim of allAnimations) {
+      collectRenders(anim.mobject);
+    }
+    if (renderPromises.length > 0) {
+      await Promise.all(renderPromises);
+    }
+
     // Force geometry sync so begin() can detect Line2 children for dash-reveal
     // animations (e.g. MathTex Create). This must happen before begin() but
     // we must NOT add to the scene yet — otherwise the mobject renders at full

--- a/src/mobjects/text/MathJaxRenderer.ts
+++ b/src/mobjects/text/MathJaxRenderer.ts
@@ -331,7 +331,9 @@ export async function renderLatexToSVG(
     } else {
       const parser = new DOMParser();
       const doc = parser.parseFromString(svgString, 'image/svg+xml');
-      svgElement = doc.documentElement as unknown as SVGElement;
+      // mathjax-full wraps SVG in <mjx-container>; extract the inner <svg>
+      const innerSvg = doc.querySelector('svg');
+      svgElement = (innerSvg || doc.documentElement) as unknown as SVGElement;
     }
   }
 

--- a/src/mobjects/text/MathJaxRenderer.ts
+++ b/src/mobjects/text/MathJaxRenderer.ts
@@ -144,6 +144,8 @@ async function loadMathJax(): Promise<MathJaxModuleState> {
       const svgModule = await import('mathjax-full/js/output/svg.js');
       const liteAdaptor = await import('mathjax-full/js/adaptors/liteAdaptor.js');
       const htmlHandler = await import('mathjax-full/js/handlers/html.js');
+      // Register all TeX packages (ams, etc.) so environments like pmatrix/bmatrix work
+      await import('mathjax-full/js/input/tex/AllPackages.js');
 
       const adaptor = liteAdaptor.liteAdaptor();
       htmlHandler.RegisterHTMLHandler(adaptor);
@@ -373,7 +375,13 @@ export async function renderLatexToSVG(
   // ------------------------------------------------------------------
   // Convert SVG paths to VMobjects
   // ------------------------------------------------------------------
-  const vmobjectGroup = svgToVMobjects(svgElement, { color, scale: fontScale, flipY: false });
+  const vmobjectGroup = svgToVMobjects(svgElement, {
+    color,
+    scale: fontScale,
+    flipY: false,
+    strokeWidth: 0.02,
+    fillOpacity: 1,
+  });
 
   return {
     svgElement,

--- a/src/mobjects/text/MathTex.ts
+++ b/src/mobjects/text/MathTex.ts
@@ -29,7 +29,7 @@ export interface MathTexOptions {
   displayMode?: boolean;
   /** Position in 3D space. Default: [0,0,0] */
   position?: Vector3Tuple;
-  /** Stroke width for glyph outlines. Default: 2 */
+  /** Stroke width for glyph outlines. Default: 0.02 */
   strokeWidth?: number;
   /** Fill opacity for glyph interiors. Default: 1 */
   fillOpacity?: number;
@@ -68,7 +68,7 @@ export class MathTex extends VGroup {
       fontSize = 1,
       displayMode = true,
       position = [0, 0, 0],
-      strokeWidth = 2,
+      strokeWidth = 0.02,
       fillOpacity = 1,
       height,
       macros,
@@ -232,12 +232,9 @@ export class MathTex extends VGroup {
   protected _restyleChildren(group: VGroup): void {
     const restyle = (mob: Mobject) => {
       if (mob instanceof VMobject) {
-        mob.fillOpacity = this._svgFillOpacity;
-        mob.strokeWidth = this._svgStrokeWidth;
         mob.setColor(this._color);
-        // Access _style via any cast since protected access from sibling instances
-        (mob as any)._style.fillOpacity = this._svgFillOpacity;
-        (mob as any)._style.strokeWidth = this._svgStrokeWidth;
+        mob.setStrokeWidth(this._svgStrokeWidth);
+        mob.setFillOpacity(this._svgFillOpacity);
       }
       if ('children' in mob) {
         for (const child of (mob as any).children) {

--- a/src/mobjects/text/MathTex.ts
+++ b/src/mobjects/text/MathTex.ts
@@ -289,11 +289,10 @@ export class MathTex extends VGroup {
       // Explicit height: scale bounding box to fit (user intent)
       s = this._targetHeight / rawHeight;
     } else {
-      // Scale based on em height for consistent font sizing.
-      // svgToVMobjects scales paths by fontSize / vbWidth, so in raw coords
-      // 1 em = 1000 * fontSize / vbWidth. We want 1 em = 0.5 * fontSize
-      // world units, giving: s = 0.5 * vbWidth / 1000.
-      s = (0.5 * this._svgViewBoxWidth) / 1000;
+      // Scale to a readable size: fontSize acts as a multiplier.
+      // Default height ≈ 1 world unit (readable in standard camera view).
+      const targetHeight = this._fontSize;
+      s = targetHeight / rawHeight;
     }
 
     // Center of current bounds

--- a/src/mobjects/text/svgPathParser.ts
+++ b/src/mobjects/text/svgPathParser.ts
@@ -485,6 +485,9 @@ export function svgToVMobjects(
     // Skip <defs> — we collected them above
     if (tag === 'defs') return;
 
+    // Skip MathJax error elements (merror produces a background rect)
+    if (el.getAttribute('data-mml-node') === 'merror') return;
+
     // Handle <g> transform: translate and scale
     // SVG transforms apply left-to-right in the attribute string.
     // For "translate(a,b) scale(s)": point p → (a + s*p.x, b + s*p.y)


### PR DESCRIPTION
## Summary

Fix broken MathTex/TeX/Matrix examples on the docs site after the MathTexSVG → MathTex rename (#243).

### Root causes found and fixed:

1. **`<mjx-container>` wrapper** — mathjax-full wraps SVG in `<mjx-container>`, but `DOMParser` returned this wrapper instead of the inner `<svg>`. viewBox was null → no coordinate scaling → 1000x too large.

2. **Missing TeX packages** — mathjax-full npm requires explicit `AllPackages` import to register ams environments. Without it, `\begin{pmatrix}` produced `merror` (rendered as a white rect).

3. **strokeWidth too large** — Default strokeWidth=2 overwhelmed scaled-down SVG glyphs. Changed to 0.02 and used `setStrokeWidth()` to properly sync Three.js materials.

4. **`_scaleToTarget` formula** — Old formula assumed unscaled coordinates. Fixed to use `fontSize` directly as target height in world units.

5. **`moveTo` before render** — MathTex renders async. Calling `moveTo()` before `waitForRender()` shifts an empty VGroup (no children yet), then `_scaleToTarget` centers new children at origin. Fixed examples to await render before positioning.

6. **MathTexPart example** — Rewritten to use multi-part MathTex API (`latex: ['x^2', '+', 'y^2', '=', 'r^2']`) instead of separate MathTex instances per symbol.

7. **MathTexSVG references** — Updated generator script and docs to use `MathTex` (renamed in #243).

### Also includes:
- `Scene.play()` awaits `waitForRender()` on animated mobjects before starting animations
- Skip `merror` elements in `svgToVMobjects` to avoid error backgrounds becoming visible
- Regenerated auto-generated example components

## Test plan
- [x] All 5742 tests pass
- [x] Library builds successfully
- [x] Verified TeX Templates, MathTex Parts, and Matrix Helpers render correctly on localhost
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)