### PR TITLE
fix: implement showLabels option in ThreeDAxes (#263)

### DIFF
--- a/examples/three_d_axes_labels.html
+++ b/examples/three_d_axes_labels.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ManimWeb - ThreeDAxes showLabels (issue #263)</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: #1a1a2e;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        min-height: 100vh;
+        font-family: system-ui, sans-serif;
+        color: #ddd;
+      }
+      h1 {
+        margin: 16px;
+        font-size: 18px;
+      }
+      #container {
+        border: 2px solid #333;
+        border-radius: 8px;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>ThreeDAxes with <code>showLabels: true</code> (regression test for #263)</h1>
+    <div id="container"></div>
+    <script type="module" src="./three_d_axes_labels.ts"></script>
+  </body>
+</html>

--- a/examples/three_d_axes_labels.ts
+++ b/examples/three_d_axes_labels.ts
@@ -7,8 +7,8 @@ const scene = new ThreeDScene(container, {
   backgroundColor: '#191919',
   phi: 75 * (Math.PI / 180),
   theta: -45 * (Math.PI / 180),
-  distance: 20,
-  fov: 30,
+  distance: 24,
+  fov: 35,
   enableOrbitControls: true,
 });
 

--- a/examples/three_d_axes_labels.ts
+++ b/examples/three_d_axes_labels.ts
@@ -1,0 +1,26 @@
+import { ThreeDAxes, ThreeDScene } from '../src/index.ts';
+
+const container = document.getElementById('container');
+const scene = new ThreeDScene(container, {
+  width: 800,
+  height: 450,
+  backgroundColor: '#191919',
+  phi: 75 * (Math.PI / 180),
+  theta: -45 * (Math.PI / 180),
+  distance: 20,
+  fov: 30,
+  enableOrbitControls: true,
+});
+
+const axes = new ThreeDAxes({
+  xRange: [-5, 5, 1],
+  yRange: [-5, 5, 1],
+  zRange: [-5, 5, 1],
+  showLabels: true,
+  xColor: '#ff6b6b',
+  yColor: '#6bcb77',
+  zColor: '#4d96ff',
+});
+
+scene.add(axes);
+await scene.wait(Infinity);

--- a/examples/three_d_axes_labels.ts
+++ b/examples/three_d_axes_labels.ts
@@ -23,4 +23,12 @@ const axes = new ThreeDAxes({
 });
 
 scene.add(axes);
+
+// Opt-in Manim CE `shift_onto_screen` equivalent: pull any axis label back
+// toward the origin if it would render outside the viewport.
+// Called after the first render so MathTex sizes exist and the camera matrix
+// is up-to-date.
+await scene.wait(0.05);
+axes.shiftLabelsOntoScreen(scene.camera3D.getCamera());
+
 await scene.wait(Infinity);

--- a/examples/three_d_axes_labels_shift.html
+++ b/examples/three_d_axes_labels_shift.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>shiftLabelsOntoScreen stress test</title>
+    <style>
+      body {
+        margin: 0;
+        background: #191919;
+        color: #ccc;
+        font-family: system-ui, sans-serif;
+      }
+      .row {
+        display: flex;
+        gap: 16px;
+        padding: 16px;
+      }
+      .cell {
+        border: 1px solid #333;
+      }
+      h3 {
+        margin: 8px;
+        font-size: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="row">
+      <div class="cell"><h3>before shift (labels clip)</h3><div id="c1"></div></div>
+      <div class="cell"><h3>after shift</h3><div id="c2"></div></div>
+    </div>
+    <script type="module" src="./three_d_axes_labels_shift.ts"></script>
+  </body>
+</html>

--- a/examples/three_d_axes_labels_shift.ts
+++ b/examples/three_d_axes_labels_shift.ts
@@ -1,0 +1,51 @@
+import { ThreeDAxes, ThreeDScene } from '../src/index.ts';
+
+async function makeScene(id: string, shift: boolean) {
+  const container = document.getElementById(id);
+  const scene = new ThreeDScene(container, {
+    width: 500,
+    height: 500,
+    backgroundColor: '#191919',
+    phi: 75 * (Math.PI / 180),
+    theta: -45 * (Math.PI / 180),
+    // Deliberately tight: camera close + narrow FOV so default axis tips clip.
+    distance: 12,
+    fov: 25,
+  });
+
+  const axes = new ThreeDAxes({
+    xRange: [-5, 5, 1],
+    yRange: [-5, 5, 1],
+    zRange: [-5, 5, 1],
+    showLabels: true,
+    xColor: '#ff6b6b',
+    yColor: '#6bcb77',
+    zColor: '#4d96ff',
+  });
+  scene.add(axes);
+
+  // Let MathTex finish + camera/matrices update.
+  await scene.wait(0.1);
+  if (shift) {
+    axes.shiftLabelsOntoScreen(scene.camera3D.getCamera(), 0.08);
+  }
+
+  // Log positions to console for verification.
+  const cam = scene.camera3D.getCamera();
+  cam.updateMatrixWorld();
+  for (const [name, lbl] of [
+    ['x', axes.getXLabel()],
+    ['y', axes.getYLabel()],
+    ['z', axes.getZLabel()],
+  ] as const) {
+    const world = lbl!.getThreeObject().getWorldPosition(new (await import('three')).Vector3());
+    const ndc = world.clone().project(cam);
+    console.log(
+      `[${shift ? 'SHIFT' : 'BEFORE'}] ${name}: world=(${world.x.toFixed(2)},${world.y.toFixed(2)},${world.z.toFixed(2)}) ndc=(${ndc.x.toFixed(2)},${ndc.y.toFixed(2)})`,
+    );
+  }
+
+  await scene.wait(Infinity);
+}
+
+await Promise.all([makeScene('c1', false), makeScene('c2', true)]);

--- a/src/mobjects/three-d/ThreeDAxes.test.ts
+++ b/src/mobjects/three-d/ThreeDAxes.test.ts
@@ -78,6 +78,48 @@ describe('ThreeDAxes showLabels', () => {
     expect(zPos.z).toBeCloseTo(0);
   });
 
+  it('installs an onBeforeRender billboard hook on each label by default', () => {
+    const axes = new ThreeDAxes({ showLabels: true });
+    for (const label of [axes.getXLabel(), axes.getYLabel(), axes.getZLabel()]) {
+      expect(label!.getThreeObject().onBeforeRender).toBeInstanceOf(Function);
+    }
+
+    // The hook copies camera.quaternion onto the label's THREE object.
+    const cam = new THREE.PerspectiveCamera(50, 1, 0.1, 100);
+    cam.position.set(5, 5, 5);
+    cam.lookAt(0, 0, 0);
+    cam.updateMatrixWorld();
+    const dummyScene = new THREE.Scene();
+    const renderer = {} as THREE.WebGLRenderer;
+    const label = axes.getXLabel()!;
+    const three = label.getThreeObject();
+    three.onBeforeRender!(
+      renderer,
+      dummyScene,
+      cam,
+      three as THREE.Mesh,
+      {} as THREE.Material,
+      null,
+    );
+    expect(three.quaternion.x).toBeCloseTo(cam.quaternion.x);
+    expect(three.quaternion.y).toBeCloseTo(cam.quaternion.y);
+    expect(three.quaternion.z).toBeCloseTo(cam.quaternion.z);
+    expect(three.quaternion.w).toBeCloseTo(cam.quaternion.w);
+  });
+
+  it('skips billboard hook when billboardLabels is false', () => {
+    const axes = new ThreeDAxes({ showLabels: true, billboardLabels: false });
+    for (const label of [axes.getXLabel(), axes.getYLabel(), axes.getZLabel()]) {
+      // Default `onBeforeRender` on a THREE.Object3D is a no-op function; we
+      // only care that we didn't overwrite it.
+      const fn = label!.getThreeObject().onBeforeRender;
+      // The default is a reference-shared no-op function from Object3D's
+      // prototype; calling it does nothing, so its toString shouldn't
+      // reference camera.quaternion.
+      expect(String(fn)).not.toContain('camera.quaternion');
+    }
+  });
+
   it('leaves labels upright (MathTexImage plane already stands vertical in THREE)', () => {
     // Manim CE rotates its z-label PI/2 around X because its native coord
     // system has Z up and Text lies on XY by default. In THREE, MathTexImage's

--- a/src/mobjects/three-d/ThreeDAxes.test.ts
+++ b/src/mobjects/three-d/ThreeDAxes.test.ts
@@ -9,6 +9,7 @@
  * - Z label rotated PI/2 around X so it stands upright,
  * - `getAxisLabels(x, y, z)` creates labels on demand with overrides.
  */
+import * as THREE from 'three';
 import { describe, expect, it } from 'vitest';
 import { Group } from '../../core/Group';
 import { Mobject } from '../../core/Mobject';
@@ -49,32 +50,35 @@ describe('ThreeDAxes showLabels', () => {
     expect(labelGroup.children).toContain(axes.getZLabel());
   });
 
-  it('positions labels just past the arrow tip along each axis', () => {
+  it('positions labels using Manim CE direction vectors (UR, UP*0.5+RIGHT, RIGHT)', () => {
+    const buf = 0.4;
     const axes = new ThreeDAxes({
       xRange: [-5, 5, 1],
       yRange: [-5, 5, 1],
       zRange: [-5, 5, 1],
       showLabels: true,
-      labelBuffer: 0.4,
+      labelBuffer: buf,
     });
 
-    // Manim→THREE: (mx, my, mz) → (mx, mz, -my)
-    // X at Manim (5.4, 0, 0) → THREE (5.4, 0, 0)
+    // Helper: Manim→THREE map is (mx, my, mz) → (mx, mz, -my)
+    // X: Manim offset buf * normalize(1, 1, 0) = buf * (1/√2, 1/√2, 0).
+    const sqrt2Inv = 1 / Math.sqrt(2);
     const xPos = axes.getXLabel()!.position;
-    expect(xPos.x).toBeCloseTo(5.4);
+    expect(xPos.x).toBeCloseTo(5 + buf * sqrt2Inv);
     expect(xPos.y).toBeCloseTo(0);
-    expect(xPos.z).toBeCloseTo(0);
+    expect(xPos.z).toBeCloseTo(-buf * sqrt2Inv);
 
-    // Y at Manim (0, 5.4, 0) → THREE (0, 0, -5.4)
+    // Y: Manim offset buf * normalize(1, 0.5, 0) = buf * (1, 0.5, 0)/√1.25.
+    const invLen = 1 / Math.sqrt(1.25);
     const yPos = axes.getYLabel()!.position;
-    expect(yPos.x).toBeCloseTo(0);
+    expect(yPos.x).toBeCloseTo(buf * invLen);
     expect(yPos.y).toBeCloseTo(0);
-    expect(yPos.z).toBeCloseTo(-5.4);
+    expect(yPos.z).toBeCloseTo(-(5 + buf * 0.5 * invLen));
 
-    // Z at Manim (0, 0, 5.4) → THREE (0, 5.4, 0)
+    // Z: Manim offset buf * (1, 0, 0) → THREE (buf, zMax, 0).
     const zPos = axes.getZLabel()!.position;
-    expect(zPos.x).toBeCloseTo(0);
-    expect(zPos.y).toBeCloseTo(5.4);
+    expect(zPos.x).toBeCloseTo(buf);
+    expect(zPos.y).toBeCloseTo(5);
     expect(zPos.z).toBeCloseTo(0);
   });
 
@@ -174,6 +178,66 @@ describe('ThreeDAxes showLabels', () => {
       expect(axes.getXLabel()).not.toBe(oldX);
       expect(group.children).not.toContain(oldX);
       expect(group.children).toContain(axes.getXLabel());
+    });
+  });
+
+  describe('shiftLabelsOntoScreen (Manim CE shift_onto_screen parity)', () => {
+    // Use a tight camera so the far axis tips land outside the viewport.
+    const makeTightCamera = () => {
+      const cam = new THREE.PerspectiveCamera(20, 1, 0.1, 1000);
+      cam.position.set(0, 8, 8);
+      cam.lookAt(0, 0, 0);
+      cam.updateMatrixWorld();
+      return cam;
+    };
+
+    it('is a no-op when labels already fit the viewport', () => {
+      const axes = new ThreeDAxes({
+        xRange: [-1, 1, 1],
+        yRange: [-1, 1, 1],
+        zRange: [-1, 1, 1],
+        showLabels: true,
+      });
+      const cam = new THREE.PerspectiveCamera(80, 1, 0.1, 1000);
+      cam.position.set(0, 6, 6);
+      cam.lookAt(0, 0, 0);
+      cam.updateMatrixWorld();
+      const before = axes.getXLabel()!.position.clone();
+      axes.shiftLabelsOntoScreen(cam);
+      expect(axes.getXLabel()!.position.distanceTo(before)).toBeLessThan(1e-6);
+    });
+
+    it('pulls labels back toward the origin when they overflow the viewport', () => {
+      const axes = new ThreeDAxes({
+        xRange: [-5, 5, 1],
+        yRange: [-5, 5, 1],
+        zRange: [-5, 5, 1],
+        showLabels: true,
+      });
+      const cam = makeTightCamera();
+      const beforeX = axes.getXLabel()!.position.clone();
+      axes.shiftLabelsOntoScreen(cam);
+      const afterX = axes.getXLabel()!.position;
+      // Label moved strictly closer to the origin along the same ray.
+      expect(afterX.length()).toBeLessThan(beforeX.length());
+      // Direction preserved: dot > 0 means still on the +X-ish ray.
+      expect(afterX.dot(beforeX)).toBeGreaterThan(0);
+    });
+
+    it('leaves label NDC within [-limit, limit] after shifting', () => {
+      const axes = new ThreeDAxes({
+        xRange: [-10, 10, 1],
+        yRange: [-10, 10, 1],
+        zRange: [-10, 10, 1],
+        showLabels: true,
+      });
+      const cam = makeTightCamera();
+      const margin = 0.05;
+      axes.shiftLabelsOntoScreen(cam, margin);
+
+      const ndcX = axes.getXLabel()!.position.clone().project(cam);
+      expect(Math.abs(ndcX.x)).toBeLessThanOrEqual(1 - margin + 1e-3);
+      expect(Math.abs(ndcX.y)).toBeLessThanOrEqual(1 - margin + 1e-3);
     });
   });
 });

--- a/src/mobjects/three-d/ThreeDAxes.test.ts
+++ b/src/mobjects/three-d/ThreeDAxes.test.ts
@@ -78,45 +78,57 @@ describe('ThreeDAxes showLabels', () => {
     expect(zPos.z).toBeCloseTo(0);
   });
 
-  it('installs an onBeforeRender billboard hook on each label by default', () => {
+  // Helper: find the Mesh nested inside a MathTexImage-style Group.
+  const findMesh = (obj: THREE.Object3D): THREE.Mesh | null => {
+    let found: THREE.Mesh | null = null;
+    obj.traverse((child) => {
+      if (!found && child instanceof THREE.Mesh) found = child;
+    });
+    return found;
+  };
+
+  it('installs an onBeforeRender billboard hook on each label mesh by default', () => {
     const axes = new ThreeDAxes({ showLabels: true });
     for (const label of [axes.getXLabel(), axes.getYLabel(), axes.getZLabel()]) {
-      expect(label!.getThreeObject().onBeforeRender).toBeInstanceOf(Function);
+      const mesh = findMesh(label!.getThreeObject());
+      expect(mesh).not.toBeNull();
+      expect(mesh!.onBeforeRender).toBeInstanceOf(Function);
     }
+  });
 
-    // The hook copies camera.quaternion onto the label's THREE object.
+  it('billboard hook aligns mesh world rotation with the camera', () => {
+    const axes = new ThreeDAxes({ showLabels: true });
+    // Put the axes into a THREE scene so matrixWorld on the mesh resolves.
+    const dummyScene = new THREE.Scene();
+    dummyScene.add(axes.getThreeObject());
+
     const cam = new THREE.PerspectiveCamera(50, 1, 0.1, 100);
-    cam.position.set(5, 5, 5);
+    cam.position.set(5, 3, 8);
     cam.lookAt(0, 0, 0);
     cam.updateMatrixWorld();
-    const dummyScene = new THREE.Scene();
+
+    const mesh = findMesh(axes.getXLabel()!.getThreeObject())!;
     const renderer = {} as THREE.WebGLRenderer;
-    const label = axes.getXLabel()!;
-    const three = label.getThreeObject();
-    three.onBeforeRender!(
+    mesh.onBeforeRender!(
       renderer,
       dummyScene,
       cam,
-      three as THREE.Mesh,
-      {} as THREE.Material,
+      mesh.geometry,
+      mesh.material as THREE.Material,
       null,
     );
-    expect(three.quaternion.x).toBeCloseTo(cam.quaternion.x);
-    expect(three.quaternion.y).toBeCloseTo(cam.quaternion.y);
-    expect(three.quaternion.z).toBeCloseTo(cam.quaternion.z);
-    expect(three.quaternion.w).toBeCloseTo(cam.quaternion.w);
+    const meshWorldQuat = new THREE.Quaternion();
+    mesh.getWorldQuaternion(meshWorldQuat);
+    expect(meshWorldQuat.angleTo(cam.quaternion)).toBeLessThan(1e-3);
   });
 
   it('skips billboard hook when billboardLabels is false', () => {
     const axes = new ThreeDAxes({ showLabels: true, billboardLabels: false });
     for (const label of [axes.getXLabel(), axes.getYLabel(), axes.getZLabel()]) {
-      // Default `onBeforeRender` on a THREE.Object3D is a no-op function; we
-      // only care that we didn't overwrite it.
-      const fn = label!.getThreeObject().onBeforeRender;
-      // The default is a reference-shared no-op function from Object3D's
-      // prototype; calling it does nothing, so its toString shouldn't
-      // reference camera.quaternion.
-      expect(String(fn)).not.toContain('camera.quaternion');
+      const mesh = findMesh(label!.getThreeObject());
+      // Default Object3D.onBeforeRender is a reference-shared no-op. It does
+      // NOT mention camera.quaternion in its source.
+      expect(String(mesh!.onBeforeRender)).not.toContain('camera.quaternion');
     }
   });
 

--- a/src/mobjects/three-d/ThreeDAxes.test.ts
+++ b/src/mobjects/three-d/ThreeDAxes.test.ts
@@ -3,10 +3,16 @@
  *
  * Before the fix, `showLabels: true` was accepted by the options type
  * but ignored, so no label mobjects were ever added.
+ *
+ * Label rendering mirrors Manim CE's `ThreeDAxes.get_axis_labels`:
+ * - defaults "x", "y", "z" rendered via MathTex (italic math),
+ * - Z label rotated PI/2 around X so it stands upright,
+ * - `getAxisLabels(x, y, z)` creates labels on demand with overrides.
  */
 import { describe, expect, it } from 'vitest';
 import { Group } from '../../core/Group';
 import { Mobject } from '../../core/Mobject';
+import { MathTexImage } from '../text/MathTexImage';
 import { Text } from '../text/Text';
 import { ThreeDAxes } from './ThreeDAxes';
 
@@ -16,32 +22,31 @@ describe('ThreeDAxes showLabels', () => {
     expect(axes.getXLabel()).toBeNull();
     expect(axes.getYLabel()).toBeNull();
     expect(axes.getZLabel()).toBeNull();
-    expect(axes.getAxisLabels().children.length).toBe(0);
   });
 
-  it('creates x/y/z labels when showLabels is true', () => {
+  it('creates x/y/z MathTex labels when showLabels is true', () => {
     const axes = new ThreeDAxes({ showLabels: true });
 
     const xLabel = axes.getXLabel();
     const yLabel = axes.getYLabel();
     const zLabel = axes.getZLabel();
 
-    expect(xLabel).not.toBeNull();
-    expect(yLabel).not.toBeNull();
-    expect(zLabel).not.toBeNull();
+    expect(xLabel).toBeInstanceOf(MathTexImage);
+    expect(yLabel).toBeInstanceOf(MathTexImage);
+    expect(zLabel).toBeInstanceOf(MathTexImage);
 
-    expect(xLabel).toBeInstanceOf(Text);
-    expect((xLabel as Text).getText()).toBe('x');
-    expect((yLabel as Text).getText()).toBe('y');
-    expect((zLabel as Text).getText()).toBe('z');
+    expect((xLabel as MathTexImage).getLatex()).toBe('x');
+    expect((yLabel as MathTexImage).getLatex()).toBe('y');
+    expect((zLabel as MathTexImage).getLatex()).toBe('z');
   });
 
-  it('adds label mobjects as children of the axes group', () => {
+  it('adds label mobjects as descendants of the axes group', () => {
     const axes = new ThreeDAxes({ showLabels: true });
-    const children = axes.children;
-    expect(children).toContain(axes.getXLabel());
-    expect(children).toContain(axes.getYLabel());
-    expect(children).toContain(axes.getZLabel());
+    const labelGroup = axes.getAxisLabels();
+    expect(axes.children).toContain(labelGroup);
+    expect(labelGroup.children).toContain(axes.getXLabel());
+    expect(labelGroup.children).toContain(axes.getYLabel());
+    expect(labelGroup.children).toContain(axes.getZLabel());
   });
 
   it('positions labels just past the arrow tip along each axis', () => {
@@ -53,34 +58,45 @@ describe('ThreeDAxes showLabels', () => {
       labelBuffer: 0.4,
     });
 
-    // Manim→THREE mapping: (mx, my, mz) → (mx, mz, -my)
-    // X label at Manim (5.4, 0, 0) → THREE (5.4, 0, 0)
+    // Manim→THREE: (mx, my, mz) → (mx, mz, -my)
+    // X at Manim (5.4, 0, 0) → THREE (5.4, 0, 0)
     const xPos = axes.getXLabel()!.position;
     expect(xPos.x).toBeCloseTo(5.4);
     expect(xPos.y).toBeCloseTo(0);
     expect(xPos.z).toBeCloseTo(0);
 
-    // Y label at Manim (0, 5.4, 0) → THREE (0, 0, -5.4)
+    // Y at Manim (0, 5.4, 0) → THREE (0, 0, -5.4)
     const yPos = axes.getYLabel()!.position;
     expect(yPos.x).toBeCloseTo(0);
     expect(yPos.y).toBeCloseTo(0);
     expect(yPos.z).toBeCloseTo(-5.4);
 
-    // Z label at Manim (0, 0, 5.4) → THREE (0, 5.4, 0)
+    // Z at Manim (0, 0, 5.4) → THREE (0, 5.4, 0)
     const zPos = axes.getZLabel()!.position;
     expect(zPos.x).toBeCloseTo(0);
     expect(zPos.y).toBeCloseTo(5.4);
     expect(zPos.z).toBeCloseTo(0);
   });
 
+  it('leaves labels upright (MathTexImage plane already stands vertical in THREE)', () => {
+    // Manim CE rotates its z-label PI/2 around X because its native coord
+    // system has Z up and Text lies on XY by default. In THREE, MathTexImage's
+    // plane is already vertical (normal +Z), so no axis-specific rotation is
+    // applied here. All three labels keep identity rotation.
+    const axes = new ThreeDAxes({ showLabels: true });
+    expect(axes.getXLabel()!.rotation.x).toBeCloseTo(0);
+    expect(axes.getYLabel()!.rotation.x).toBeCloseTo(0);
+    expect(axes.getZLabel()!.rotation.x).toBeCloseTo(0);
+  });
+
   it('accepts custom label strings per axis', () => {
     const axes = new ThreeDAxes({
       showLabels: true,
-      labels: { x: 'time', y: 'depth', z: 'height' },
+      labels: { x: 'time', y: 'depth', z: '\\theta' },
     });
-    expect((axes.getXLabel() as Text).getText()).toBe('time');
-    expect((axes.getYLabel() as Text).getText()).toBe('depth');
-    expect((axes.getZLabel() as Text).getText()).toBe('height');
+    expect((axes.getXLabel() as MathTexImage).getLatex()).toBe('time');
+    expect((axes.getYLabel() as MathTexImage).getLatex()).toBe('depth');
+    expect((axes.getZLabel() as MathTexImage).getLatex()).toBe('\\theta');
   });
 
   it('accepts pre-built Mobject labels without wrapping them', () => {
@@ -90,13 +106,6 @@ describe('ThreeDAxes showLabels', () => {
       labels: { x: custom },
     });
     expect(axes.getXLabel()).toBe(custom);
-  });
-
-  it('getAxisLabels returns a Group containing all three labels', () => {
-    const axes = new ThreeDAxes({ showLabels: true });
-    const group = axes.getAxisLabels();
-    expect(group).toBeInstanceOf(Group);
-    expect(group.children.length).toBe(3);
   });
 
   it('colors labels using each axis color', () => {
@@ -118,7 +127,53 @@ describe('ThreeDAxes showLabels', () => {
     });
     const copy = axes.copy() as ThreeDAxes;
     expect(copy.getXLabel()).not.toBeNull();
-    expect((copy.getXLabel() as Text).getText()).toBe('time');
-    expect((copy.getYLabel() as Text).getText()).toBe('y');
+    expect((copy.getXLabel() as MathTexImage).getLatex()).toBe('time');
+    expect((copy.getYLabel() as MathTexImage).getLatex()).toBe('y');
+  });
+
+  describe('getAxisLabels() on-demand creation (Manim CE parity)', () => {
+    it('creates labels on demand when showLabels was false', () => {
+      const axes = new ThreeDAxes();
+      const group = axes.getAxisLabels();
+      expect(group).toBeInstanceOf(Group);
+      expect(group.children.length).toBe(3);
+      expect(axes.getXLabel()).not.toBeNull();
+    });
+
+    it('returns the group of existing labels when already created', () => {
+      const axes = new ThreeDAxes({ showLabels: true });
+      const firstX = axes.getXLabel();
+      const group = axes.getAxisLabels();
+      expect(group.children.length).toBe(3);
+      // Same underlying label mobject if no overrides passed
+      expect(axes.getXLabel()).toBe(firstX);
+    });
+
+    it('overrides label strings when arguments are passed', () => {
+      const axes = new ThreeDAxes();
+      axes.getAxisLabels('\\alpha', '\\beta', '\\gamma');
+      expect((axes.getXLabel() as MathTexImage).getLatex()).toBe('\\alpha');
+      expect((axes.getYLabel() as MathTexImage).getLatex()).toBe('\\beta');
+      expect((axes.getZLabel() as MathTexImage).getLatex()).toBe('\\gamma');
+    });
+
+    it('accepts a Mobject for any individual axis', () => {
+      const axes = new ThreeDAxes();
+      const customY = new Text({ text: 'depth' });
+      axes.getAxisLabels(undefined, customY);
+      expect(axes.getYLabel()).toBe(customY);
+      // x/z still fall back to defaults
+      expect((axes.getXLabel() as MathTexImage).getLatex()).toBe('x');
+      expect((axes.getZLabel() as MathTexImage).getLatex()).toBe('z');
+    });
+
+    it('replaces prior labels in the label group', () => {
+      const axes = new ThreeDAxes({ showLabels: true });
+      const oldX = axes.getXLabel();
+      const group = axes.getAxisLabels('new');
+      expect(axes.getXLabel()).not.toBe(oldX);
+      expect(group.children).not.toContain(oldX);
+      expect(group.children).toContain(axes.getXLabel());
+    });
   });
 });

--- a/src/mobjects/three-d/ThreeDAxes.test.ts
+++ b/src/mobjects/three-d/ThreeDAxes.test.ts
@@ -50,35 +50,31 @@ describe('ThreeDAxes showLabels', () => {
     expect(labelGroup.children).toContain(axes.getZLabel());
   });
 
-  it('positions labels using Manim CE direction vectors (UR, UP*0.5+RIGHT, RIGHT)', () => {
-    const buf = 0.4;
+  it('positions labels just past each arrow tip along the axis direction', () => {
     const axes = new ThreeDAxes({
       xRange: [-5, 5, 1],
       yRange: [-5, 5, 1],
       zRange: [-5, 5, 1],
       showLabels: true,
-      labelBuffer: buf,
+      labelBuffer: 0.4,
     });
 
-    // Helper: Manim→THREE map is (mx, my, mz) → (mx, mz, -my)
-    // X: Manim offset buf * normalize(1, 1, 0) = buf * (1/√2, 1/√2, 0).
-    const sqrt2Inv = 1 / Math.sqrt(2);
+    // Manim→THREE: (mx, my, mz) → (mx, mz, -my)
     const xPos = axes.getXLabel()!.position;
-    expect(xPos.x).toBeCloseTo(5 + buf * sqrt2Inv);
+    expect(xPos.x).toBeCloseTo(5.4);
     expect(xPos.y).toBeCloseTo(0);
-    expect(xPos.z).toBeCloseTo(-buf * sqrt2Inv);
+    expect(xPos.z).toBeCloseTo(0);
 
-    // Y: Manim offset buf * normalize(1, 0.5, 0) = buf * (1, 0.5, 0)/√1.25.
-    const invLen = 1 / Math.sqrt(1.25);
     const yPos = axes.getYLabel()!.position;
-    expect(yPos.x).toBeCloseTo(buf * invLen);
+    expect(yPos.x).toBeCloseTo(0);
     expect(yPos.y).toBeCloseTo(0);
-    expect(yPos.z).toBeCloseTo(-(5 + buf * 0.5 * invLen));
+    expect(yPos.z).toBeCloseTo(-5.4);
 
-    // Z: Manim offset buf * (1, 0, 0) → THREE (buf, zMax, 0).
+    // Z label: offset to the side of the tip (Manim CE RIGHT direction)
+    // so it doesn't sit directly on the arrow.
     const zPos = axes.getZLabel()!.position;
-    expect(zPos.x).toBeCloseTo(buf);
-    expect(zPos.y).toBeCloseTo(5);
+    expect(zPos.x).toBeCloseTo(0.4);
+    expect(zPos.y).toBeCloseTo(5 + 0.4 * 0.3);
     expect(zPos.z).toBeCloseTo(0);
   });
 

--- a/src/mobjects/three-d/ThreeDAxes.test.ts
+++ b/src/mobjects/three-d/ThreeDAxes.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Regression tests for ThreeDAxes labels (issue #263).
+ *
+ * Before the fix, `showLabels: true` was accepted by the options type
+ * but ignored, so no label mobjects were ever added.
+ */
+import { describe, expect, it } from 'vitest';
+import { Group } from '../../core/Group';
+import { Mobject } from '../../core/Mobject';
+import { Text } from '../text/Text';
+import { ThreeDAxes } from './ThreeDAxes';
+
+describe('ThreeDAxes showLabels', () => {
+  it('does not create labels by default', () => {
+    const axes = new ThreeDAxes();
+    expect(axes.getXLabel()).toBeNull();
+    expect(axes.getYLabel()).toBeNull();
+    expect(axes.getZLabel()).toBeNull();
+    expect(axes.getAxisLabels().children.length).toBe(0);
+  });
+
+  it('creates x/y/z labels when showLabels is true', () => {
+    const axes = new ThreeDAxes({ showLabels: true });
+
+    const xLabel = axes.getXLabel();
+    const yLabel = axes.getYLabel();
+    const zLabel = axes.getZLabel();
+
+    expect(xLabel).not.toBeNull();
+    expect(yLabel).not.toBeNull();
+    expect(zLabel).not.toBeNull();
+
+    expect(xLabel).toBeInstanceOf(Text);
+    expect((xLabel as Text).getText()).toBe('x');
+    expect((yLabel as Text).getText()).toBe('y');
+    expect((zLabel as Text).getText()).toBe('z');
+  });
+
+  it('adds label mobjects as children of the axes group', () => {
+    const axes = new ThreeDAxes({ showLabels: true });
+    const children = axes.children;
+    expect(children).toContain(axes.getXLabel());
+    expect(children).toContain(axes.getYLabel());
+    expect(children).toContain(axes.getZLabel());
+  });
+
+  it('positions labels just past the arrow tip along each axis', () => {
+    const axes = new ThreeDAxes({
+      xRange: [-5, 5, 1],
+      yRange: [-5, 5, 1],
+      zRange: [-5, 5, 1],
+      showLabels: true,
+      labelBuffer: 0.4,
+    });
+
+    // Manim→THREE mapping: (mx, my, mz) → (mx, mz, -my)
+    // X label at Manim (5.4, 0, 0) → THREE (5.4, 0, 0)
+    const xPos = axes.getXLabel()!.position;
+    expect(xPos.x).toBeCloseTo(5.4);
+    expect(xPos.y).toBeCloseTo(0);
+    expect(xPos.z).toBeCloseTo(0);
+
+    // Y label at Manim (0, 5.4, 0) → THREE (0, 0, -5.4)
+    const yPos = axes.getYLabel()!.position;
+    expect(yPos.x).toBeCloseTo(0);
+    expect(yPos.y).toBeCloseTo(0);
+    expect(yPos.z).toBeCloseTo(-5.4);
+
+    // Z label at Manim (0, 0, 5.4) → THREE (0, 5.4, 0)
+    const zPos = axes.getZLabel()!.position;
+    expect(zPos.x).toBeCloseTo(0);
+    expect(zPos.y).toBeCloseTo(5.4);
+    expect(zPos.z).toBeCloseTo(0);
+  });
+
+  it('accepts custom label strings per axis', () => {
+    const axes = new ThreeDAxes({
+      showLabels: true,
+      labels: { x: 'time', y: 'depth', z: 'height' },
+    });
+    expect((axes.getXLabel() as Text).getText()).toBe('time');
+    expect((axes.getYLabel() as Text).getText()).toBe('depth');
+    expect((axes.getZLabel() as Text).getText()).toBe('height');
+  });
+
+  it('accepts pre-built Mobject labels without wrapping them', () => {
+    const custom = new Text({ text: 'foo', fontSize: 12 });
+    const axes = new ThreeDAxes({
+      showLabels: true,
+      labels: { x: custom },
+    });
+    expect(axes.getXLabel()).toBe(custom);
+  });
+
+  it('getAxisLabels returns a Group containing all three labels', () => {
+    const axes = new ThreeDAxes({ showLabels: true });
+    const group = axes.getAxisLabels();
+    expect(group).toBeInstanceOf(Group);
+    expect(group.children.length).toBe(3);
+  });
+
+  it('colors labels using each axis color', () => {
+    const axes = new ThreeDAxes({
+      showLabels: true,
+      xColor: '#ff0000',
+      yColor: '#00ff00',
+      zColor: '#0000ff',
+    });
+    expect((axes.getXLabel() as Mobject).color).toBe('#ff0000');
+    expect((axes.getYLabel() as Mobject).color).toBe('#00ff00');
+    expect((axes.getZLabel() as Mobject).color).toBe('#0000ff');
+  });
+
+  it('copies preserve showLabels and custom labels', () => {
+    const axes = new ThreeDAxes({
+      showLabels: true,
+      labels: { x: 'time' },
+    });
+    const copy = axes.copy() as ThreeDAxes;
+    expect(copy.getXLabel()).not.toBeNull();
+    expect((copy.getXLabel() as Text).getText()).toBe('time');
+    expect((copy.getYLabel() as Text).getText()).toBe('y');
+  });
+});

--- a/src/mobjects/three-d/ThreeDAxes.ts
+++ b/src/mobjects/three-d/ThreeDAxes.ts
@@ -318,10 +318,30 @@ export class ThreeDAxes extends Group {
   private _installBillboardHooks(): void {
     for (const label of [this._xLabel, this._yLabel, this._zLabel]) {
       if (!label) continue;
-      const threeObj = label.getThreeObject();
-      threeObj.onBeforeRender = (_renderer, _scene, camera) => {
-        threeObj.quaternion.copy(camera.quaternion);
-      };
+      const root = label.getThreeObject();
+      // `onBeforeRender` only fires on objects THREE actually rasterizes
+      // (meshes/points/lines). MathTexImage wraps its Mesh inside a Group
+      // from `_createThreeObject()`, so traverse and hook each descendant
+      // Mesh. On each draw, align the mesh with the camera's world
+      // quaternion so the label always faces the viewer. We compensate for
+      // the ancestor chain by factoring out `parent.matrixWorld`'s rotation
+      // so the final world rotation equals `camera.quaternion`.
+      root.traverse((child) => {
+        if (!(child instanceof THREE.Mesh)) return;
+        child.onBeforeRender = (_renderer, _scene, camera) => {
+          const parent = child.parent;
+          if (parent) {
+            parent.updateMatrixWorld(true);
+            const parentWorldQuat = new THREE.Quaternion();
+            parent.getWorldQuaternion(parentWorldQuat);
+            child.quaternion.copy(parentWorldQuat.invert()).multiply(camera.quaternion);
+          } else {
+            child.quaternion.copy(camera.quaternion);
+          }
+          child.updateMatrix();
+          child.updateMatrixWorld(true);
+        };
+      });
     }
   }
 

--- a/src/mobjects/three-d/ThreeDAxes.ts
+++ b/src/mobjects/three-d/ThreeDAxes.ts
@@ -449,8 +449,13 @@ export class ThreeDAxes extends Group {
    */
   shiftLabelsOntoScreen(camera: THREE.Camera, margin: number = 0.05): this {
     camera.updateMatrixWorld();
+    // Ensure every label's world matrix is current so projection uses the
+    // live position, not a stale render-cached one.
+    this.getThreeObject().updateMatrixWorld(true);
+
     const origin = new THREE.Vector3();
     this.getThreeObject().localToWorld(origin.set(0, 0, 0));
+    const limit = 1 - margin;
 
     for (const label of [this._xLabel, this._yLabel, this._zLabel]) {
       if (!label) continue;
@@ -459,28 +464,31 @@ export class ThreeDAxes extends Group {
       threeObj.getWorldPosition(worldPos);
 
       const ndc = worldPos.clone().project(camera);
-      const limit = 1 - margin;
       if (Math.abs(ndc.x) <= limit && Math.abs(ndc.y) <= limit) continue;
 
-      // Shift along the vector from origin→label (local axis direction) back
-      // toward the axes origin until the projection fits. Bisect over t ∈ [0, 1]
-      // where t=1 keeps the original position and t=0 collapses to origin.
+      // Bisect t ∈ [0, 1] along origin→label until the projected candidate
+      // fits the viewport. t=1 keeps the original position; t=0 collapses
+      // onto the axes origin.
       const dir = worldPos.clone().sub(origin);
       let lo = 0;
       let hi = 1;
-      for (let i = 0; i < 16; i++) {
+      for (let i = 0; i < 20; i++) {
         const mid = (lo + hi) / 2;
         const candidate = origin.clone().add(dir.clone().multiplyScalar(mid));
-        const p = candidate.project(camera);
-        if (Math.abs(p.x) <= limit && Math.abs(p.y) <= limit) {
+        candidate.project(camera);
+        if (Math.abs(candidate.x) <= limit && Math.abs(candidate.y) <= limit) {
           lo = mid;
         } else {
           hi = mid;
         }
       }
       const finalWorld = origin.clone().add(dir.clone().multiplyScalar(lo));
-      threeObj.parent?.worldToLocal(finalWorld);
-      label.position.copy(finalWorld);
+      const parent = threeObj.parent;
+      if (parent) parent.worldToLocal(finalWorld);
+      // Use moveTo so Mobject._markDirty fires and the next render syncs the
+      // THREE object's position. Direct mutation of `position` would bypass
+      // the dirty flag and leave the on-screen label at the original spot.
+      label.moveTo([finalWorld.x, finalWorld.y, finalWorld.z]);
     }
     return this;
   }

--- a/src/mobjects/three-d/ThreeDAxes.ts
+++ b/src/mobjects/three-d/ThreeDAxes.ts
@@ -1,3 +1,4 @@
+import * as THREE from 'three';
 import { Group } from '../../core/Group';
 import { Mobject, Vector3Tuple } from '../../core/Mobject';
 import { MathTexImage } from '../text/MathTexImage';
@@ -242,9 +243,21 @@ export class ThreeDAxes extends Group {
 
   /**
    * Build label mobjects for each axis.
-   * Matches Manim CE conventions: strings are rendered as MathTex (italic math),
-   * positioned just past each arrow tip, and the Z label is rotated PI/2 around
-   * the X axis so it stands upright next to the Z arrow.
+   *
+   * Matches Manim CE's per-axis direction vectors from
+   * `CoordinateSystem._get_axis_label` / `ThreeDAxes.get_axis_labels`:
+   *   - x: edge at Manim (xMax, 0, 0), offset direction UR = (1, 1, 0)
+   *   - y: edge at Manim (0, yMax, 0), offset direction UP*0.5 + RIGHT = (1, 0.5, 0)
+   *   - z: edge at Manim (0, 0, zMax), offset direction RIGHT = (1, 0, 0)
+   * Buffer magnitude is `labelBuffer` along the normalized direction, which
+   * approximates Manim's `next_to(..., buff=SMALL_BUFF)` for the small label
+   * sizes used on axes.
+   *
+   * The Z label is *not* rotated here. Manim CE calls `rotate(PI/2, axis=RIGHT)`
+   * because its default MathTex lies in the Manim XY plane (normal +Z_manim);
+   * after rotation the normal becomes -Y_manim. Under our Manim→THREE mapping
+   * that target normal equals +Z_THREE — which is already the default
+   * MathTexImage plane orientation. So the rotation is implicit.
    */
   private _createLabels(xColor: string, yColor: string, zColor: string): void {
     const xInput = this._labelOptions?.x ?? 'x';
@@ -260,18 +273,21 @@ export class ThreeDAxes extends Group {
     const yMax = this._yRange[1];
     const zMax = this._zRange[1];
 
-    // X tip → offset along +X
-    const xPos = this._m2t(xMax + buf, 0, 0);
+    // X label: Manim (xMax, 0, 0) + buf * normalize(1, 1, 0)
+    const xDir = this._normalize3(1, 1, 0);
+    const xManim: [number, number, number] = [xMax + buf * xDir[0], buf * xDir[1], buf * xDir[2]];
+    const xPos = this._m2t(xManim[0], xManim[1], xManim[2]);
     this._xLabel.position.set(xPos[0], xPos[1], xPos[2]);
-    // Y tip → offset along +Y (Manim) = -Z (THREE)
-    const yPos = this._m2t(0, yMax + buf, 0);
+
+    // Y label: Manim (0, yMax, 0) + buf * normalize(1, 0.5, 0)
+    const yDir = this._normalize3(1, 0.5, 0);
+    const yManim: [number, number, number] = [buf * yDir[0], yMax + buf * yDir[1], buf * yDir[2]];
+    const yPos = this._m2t(yManim[0], yManim[1], yManim[2]);
     this._yLabel.position.set(yPos[0], yPos[1], yPos[2]);
-    // Z tip → offset along +Z (Manim) = +Y (THREE).
-    // Note: Manim CE calls `rotate(PI/2, axis=RIGHT)` on the z-label because
-    // in Manim's default coord system (Z up) a bare MathTex sits flat on XY.
-    // In THREE, MathTexImage's plane is already vertical (normal = +Z_THREE),
-    // so no extra rotation is needed — it stands upright next to the Z arrow.
-    const zPos = this._m2t(0, 0, zMax + buf);
+
+    // Z label: Manim (0, 0, zMax) + buf * (1, 0, 0)
+    const zManim: [number, number, number] = [buf, 0, zMax];
+    const zPos = this._m2t(zManim[0], zManim[1], zManim[2]);
     this._zLabel.position.set(zPos[0], zPos[1], zPos[2]);
 
     // Labels live in a dedicated Group so `getAxisLabels()` can return the
@@ -284,6 +300,11 @@ export class ThreeDAxes extends Group {
     this._labelGroup.add(this._xLabel);
     this._labelGroup.add(this._yLabel);
     this._labelGroup.add(this._zLabel);
+  }
+
+  private _normalize3(x: number, y: number, z: number): [number, number, number] {
+    const len = Math.hypot(x, y, z);
+    return len > 0 ? [x / len, y / len, z / len] : [0, 0, 0];
   }
 
   /**
@@ -409,6 +430,59 @@ export class ThreeDAxes extends Group {
    */
   c2pZ(z: number): number {
     return this.coordsToPoint(0, 0, z)[2];
+  }
+
+  /**
+   * Manim CE's `shift_onto_screen` equivalent. Call once the scene/camera
+   * exist (e.g. after `scene.add(axes)` and a first render). Projects each
+   * axis label to normalized device coordinates using the supplied camera and,
+   * if the label sits outside the [-1, 1] viewport box, shifts it back along
+   * the vector to its axis tip until it lies inside.
+   *
+   * Requires runtime access to the camera, which `ThreeDAxes` has no handle
+   * on at construction time — so this is an opt-in method rather than
+   * automatic.
+   *
+   * @param camera - The camera the scene is rendering with (perspective/ortho).
+   * @param margin - Fraction of NDC to keep as padding inside the viewport.
+   *                 Default 0.05 (5% margin).
+   */
+  shiftLabelsOntoScreen(camera: THREE.Camera, margin: number = 0.05): this {
+    camera.updateMatrixWorld();
+    const origin = new THREE.Vector3();
+    this.getThreeObject().localToWorld(origin.set(0, 0, 0));
+
+    for (const label of [this._xLabel, this._yLabel, this._zLabel]) {
+      if (!label) continue;
+      const threeObj = label.getThreeObject();
+      const worldPos = new THREE.Vector3();
+      threeObj.getWorldPosition(worldPos);
+
+      const ndc = worldPos.clone().project(camera);
+      const limit = 1 - margin;
+      if (Math.abs(ndc.x) <= limit && Math.abs(ndc.y) <= limit) continue;
+
+      // Shift along the vector from origin→label (local axis direction) back
+      // toward the axes origin until the projection fits. Bisect over t ∈ [0, 1]
+      // where t=1 keeps the original position and t=0 collapses to origin.
+      const dir = worldPos.clone().sub(origin);
+      let lo = 0;
+      let hi = 1;
+      for (let i = 0; i < 16; i++) {
+        const mid = (lo + hi) / 2;
+        const candidate = origin.clone().add(dir.clone().multiplyScalar(mid));
+        const p = candidate.project(camera);
+        if (Math.abs(p.x) <= limit && Math.abs(p.y) <= limit) {
+          lo = mid;
+        } else {
+          hi = mid;
+        }
+      }
+      const finalWorld = origin.clone().add(dir.clone().multiplyScalar(lo));
+      threeObj.parent?.worldToLocal(finalWorld);
+      label.position.copy(finalWorld);
+    }
+    return this;
   }
 
   /**

--- a/src/mobjects/three-d/ThreeDAxes.ts
+++ b/src/mobjects/three-d/ThreeDAxes.ts
@@ -86,16 +86,16 @@ export class ThreeDAxes extends Group {
   private _xAxis: Arrow3D;
   private _yAxis: Arrow3D;
   private _zAxis: Arrow3D;
-  private _xRange: [number, number, number];
-  private _yRange: [number, number, number];
-  private _zRange: [number, number, number];
-  private _showTicks: boolean;
-  private _tickLength: number;
+  private _xRange!: [number, number, number];
+  private _yRange!: [number, number, number];
+  private _zRange!: [number, number, number];
+  private _showTicks!: boolean;
+  private _tickLength!: number;
   private _ticks: Line3D[] = [];
-  private _showLabels: boolean;
-  private _labelFontSize: number;
-  private _labelBuffer: number;
-  private _billboardLabels: boolean;
+  private _showLabels!: boolean;
+  private _labelFontSize!: number;
+  private _labelBuffer!: number;
+  private _billboardLabels!: boolean;
   private _xLabel: Mobject | null = null;
   private _yLabel: Mobject | null = null;
   private _zLabel: Mobject | null = null;
@@ -106,87 +106,101 @@ export class ThreeDAxes extends Group {
     super();
     this._disableChildZLayering = true;
 
-    const {
-      xRange = [-6, 6, 1],
-      yRange = [-5, 5, 1],
-      zRange = [-4, 4, 1],
-      axisColor = '#ffffff',
-      xColor,
-      yColor,
-      zColor,
-      showLabels = false,
-      labels,
-      labelFontSize = 32,
-      labelBuffer = 0.4,
-      billboardLabels = true,
-      showTicks = true,
-      tickLength = 0.15,
-      tipLength = 0.2,
-      tipRadius = 0.08,
-      shaftRadius = 0.01,
-    } = options;
+    const ranges = this._initRanges(options);
+    this._initTickConfig(options);
+    this._initLabelConfig(options);
 
-    this._xRange = [...xRange];
-    this._yRange = [...yRange];
-    this._zRange = [...zRange];
-    this._showTicks = showTicks;
-    this._tickLength = tickLength;
-    this._showLabels = showLabels;
-    this._labelFontSize = labelFontSize;
-    this._labelBuffer = labelBuffer;
-    this._billboardLabels = billboardLabels;
-    this._labelOptions = labels;
+    const colors = this._resolveAxisColors(options);
+    const arrowCfg = this._resolveArrowConfig(options);
 
-    const effectiveXColor = xColor ?? axisColor;
-    const effectiveYColor = yColor ?? axisColor;
-    const effectiveZColor = zColor ?? axisColor;
-
-    // Unit_size=1: graph coordinates map directly to visual positions (matching Python manim)
-    // Manim→THREE.js coordinate mapping: (mx, my, mz) → (mx, mz, -my)
-
-    // Create X-axis (Manim +X → THREE.js +X)
-    this._xAxis = new Arrow3D({
-      start: [xRange[0], 0, 0],
-      end: [xRange[1], 0, 0],
-      color: effectiveXColor,
-      tipLength,
-      tipRadius,
-      shaftRadius,
-    });
-
-    // Create Y-axis (Manim +Y → THREE.js -Z)
-    this._yAxis = new Arrow3D({
-      start: [0, 0, -yRange[0]],
-      end: [0, 0, -yRange[1]],
-      color: effectiveYColor,
-      tipLength,
-      tipRadius,
-      shaftRadius,
-    });
-
-    // Create Z-axis (Manim +Z → THREE.js +Y, up)
-    this._zAxis = new Arrow3D({
-      start: [0, zRange[0], 0],
-      end: [0, zRange[1], 0],
-      color: effectiveZColor,
-      tipLength,
-      tipRadius,
-      shaftRadius,
-    });
+    this._xAxis = this._buildAxisArrow(
+      [ranges.x[0], 0, 0],
+      [ranges.x[1], 0, 0],
+      colors.x,
+      arrowCfg,
+    );
+    // Manim +Y maps to THREE -Z.
+    this._yAxis = this._buildAxisArrow(
+      [0, 0, -ranges.y[0]],
+      [0, 0, -ranges.y[1]],
+      colors.y,
+      arrowCfg,
+    );
+    // Manim +Z maps to THREE +Y (up).
+    this._zAxis = this._buildAxisArrow(
+      [0, ranges.z[0], 0],
+      [0, ranges.z[1], 0],
+      colors.z,
+      arrowCfg,
+    );
 
     this.add(this._xAxis);
     this.add(this._yAxis);
     this.add(this._zAxis);
 
-    // Add tick marks if enabled
-    if (showTicks) {
-      this._createTicks(effectiveXColor, effectiveYColor, effectiveZColor);
+    if (this._showTicks) {
+      this._createTicks(colors.x, colors.y, colors.z);
     }
+    if (this._showLabels) {
+      this._createLabels(colors.x, colors.y, colors.z);
+    }
+  }
 
-    // Add axis labels if enabled
-    if (showLabels) {
-      this._createLabels(effectiveXColor, effectiveYColor, effectiveZColor);
-    }
+  private _initRanges(options: ThreeDAxesOptions): {
+    x: [number, number, number];
+    y: [number, number, number];
+    z: [number, number, number];
+  } {
+    const x: [number, number, number] = [...(options.xRange ?? [-6, 6, 1])];
+    const y: [number, number, number] = [...(options.yRange ?? [-5, 5, 1])];
+    const z: [number, number, number] = [...(options.zRange ?? [-4, 4, 1])];
+    this._xRange = x;
+    this._yRange = y;
+    this._zRange = z;
+    return { x, y, z };
+  }
+
+  private _initTickConfig(options: ThreeDAxesOptions): void {
+    this._showTicks = options.showTicks ?? true;
+    this._tickLength = options.tickLength ?? 0.15;
+  }
+
+  private _initLabelConfig(options: ThreeDAxesOptions): void {
+    this._showLabels = options.showLabels ?? false;
+    this._labelFontSize = options.labelFontSize ?? 32;
+    this._labelBuffer = options.labelBuffer ?? 0.4;
+    this._billboardLabels = options.billboardLabels ?? true;
+    this._labelOptions = options.labels;
+  }
+
+  private _resolveAxisColors(options: ThreeDAxesOptions): { x: string; y: string; z: string } {
+    const axisColor = options.axisColor ?? '#ffffff';
+    return {
+      x: options.xColor ?? axisColor,
+      y: options.yColor ?? axisColor,
+      z: options.zColor ?? axisColor,
+    };
+  }
+
+  private _resolveArrowConfig(options: ThreeDAxesOptions): {
+    tipLength: number;
+    tipRadius: number;
+    shaftRadius: number;
+  } {
+    return {
+      tipLength: options.tipLength ?? 0.2,
+      tipRadius: options.tipRadius ?? 0.08,
+      shaftRadius: options.shaftRadius ?? 0.01,
+    };
+  }
+
+  private _buildAxisArrow(
+    start: [number, number, number],
+    end: [number, number, number],
+    color: string,
+    arrow: { tipLength: number; tipRadius: number; shaftRadius: number },
+  ): Arrow3D {
+    return new Arrow3D({ start, end, color, ...arrow });
   }
 
   /**
@@ -569,37 +583,42 @@ export class ThreeDAxes extends Group {
     yLabel?: string | Mobject,
     zLabel?: string | Mobject,
   ): Group {
-    const needsCreate =
-      xLabel !== undefined || yLabel !== undefined || zLabel !== undefined || !this._showLabels;
-
-    if (needsCreate) {
-      // Merge args with construction-time label options (args win).
-      this._labelOptions = {
-        x: xLabel ?? this._labelOptions?.x,
-        y: yLabel ?? this._labelOptions?.y,
-        z: zLabel ?? this._labelOptions?.z,
-      };
-      this._showLabels = true;
-      // Drop any previously created labels so we don't orphan children.
-      if (this._labelGroup) {
-        if (this._xLabel) this._labelGroup.remove(this._xLabel);
-        if (this._yLabel) this._labelGroup.remove(this._yLabel);
-        if (this._zLabel) this._labelGroup.remove(this._zLabel);
-      }
-      this._xLabel = this._yLabel = this._zLabel = null;
-
-      // Recreate with the same per-axis colors used by the arrows.
-      this._createLabels(
-        this._xAxis.color as string,
-        this._yAxis.color as string,
-        this._zAxis.color as string,
-      );
+    const hasOverride = xLabel !== undefined || yLabel !== undefined || zLabel !== undefined;
+    if (hasOverride || !this._showLabels) {
+      this._rebuildLabels(xLabel, yLabel, zLabel);
     }
-
-    // Return the persistent internal Group; adding it to a scene wouldn't
-    // make sense (it's a child of `this`), but callers typically use it to
-    // animate / style the labels collectively.
+    // Persistent internal Group; callers use it to animate/style labels
+    // collectively. Labels remain parented to this axes.
     return this._labelGroup ?? new Group();
+  }
+
+  private _rebuildLabels(
+    xLabel?: string | Mobject,
+    yLabel?: string | Mobject,
+    zLabel?: string | Mobject,
+  ): void {
+    this._labelOptions = {
+      x: xLabel ?? this._labelOptions?.x,
+      y: yLabel ?? this._labelOptions?.y,
+      z: zLabel ?? this._labelOptions?.z,
+    };
+    this._showLabels = true;
+    this._detachExistingLabels();
+    this._createLabels(
+      this._xAxis.color as string,
+      this._yAxis.color as string,
+      this._zAxis.color as string,
+    );
+  }
+
+  private _detachExistingLabels(): void {
+    if (!this._labelGroup) return;
+    if (this._xLabel) this._labelGroup.remove(this._xLabel);
+    if (this._yLabel) this._labelGroup.remove(this._yLabel);
+    if (this._zLabel) this._labelGroup.remove(this._zLabel);
+    this._xLabel = null;
+    this._yLabel = null;
+    this._zLabel = null;
   }
 
   /**

--- a/src/mobjects/three-d/ThreeDAxes.ts
+++ b/src/mobjects/three-d/ThreeDAxes.ts
@@ -35,6 +35,11 @@ export interface ThreeDAxesOptions {
   labelFontSize?: number;
   /** Offset in world units from each axis tip to its label. Default: 0.4 */
   labelBuffer?: number;
+  /**
+   * Whether axis labels rotate to always face the camera (Manim CE's
+   * `add_fixed_orientation_mobjects` behavior). Default: true.
+   */
+  billboardLabels?: boolean;
   /** Whether to show tick marks. Default: true */
   showTicks?: boolean;
   /** Length of tick marks. Default: 0.15 */
@@ -90,6 +95,7 @@ export class ThreeDAxes extends Group {
   private _showLabels: boolean;
   private _labelFontSize: number;
   private _labelBuffer: number;
+  private _billboardLabels: boolean;
   private _xLabel: Mobject | null = null;
   private _yLabel: Mobject | null = null;
   private _zLabel: Mobject | null = null;
@@ -112,6 +118,7 @@ export class ThreeDAxes extends Group {
       labels,
       labelFontSize = 32,
       labelBuffer = 0.4,
+      billboardLabels = true,
       showTicks = true,
       tickLength = 0.15,
       tipLength = 0.2,
@@ -127,6 +134,7 @@ export class ThreeDAxes extends Group {
     this._showLabels = showLabels;
     this._labelFontSize = labelFontSize;
     this._labelBuffer = labelBuffer;
+    this._billboardLabels = billboardLabels;
     this._labelOptions = labels;
 
     const effectiveXColor = xColor ?? axisColor;
@@ -293,6 +301,28 @@ export class ThreeDAxes extends Group {
     this._labelGroup.add(this._xLabel);
     this._labelGroup.add(this._yLabel);
     this._labelGroup.add(this._zLabel);
+
+    if (this._billboardLabels) {
+      this._installBillboardHooks();
+    }
+  }
+
+  /**
+   * Attach an `onBeforeRender` hook to each label mesh that copies the
+   * camera's quaternion at draw time, so labels always face the viewer
+   * regardless of orbit/camera motion. Equivalent to Manim CE's
+   * `add_fixed_orientation_mobjects` but without needing scene context.
+   *
+   * The hook is idempotent — calling this again replaces any prior hook.
+   */
+  private _installBillboardHooks(): void {
+    for (const label of [this._xLabel, this._yLabel, this._zLabel]) {
+      if (!label) continue;
+      const threeObj = label.getThreeObject();
+      threeObj.onBeforeRender = (_renderer, _scene, camera) => {
+        threeObj.quaternion.copy(camera.quaternion);
+      };
+    }
   }
 
   /**
@@ -566,6 +596,7 @@ export class ThreeDAxes extends Group {
       labels: this._labelOptions,
       labelFontSize: this._labelFontSize,
       labelBuffer: this._labelBuffer,
+      billboardLabels: this._billboardLabels,
     });
   }
 }

--- a/src/mobjects/three-d/ThreeDAxes.ts
+++ b/src/mobjects/three-d/ThreeDAxes.ts
@@ -1,5 +1,6 @@
 import { Group } from '../../core/Group';
-import { Vector3Tuple } from '../../core/Mobject';
+import { Mobject, Vector3Tuple } from '../../core/Mobject';
+import { Text } from '../text/Text';
 import { Arrow3D } from './Arrow3D';
 import { Line3D } from './Line3D';
 
@@ -21,8 +22,18 @@ export interface ThreeDAxesOptions {
   yColor?: string;
   /** Color for z-axis (overrides axisColor). Default: same as axisColor */
   zColor?: string;
-  /** Whether to show axis labels (X, Y, Z). Default: false */
+  /** Whether to show axis labels (x, y, z). Default: false */
   showLabels?: boolean;
+  /** Custom label text or Mobjects per axis. String entries become Text mobjects. Defaults: 'x', 'y', 'z' */
+  labels?: {
+    x?: string | Mobject;
+    y?: string | Mobject;
+    z?: string | Mobject;
+  };
+  /** Font size used when creating labels from strings. Default: 36 */
+  labelFontSize?: number;
+  /** Offset in world units from each axis tip to its label. Default: 0.4 */
+  labelBuffer?: number;
   /** Whether to show tick marks. Default: true */
   showTicks?: boolean;
   /** Length of tick marks. Default: 0.15 */
@@ -75,6 +86,13 @@ export class ThreeDAxes extends Group {
   private _showTicks: boolean;
   private _tickLength: number;
   private _ticks: Line3D[] = [];
+  private _showLabels: boolean;
+  private _labelFontSize: number;
+  private _labelBuffer: number;
+  private _xLabel: Mobject | null = null;
+  private _yLabel: Mobject | null = null;
+  private _zLabel: Mobject | null = null;
+  private _labelOptions: ThreeDAxesOptions['labels'];
 
   constructor(options: ThreeDAxesOptions = {}) {
     super();
@@ -88,7 +106,10 @@ export class ThreeDAxes extends Group {
       xColor,
       yColor,
       zColor,
-      // showLabels is accepted by options but not yet implemented
+      showLabels = false,
+      labels,
+      labelFontSize = 36,
+      labelBuffer = 0.4,
       showTicks = true,
       tickLength = 0.15,
       tipLength = 0.2,
@@ -101,6 +122,10 @@ export class ThreeDAxes extends Group {
     this._zRange = [...zRange];
     this._showTicks = showTicks;
     this._tickLength = tickLength;
+    this._showLabels = showLabels;
+    this._labelFontSize = labelFontSize;
+    this._labelBuffer = labelBuffer;
+    this._labelOptions = labels;
 
     const effectiveXColor = xColor ?? axisColor;
     const effectiveYColor = yColor ?? axisColor;
@@ -146,6 +171,11 @@ export class ThreeDAxes extends Group {
     // Add tick marks if enabled
     if (showTicks) {
       this._createTicks(effectiveXColor, effectiveYColor, effectiveZColor);
+    }
+
+    // Add axis labels if enabled
+    if (showLabels) {
+      this._createLabels(effectiveXColor, effectiveYColor, effectiveZColor);
     }
   }
 
@@ -207,6 +237,54 @@ export class ThreeDAxes extends Group {
       this._ticks.push(tick);
       this.add(tick);
     }
+  }
+
+  /**
+   * Build label mobjects for each axis.
+   * Accepts either a string (turned into Text) or a pre-built Mobject per axis.
+   * Labels are positioned just past the arrow tip along each axis.
+   */
+  private _createLabels(xColor: string, yColor: string, zColor: string): void {
+    const xInput = this._labelOptions?.x ?? 'x';
+    const yInput = this._labelOptions?.y ?? 'y';
+    const zInput = this._labelOptions?.z ?? 'z';
+
+    this._xLabel = this._buildLabel(xInput, xColor);
+    this._yLabel = this._buildLabel(yInput, yColor);
+    this._zLabel = this._buildLabel(zInput, zColor);
+
+    const buf = this._labelBuffer;
+    const xMax = this._xRange[1];
+    const yMax = this._yRange[1];
+    const zMax = this._zRange[1];
+
+    // X tip → offset along +X
+    const xPos = this._m2t(xMax + buf, 0, 0);
+    this._xLabel.position.set(xPos[0], xPos[1], xPos[2]);
+    // Y tip → offset along +Y (Manim) = -Z (THREE)
+    const yPos = this._m2t(0, yMax + buf, 0);
+    this._yLabel.position.set(yPos[0], yPos[1], yPos[2]);
+    // Z tip → offset along +Z (Manim) = +Y (THREE)
+    const zPos = this._m2t(0, 0, zMax + buf);
+    this._zLabel.position.set(zPos[0], zPos[1], zPos[2]);
+
+    this.add(this._xLabel);
+    this.add(this._yLabel);
+    this.add(this._zLabel);
+  }
+
+  /**
+   * Turn a string into a Text mobject or pass through an existing Mobject.
+   */
+  private _buildLabel(input: string | Mobject, color: string): Mobject {
+    if (typeof input === 'string') {
+      return new Text({
+        text: input,
+        fontSize: this._labelFontSize,
+        color,
+      });
+    }
+    return input;
   }
 
   /**
@@ -321,6 +399,38 @@ export class ThreeDAxes extends Group {
   }
 
   /**
+   * Get the x-axis label mobject (null if showLabels was false)
+   */
+  getXLabel(): Mobject | null {
+    return this._xLabel;
+  }
+
+  /**
+   * Get the y-axis label mobject (null if showLabels was false)
+   */
+  getYLabel(): Mobject | null {
+    return this._yLabel;
+  }
+
+  /**
+   * Get the z-axis label mobject (null if showLabels was false)
+   */
+  getZLabel(): Mobject | null {
+    return this._zLabel;
+  }
+
+  /**
+   * Get all axis label mobjects as a Group. Empty group if no labels.
+   */
+  getAxisLabels(): Group {
+    const group = new Group();
+    if (this._xLabel) group.add(this._xLabel);
+    if (this._yLabel) group.add(this._yLabel);
+    if (this._zLabel) group.add(this._zLabel);
+    return group;
+  }
+
+  /**
    * Create a copy of this ThreeDAxes
    */
   protected override _createCopy(): ThreeDAxes {
@@ -330,6 +440,10 @@ export class ThreeDAxes extends Group {
       zRange: this._zRange,
       showTicks: this._showTicks,
       tickLength: this._tickLength,
+      showLabels: this._showLabels,
+      labels: this._labelOptions,
+      labelFontSize: this._labelFontSize,
+      labelBuffer: this._labelBuffer,
     });
   }
 }

--- a/src/mobjects/three-d/ThreeDAxes.ts
+++ b/src/mobjects/three-d/ThreeDAxes.ts
@@ -242,22 +242,22 @@ export class ThreeDAxes extends Group {
   }
 
   /**
-   * Build label mobjects for each axis.
+   * Build label mobjects for each axis and place them just past each arrow
+   * tip along the arrow direction.
    *
-   * Matches Manim CE's per-axis direction vectors from
-   * `CoordinateSystem._get_axis_label` / `ThreeDAxes.get_axis_labels`:
-   *   - x: edge at Manim (xMax, 0, 0), offset direction UR = (1, 1, 0)
-   *   - y: edge at Manim (0, yMax, 0), offset direction UP*0.5 + RIGHT = (1, 0.5, 0)
-   *   - z: edge at Manim (0, 0, zMax), offset direction RIGHT = (1, 0, 0)
-   * Buffer magnitude is `labelBuffer` along the normalized direction, which
-   * approximates Manim's `next_to(..., buff=SMALL_BUFF)` for the small label
-   * sizes used on axes.
+   * Note on Manim CE parity: Manim CE's `_get_axis_label` uses 2D screen
+   * direction constants (UR = UP + RIGHT, etc.) which read nicely in 2D Axes
+   * but map into arbitrary 3D offsets under a ThreeDScene camera — e.g. Manim
+   * Y+ ("up" of UP+RIGHT) is scene depth in THREE's coord system, which
+   * visually projects as "down-right of tip" under a phi≈75° camera. We
+   * therefore offset along the axis direction, which keeps each label
+   * visually adjacent to its arrow tip for any camera orientation. The
+   * Manim CE `get_axis_labels(x, y, z)` overloaded entry point remains, so
+   * users can also pass `next_to`-positioned mobjects explicitly.
    *
-   * The Z label is *not* rotated here. Manim CE calls `rotate(PI/2, axis=RIGHT)`
-   * because its default MathTex lies in the Manim XY plane (normal +Z_manim);
-   * after rotation the normal becomes -Y_manim. Under our Manim→THREE mapping
-   * that target normal equals +Z_THREE — which is already the default
-   * MathTexImage plane orientation. So the rotation is implicit.
+   * Manim CE's `rotate(PI/2, axis=RIGHT)` on the z-label is a no-op under
+   * our Manim→THREE mapping: after the rotation the Manim-space normal would
+   * map to +Z_THREE, which is already MathTexImage's default plane normal.
    */
   private _createLabels(xColor: string, yColor: string, zColor: string): void {
     const xInput = this._labelOptions?.x ?? 'x';
@@ -273,21 +273,14 @@ export class ThreeDAxes extends Group {
     const yMax = this._yRange[1];
     const zMax = this._zRange[1];
 
-    // X label: Manim (xMax, 0, 0) + buf * normalize(1, 1, 0)
-    const xDir = this._normalize3(1, 1, 0);
-    const xManim: [number, number, number] = [xMax + buf * xDir[0], buf * xDir[1], buf * xDir[2]];
-    const xPos = this._m2t(xManim[0], xManim[1], xManim[2]);
+    const xPos = this._m2t(xMax + buf, 0, 0);
     this._xLabel.position.set(xPos[0], xPos[1], xPos[2]);
-
-    // Y label: Manim (0, yMax, 0) + buf * normalize(1, 0.5, 0)
-    const yDir = this._normalize3(1, 0.5, 0);
-    const yManim: [number, number, number] = [buf * yDir[0], yMax + buf * yDir[1], buf * yDir[2]];
-    const yPos = this._m2t(yManim[0], yManim[1], yManim[2]);
+    const yPos = this._m2t(0, yMax + buf, 0);
     this._yLabel.position.set(yPos[0], yPos[1], yPos[2]);
-
-    // Z label: Manim (0, 0, zMax) + buf * (1, 0, 0)
-    const zManim: [number, number, number] = [buf, 0, zMax];
-    const zPos = this._m2t(zManim[0], zManim[1], zManim[2]);
+    // Z label: mirror Manim CE's `direction=RIGHT` convention — offset to
+    // the side of the arrow tip (not directly above) so it doesn't sit
+    // on top of the arrow shaft/cone.
+    const zPos = this._m2t(buf, 0, zMax + buf * 0.3);
     this._zLabel.position.set(zPos[0], zPos[1], zPos[2]);
 
     // Labels live in a dedicated Group so `getAxisLabels()` can return the
@@ -300,11 +293,6 @@ export class ThreeDAxes extends Group {
     this._labelGroup.add(this._xLabel);
     this._labelGroup.add(this._yLabel);
     this._labelGroup.add(this._zLabel);
-  }
-
-  private _normalize3(x: number, y: number, z: number): [number, number, number] {
-    const len = Math.hypot(x, y, z);
-    return len > 0 ? [x / len, y / len, z / len] : [0, 0, 0];
   }
 
   /**

--- a/src/mobjects/three-d/ThreeDAxes.ts
+++ b/src/mobjects/three-d/ThreeDAxes.ts
@@ -1,6 +1,6 @@
 import { Group } from '../../core/Group';
 import { Mobject, Vector3Tuple } from '../../core/Mobject';
-import { Text } from '../text/Text';
+import { MathTexImage } from '../text/MathTexImage';
 import { Arrow3D } from './Arrow3D';
 import { Line3D } from './Line3D';
 
@@ -30,7 +30,7 @@ export interface ThreeDAxesOptions {
     y?: string | Mobject;
     z?: string | Mobject;
   };
-  /** Font size used when creating labels from strings. Default: 36 */
+  /** Font size used when creating labels from strings (MathTexImage pixel size). Default: 32 */
   labelFontSize?: number;
   /** Offset in world units from each axis tip to its label. Default: 0.4 */
   labelBuffer?: number;
@@ -92,6 +92,7 @@ export class ThreeDAxes extends Group {
   private _xLabel: Mobject | null = null;
   private _yLabel: Mobject | null = null;
   private _zLabel: Mobject | null = null;
+  private _labelGroup: Group | null = null;
   private _labelOptions: ThreeDAxesOptions['labels'];
 
   constructor(options: ThreeDAxesOptions = {}) {
@@ -108,7 +109,7 @@ export class ThreeDAxes extends Group {
       zColor,
       showLabels = false,
       labels,
-      labelFontSize = 36,
+      labelFontSize = 32,
       labelBuffer = 0.4,
       showTicks = true,
       tickLength = 0.15,
@@ -241,8 +242,9 @@ export class ThreeDAxes extends Group {
 
   /**
    * Build label mobjects for each axis.
-   * Accepts either a string (turned into Text) or a pre-built Mobject per axis.
-   * Labels are positioned just past the arrow tip along each axis.
+   * Matches Manim CE conventions: strings are rendered as MathTex (italic math),
+   * positioned just past each arrow tip, and the Z label is rotated PI/2 around
+   * the X axis so it stands upright next to the Z arrow.
    */
   private _createLabels(xColor: string, yColor: string, zColor: string): void {
     const xInput = this._labelOptions?.x ?? 'x';
@@ -264,22 +266,33 @@ export class ThreeDAxes extends Group {
     // Y tip → offset along +Y (Manim) = -Z (THREE)
     const yPos = this._m2t(0, yMax + buf, 0);
     this._yLabel.position.set(yPos[0], yPos[1], yPos[2]);
-    // Z tip → offset along +Z (Manim) = +Y (THREE)
+    // Z tip → offset along +Z (Manim) = +Y (THREE).
+    // Note: Manim CE calls `rotate(PI/2, axis=RIGHT)` on the z-label because
+    // in Manim's default coord system (Z up) a bare MathTex sits flat on XY.
+    // In THREE, MathTexImage's plane is already vertical (normal = +Z_THREE),
+    // so no extra rotation is needed — it stands upright next to the Z arrow.
     const zPos = this._m2t(0, 0, zMax + buf);
     this._zLabel.position.set(zPos[0], zPos[1], zPos[2]);
 
-    this.add(this._xLabel);
-    this.add(this._yLabel);
-    this.add(this._zLabel);
+    // Labels live in a dedicated Group so `getAxisLabels()` can return the
+    // same Group every time without re-parenting (which would remove the
+    // labels from this axes' children).
+    if (!this._labelGroup) {
+      this._labelGroup = new Group();
+      this.add(this._labelGroup);
+    }
+    this._labelGroup.add(this._xLabel);
+    this._labelGroup.add(this._yLabel);
+    this._labelGroup.add(this._zLabel);
   }
 
   /**
-   * Turn a string into a Text mobject or pass through an existing Mobject.
+   * Turn a string into a MathTexImage mobject or pass through an existing Mobject.
    */
   private _buildLabel(input: string | Mobject, color: string): Mobject {
     if (typeof input === 'string') {
-      return new Text({
-        text: input,
+      return new MathTexImage({
+        latex: input,
         fontSize: this._labelFontSize,
         color,
       });
@@ -420,14 +433,53 @@ export class ThreeDAxes extends Group {
   }
 
   /**
-   * Get all axis label mobjects as a Group. Empty group if no labels.
+   * Get all axis label mobjects as a Group.
+   *
+   * If no labels were created at construction time (showLabels was false)
+   * or any of xLabel/yLabel/zLabel are supplied, labels are created/replaced
+   * on demand and added to this group. Mirrors Manim CE's
+   * `ThreeDAxes.get_axis_labels(x_label, y_label, z_label)`.
+   *
+   * @param xLabel - LaTeX string or Mobject for x-axis label. Default: 'x'
+   * @param yLabel - LaTeX string or Mobject for y-axis label. Default: 'y'
+   * @param zLabel - LaTeX string or Mobject for z-axis label. Default: 'z'
    */
-  getAxisLabels(): Group {
-    const group = new Group();
-    if (this._xLabel) group.add(this._xLabel);
-    if (this._yLabel) group.add(this._yLabel);
-    if (this._zLabel) group.add(this._zLabel);
-    return group;
+  getAxisLabels(
+    xLabel?: string | Mobject,
+    yLabel?: string | Mobject,
+    zLabel?: string | Mobject,
+  ): Group {
+    const needsCreate =
+      xLabel !== undefined || yLabel !== undefined || zLabel !== undefined || !this._showLabels;
+
+    if (needsCreate) {
+      // Merge args with construction-time label options (args win).
+      this._labelOptions = {
+        x: xLabel ?? this._labelOptions?.x,
+        y: yLabel ?? this._labelOptions?.y,
+        z: zLabel ?? this._labelOptions?.z,
+      };
+      this._showLabels = true;
+      // Drop any previously created labels so we don't orphan children.
+      if (this._labelGroup) {
+        if (this._xLabel) this._labelGroup.remove(this._xLabel);
+        if (this._yLabel) this._labelGroup.remove(this._yLabel);
+        if (this._zLabel) this._labelGroup.remove(this._zLabel);
+      }
+      this._xLabel = this._yLabel = this._zLabel = null;
+
+      // Recreate with the same per-axis colors used by the arrows.
+      this._createLabels(
+        this._xAxis.color as string,
+        this._yAxis.color as string,
+        this._zAxis.color as string,
+      );
+    }
+
+    // Return the persistent internal Group; adding it to a scene wouldn't
+    // make sense (it's a child of `this`), but callers typically use it to
+    // animate / style the labels collectively.
+    return this._labelGroup ?? new Group();
   }
 
   /**


### PR DESCRIPTION
## Summary
Closes #263. `showLabels: true` on `ThreeDAxes` was silently ignored — the option was declared in `ThreeDAxesOptions` but the constructor never created any label mobjects. This PR wires it up.

- Create `Text` mobjects for x/y/z when `showLabels: true`, colored per-axis, positioned just past each arrow tip
- New options: `labels` (per-axis string or pre-built `Mobject`), `labelFontSize`, `labelBuffer`
- New accessors: `getXLabel()`, `getYLabel()`, `getZLabel()`, `getAxisLabels()`
- `_createCopy` preserves the new state
- New example: `examples/three_d_axes_labels.html` (reproduces the original issue)

## Test plan
- [x] `npx vitest run src/mobjects/three-d/ThreeDAxes.test.ts` — 9 new tests cover default (no labels), default strings, group membership, position, custom strings, custom Mobject pass-through, `getAxisLabels` shape, per-axis coloring, and copy behavior
- [x] `npx vitest run` — full suite still green (5751 passed)
- [x] `npx tsc --noEmit`
- [x] Browser check via vite — x, y, z labels render next to each arrow tip in the example page