### PR TITLE
Add a pure "source" export to manim-web

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"


### PR DESCRIPTION
## Summary
This change enables people to build libraries directly using the typescript source, without having to bundle it first.
It's mainly a quality-of-life improvement for me: I can use manim-web in my project and bundle everything in one command.
