### PR TITLE
fix(ThreeDScene): pivot fixed-orientation billboard around visual center (#264)

### DIFF
--- a/examples/fixed_orientation_follow.html
+++ b/examples/fixed_orientation_follow.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <script>
+      if (new URLSearchParams(location.search).has('embed'))
+        document.documentElement.classList.add('embed');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ManimWeb - Fixed Orientation Label Follows Dot</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: #1a1a2e;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        min-height: 100vh;
+        font-family: system-ui, sans-serif;
+        gap: 12px;
+        padding: 16px;
+        color: #eee;
+      }
+      h1 {
+        font-size: 18px;
+        font-weight: 500;
+      }
+      #container {
+        border: 2px solid #333;
+        border-radius: 8px;
+        overflow: hidden;
+      }
+      p {
+        font-size: 13px;
+        color: #aaa;
+        max-width: 640px;
+        text-align: center;
+      }
+      html.embed,
+      html.embed body {
+        margin: 0 !important;
+        padding: 0 !important;
+        overflow: hidden;
+        background: #000 !important;
+        width: 100%;
+        height: 100%;
+      }
+      html.embed body {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+      html.embed h1,
+      html.embed p {
+        display: none !important;
+      }
+      html.embed #container {
+        border: none !important;
+        border-radius: 0 !important;
+        width: 100vw;
+        height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Fixed Orientation Label Follows a Draggable Dot</h1>
+    <div id="container"></div>
+    <p>
+      Drag the dot to move it in 3D. The label <em>r</em> tracks the dot via an updater and always
+      faces the camera. Orbit the camera and the label should stay anchored to the dot in the 3D
+      world, not to the screen.
+    </p>
+
+    <script type="module" src="./fixed_orientation_follow.ts"></script>
+  </body>
+</html>

--- a/examples/fixed_orientation_follow.ts
+++ b/examples/fixed_orientation_follow.ts
@@ -1,0 +1,43 @@
+import { Dot3D, MathTex, ThreeDAxes, ThreeDScene, UP, makeDraggable } from '../src/index.ts';
+
+function addVectors(a: number[], b: number[]): [number, number, number] {
+  return [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+}
+
+function scalarMult(a: number[], b: number): [number, number, number] {
+  return [a[0] * b, a[1] * b, a[2] * b];
+}
+
+const container = document.getElementById('container')!;
+const scene = new ThreeDScene(container, {
+  width: 800,
+  height: 450,
+  backgroundColor: '#191919',
+  phi: 75 * (Math.PI / 180),
+  theta: -45 * (Math.PI / 180),
+  distance: 20,
+  fov: 30,
+  enableOrbitControls: true,
+});
+
+const axes = new ThreeDAxes({
+  xRange: [-5, 5, 1],
+  yRange: [-5, 5, 1],
+  zRange: [-5, 5, 1],
+  xLength: 10,
+  yLength: 10,
+  zLength: 10,
+  showLabels: true,
+});
+
+const dot = new Dot3D({ radius: 0.1 }).moveTo(axes.coordsToPoint(1, 1, 1));
+makeDraggable(dot, scene);
+
+const lbl = new MathTex({ latex: 'r', fontSize: 0.2 }).addUpdater((mob) => {
+  mob.moveTo(addVectors(dot.getCenter(), scalarMult(UP, 0.15)));
+});
+
+scene.add(axes, dot, lbl);
+scene.addFixedOrientationMobjects(lbl);
+
+await scene.wait(999999);

--- a/src/core/ThreeDScene.ts
+++ b/src/core/ThreeDScene.ts
@@ -5,6 +5,8 @@ import { Lighting } from './Lighting';
 import { OrbitControls, OrbitControlsOptions } from '../interaction/OrbitControls';
 import { Mobject, Vector3Tuple } from './Mobject';
 
+const BILLBOARD_TMP = new THREE.Vector3();
+
 /**
  * Options for configuring a ThreeDScene.
  */
@@ -389,7 +391,9 @@ export class ThreeDScene extends Scene {
       // Remove from fixed-orientation if present (mutually exclusive)
       if (this._fixedOrientationMobjects.has(mob)) {
         this._fixedOrientationMobjects.delete(mob);
-        mob.getThreeObject().quaternion.identity();
+        const threeObj = mob.getThreeObject();
+        threeObj.quaternion.identity();
+        threeObj.position.copy(mob.position);
       }
       this._fixedMobjects.add(mob);
       // Ensure the Three.js object is initialized
@@ -449,9 +453,10 @@ export class ThreeDScene extends Scene {
     for (const mob of mobjects) {
       if (this._fixedOrientationMobjects.has(mob)) {
         this._fixedOrientationMobjects.delete(mob);
-        // Reset rotation to identity
         const threeObj = mob.getThreeObject();
         threeObj.quaternion.identity();
+        // Restore the position the billboard may have displaced.
+        threeObj.position.copy(mob.position);
       }
     }
     return this;
@@ -529,11 +534,29 @@ export class ThreeDScene extends Scene {
       }
     }
 
-    // Apply billboard rotation to fixed-orientation mobjects
+    // Apply billboard rotation to fixed-orientation mobjects around their
+    // current world center. We can't just set `quaternion = camQuat` on the
+    // threeObject, because for VGroup-like mobjects the visual center lives in
+    // the children's offsets (threeObject.position stays at the intended
+    // origin), so a raw rotation pivots the children around the wrong point
+    // and locks them to screen space (issue #264).
     if (this._fixedOrientationMobjects && this._fixedOrientationMobjects.size > 0) {
       const camQuat = this._camera3D.getCamera().quaternion;
       for (const mob of this._fixedOrientationMobjects) {
         const threeObj = mob.getThreeObject();
+        const center = mob.getCenter();
+        // C_local = C - P, P_new = C - Q * C_local. Equivalent to pivoting
+        // around `center`. For leaf mobjects that set this.position directly,
+        // C_local is zero and P_new == P (position unchanged).
+        const cLocalX = center[0] - mob.position.x;
+        const cLocalY = center[1] - mob.position.y;
+        const cLocalZ = center[2] - mob.position.z;
+        BILLBOARD_TMP.set(cLocalX, cLocalY, cLocalZ).applyQuaternion(camQuat);
+        threeObj.position.set(
+          center[0] - BILLBOARD_TMP.x,
+          center[1] - BILLBOARD_TMP.y,
+          center[2] - BILLBOARD_TMP.z,
+        );
         threeObj.quaternion.copy(camQuat);
       }
     }
@@ -584,9 +607,11 @@ export class ThreeDScene extends Scene {
     }
     this._fixedMobjects.clear();
 
-    // Clear fixed-orientation tracking (reset quaternions for consistency)
+    // Clear fixed-orientation tracking (reset transform for consistency)
     for (const mob of this._fixedOrientationMobjects) {
-      mob.getThreeObject().quaternion.identity();
+      const threeObj = mob.getThreeObject();
+      threeObj.quaternion.identity();
+      threeObj.position.copy(mob.position);
     }
     this._fixedOrientationMobjects.clear();
 
@@ -617,7 +642,9 @@ export class ThreeDScene extends Scene {
       }
       if (this._fixedOrientationMobjects.has(mob)) {
         this._fixedOrientationMobjects.delete(mob);
-        mob.getThreeObject().quaternion.identity();
+        const threeObj = mob.getThreeObject();
+        threeObj.quaternion.identity();
+        threeObj.position.copy(mob.position);
       }
     }
     return super.remove(...mobjects);

--- a/src/core/fixed-orientation.test.ts
+++ b/src/core/fixed-orientation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import * as THREE from 'three';
 import { ThreeDScene } from './ThreeDScene';
+import { VGroup } from './VGroup';
 import { Circle } from '../mobjects/geometry/Circle';
 import { Square } from '../mobjects/geometry/Rectangle';
 
@@ -206,6 +207,106 @@ describe('addFixedOrientationMobjects', () => {
     expect(q.y).toBeCloseTo(0, 5);
     expect(q.z).toBeCloseTo(0, 5);
     expect(q.w).toBeCloseTo(1, 5);
+
+    scene.dispose();
+  });
+
+  // Regression: issue #264. A VGroup moved to a non-origin point kept its
+  // visual center stuck relative to the screen because the billboard applied
+  // camera rotation around the group's local origin (0,0,0) rather than the
+  // group's current visual center.
+  //
+  // VGroup.shift translates children's points but leaves this.position at 0,
+  // so the billboard's pivot must come from getCenter(), not threeObject.position.
+  // This helper projects the mobject's visual centroid through its THREE
+  // transforms, which is exactly what the renderer does.
+  const visualCenterWorld = (mob: VGroup): [number, number, number] => {
+    const threeObj = mob.getThreeObject();
+    threeObj.updateMatrixWorld(true);
+    const center = mob.getCenter();
+    const v = new THREE.Vector3(
+      center[0] - mob.position.x,
+      center[1] - mob.position.y,
+      center[2] - mob.position.z,
+    );
+    v.applyMatrix4(threeObj.matrixWorld);
+    return [v.x, v.y, v.z];
+  };
+
+  it('VGroup moved off-origin keeps its world center under camera orbit', () => {
+    const scene = ThreeDScene.createHeadless();
+    const group = new VGroup();
+    group.add(new Circle());
+    // VGroup.moveTo translates children's points, leaving group.position at 0.
+    group.moveTo([2, 3, -1]);
+    scene.add(group);
+    scene.addFixedOrientationMobjects(group);
+
+    expect(group.getCenter()).toEqual([2, 3, -1]);
+
+    scene.setCameraOrientation(Math.PI / 3, Math.PI / 4, 15);
+    scene.render();
+
+    // The visual centroid, after applying the group's THREE transform chain
+    // (now including the billboard's compensating translation + camera
+    // quaternion), must still land on the world anchor.
+    const [x, y, z] = visualCenterWorld(group);
+    expect(x).toBeCloseTo(2, 3);
+    expect(y).toBeCloseTo(3, 3);
+    expect(z).toBeCloseTo(-1, 3);
+
+    // And the group still faces the camera.
+    const threeObj = group.getThreeObject();
+    const cam = scene.camera3D.getCamera();
+    expect(threeObj.quaternion.x).toBeCloseTo(cam.quaternion.x, 3);
+    expect(threeObj.quaternion.y).toBeCloseTo(cam.quaternion.y, 3);
+    expect(threeObj.quaternion.z).toBeCloseTo(cam.quaternion.z, 3);
+    expect(threeObj.quaternion.w).toBeCloseTo(cam.quaternion.w, 3);
+
+    scene.dispose();
+  });
+
+  it('VGroup billboard follows a moving center (updater scenario)', () => {
+    const scene = ThreeDScene.createHeadless();
+    const group = new VGroup();
+    group.add(new Circle());
+    group.moveTo([1, 1, 1]);
+    scene.add(group);
+    scene.addFixedOrientationMobjects(group);
+
+    scene.setCameraOrientation(Math.PI / 3, Math.PI / 4, 15);
+    // Simulate an updater running between frames.
+    group.moveTo([-2, 0.5, 2]);
+    scene.render();
+
+    const [x, y, z] = visualCenterWorld(group);
+    expect(x).toBeCloseTo(-2, 3);
+    expect(y).toBeCloseTo(0.5, 3);
+    expect(z).toBeCloseTo(2, 3);
+
+    scene.dispose();
+  });
+
+  it('removeFixedOrientationMobjects restores the displaced position', () => {
+    const scene = ThreeDScene.createHeadless();
+    const group = new VGroup();
+    group.add(new Circle());
+    group.moveTo([4, 0, 0]);
+    scene.add(group);
+    scene.addFixedOrientationMobjects(group);
+    scene.setCameraOrientation(Math.PI / 3, Math.PI / 4, 15);
+
+    // Billboard has shifted threeObject.position off (0,0,0).
+    const threeObj = group.getThreeObject();
+    expect(threeObj.position.length()).toBeGreaterThan(0);
+
+    scene.removeFixedOrientationMobjects(group);
+
+    // Mobject position was never mutated by the billboard; threeObject must
+    // be restored to it so the next sync starts from a clean slate.
+    expect(threeObj.position.x).toBeCloseTo(group.position.x, 5);
+    expect(threeObj.position.y).toBeCloseTo(group.position.y, 5);
+    expect(threeObj.position.z).toBeCloseTo(group.position.z, 5);
 
     scene.dispose();
   });


### PR DESCRIPTION
Fixes #264.

## Summary

- Billboard pivot for `addFixedOrientationMobjects` now comes from `mob.getCenter()` rather than the threeObject's local origin, so VGroup/MathTex mobjects that hold their world position in children stay anchored to their 3D target instead of skating across the screen.
- Formula: `P_new = C - Q * (C - P)` where `P` is `mob.position`, `C` is `mob.getCenter()`, `Q` is the camera quaternion. Leaf mobjects (`C == P`) are unchanged; only off-origin groups get the compensating translation.
- `removeFixedOrientationMobjects`, `addFixedInFrameMobjects` (takeover), `remove`, and `clear` also restore `threeObject.position` to `mob.position` so a later sync starts from a clean slate.

## Investigation

See [this comment on #264](https://github.com/maloyan/manim-web/issues/264#issuecomment-4273484325) for the manim CE reference algorithm and a walk-through of why the old `threeObj.quaternion.copy(camQuat)` collapsed a VGroup's children onto the screen (it rotated them around the group's origin instead of their visual center).

## Tests

Added regression tests in `src/core/fixed-orientation.test.ts`:
- `VGroup moved off-origin keeps its world center under camera orbit` — the direct repro for #264.
- `VGroup billboard follows a moving center (updater scenario)` — mimics an updater moving the group between frames.
- `removeFixedOrientationMobjects restores the displaced position` — guards the cleanup.

Also added a browser example (`examples/fixed_orientation_follow.{ts,html}`) that mirrors the reporter's scenario: a `MathTex` label with an updater tracking a draggable `Dot3D`, with orbit controls on.

## Test plan

- [x] `npx vitest run src/core/fixed-orientation.test.ts`
- [x] `npx vitest run` (full suite, 5765 passed)
- [x] `npx eslint src/ --max-warnings 0`
- [x] `npm run typecheck` / `npm run format:check`
- [x] `npx knip` and `npx madge --circular`
- [x] Manually verified `examples/fixed_orientation_follow.html` in Chrome: label stays anchored to the dot under orbit and while dragging the dot