### PR TITLE
fix: reduce oversized Tex labels in HeatDiagramPlot

### DIFF
--- a/docs/src/components/examples/HeatDiagramPlotExample.tsx
+++ b/docs/src/components/examples/HeatDiagramPlotExample.tsx
@@ -16,8 +16,8 @@ async function animate(scene: any) {
   });
 
   // Create Tex labels and wait for rendering
-  const xLabel = new Tex({ latex: '$\\Delta Q$' });
-  const yLabel = new Tex({ latex: 'T[$^\\circ C$]' });
+  const xLabel = new Tex({ latex: '$\\Delta Q$', fontSize: 0.4 });
+  const yLabel = new Tex({ latex: 'T[$^\\circ C$]', fontSize: 0.4 });
   await xLabel.waitForRender();
   await yLabel.waitForRender();
 

--- a/examples/heat_diagram_plot.ts
+++ b/examples/heat_diagram_plot.ts
@@ -30,8 +30,8 @@ document.getElementById('playBtn').addEventListener('click', async () => {
   });
 
   // Create Tex labels and wait for rendering
-  const xLabel = new Tex({ latex: '$\\Delta Q$' });
-  const yLabel = new Tex({ latex: 'T[$^\\circ C$]' });
+  const xLabel = new Tex({ latex: '$\\Delta Q$', fontSize: 0.4 });
+  const yLabel = new Tex({ latex: 'T[$^\\circ C$]', fontSize: 0.4 });
   await xLabel.waitForRender();
   await yLabel.waitForRender();
 


### PR DESCRIPTION
## Summary

- Set `fontSize: 0.4` on ΔQ and T[°C] axis labels in the HeatDiagramPlot example
- After the MathTex SVG scaling fix (#245), the default `fontSize: 1` produces 1-world-unit tall labels, too large for axis labels

## Test plan

- [ ] CI green
- [ ] HeatDiagramPlot example shows properly sized axis labels on docs site