### PR TITLE
fix: fill mesh geometry includes Z coordinates for 3D rotation

### DIFF
--- a/src/core/VMobjectGeometry.test.ts
+++ b/src/core/VMobjectGeometry.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { buildEarcutFillGeometry } from './VMobjectGeometry';
+
+function cornersToLinearBezier(corners: number[][]): number[][] {
+  if (corners.length < 2) return corners.map((p) => [p[0], p[1], p[2] ?? 0]);
+
+  const points: number[][] = [];
+  for (let i = 0; i < corners.length - 1; i++) {
+    const p0 = corners[i];
+    const p1 = corners[i + 1];
+    if (i === 0) points.push([p0[0], p0[1], p0[2] ?? 0]);
+
+    points.push([
+      p0[0] + (p1[0] - p0[0]) / 3,
+      p0[1] + (p1[1] - p0[1]) / 3,
+      (p0[2] ?? 0) + ((p1[2] ?? 0) - (p0[2] ?? 0)) / 3,
+    ]);
+    points.push([
+      p0[0] + (2 * (p1[0] - p0[0])) / 3,
+      p0[1] + (2 * (p1[1] - p0[1])) / 3,
+      (p0[2] ?? 0) + (2 * ((p1[2] ?? 0) - (p0[2] ?? 0))) / 3,
+    ]);
+    points.push([p1[0], p1[1], p1[2] ?? 0]);
+  }
+
+  return points;
+}
+
+describe('buildEarcutFillGeometry plane projection regressions', () => {
+  it('triangulates a square in the YZ plane (XY projection is degenerate)', () => {
+    const corners = [
+      [0, 0, 0],
+      [0, 1, 0],
+      [0, 1, 1],
+      [0, 0, 1],
+      [0, 0, 0],
+    ];
+    const points3D = cornersToLinearBezier(corners);
+    const visiblePoints = points3D.map((p) => ({ x: p[0], y: p[1] }));
+
+    const geometry = buildEarcutFillGeometry(points3D, visiblePoints);
+    expect(geometry).not.toBeNull();
+
+    const positions = geometry!.getAttribute('position').array as Float32Array;
+    expect(positions.length).toBeGreaterThan(0);
+
+    let maxAbsX = 0;
+    let maxZ = -Infinity;
+    for (let i = 0; i < positions.length; i += 3) {
+      maxAbsX = Math.max(maxAbsX, Math.abs(positions[i]));
+      maxZ = Math.max(maxZ, positions[i + 2]);
+    }
+
+    expect(maxAbsX).toBeLessThan(1e-6);
+    expect(maxZ).toBeGreaterThan(0.5);
+  });
+
+  it('triangulates a rotated compound shape with a hole using one shared plane basis', () => {
+    const outerCorners = [
+      [0, 0, 0],
+      [0, 2, 0],
+      [0, 2, 2],
+      [0, 0, 2],
+      [0, 0, 0],
+    ];
+    const holeCorners = [
+      [0, 0.75, 0.75],
+      [0, 1.25, 0.75],
+      [0, 1.25, 1.25],
+      [0, 0.75, 1.25],
+      [0, 0.75, 0.75],
+    ];
+
+    const outer = cornersToLinearBezier(outerCorners);
+    const hole = cornersToLinearBezier(holeCorners);
+    const points3D = [...outer, ...hole];
+
+    const geometry = buildEarcutFillGeometry(points3D, [], () => [outer.length, hole.length]);
+    expect(geometry).not.toBeNull();
+
+    const positions = geometry!.getAttribute('position').array as Float32Array;
+    expect(positions.length).toBeGreaterThan(0);
+    expect(positions.length % 9).toBe(0);
+
+    let minY = Infinity;
+    let maxY = -Infinity;
+    let minZ = Infinity;
+    let maxZ = -Infinity;
+    for (let i = 0; i < positions.length; i += 3) {
+      minY = Math.min(minY, positions[i + 1]);
+      maxY = Math.max(maxY, positions[i + 1]);
+      minZ = Math.min(minZ, positions[i + 2]);
+      maxZ = Math.max(maxZ, positions[i + 2]);
+    }
+
+    // Triangulated output should span the outer ring extents in plane coordinates.
+    expect(minY).toBeLessThan(0.1);
+    expect(maxY).toBeGreaterThan(1.9);
+    expect(minZ).toBeLessThan(0.1);
+    expect(maxZ).toBeGreaterThan(1.9);
+  });
+});

--- a/src/core/VMobjectGeometry.ts
+++ b/src/core/VMobjectGeometry.ts
@@ -119,14 +119,14 @@ export function sampleBezierOutline(points: number[][], samplesPerSegment: numbe
     for (let t = startT; t <= samples; t++) {
       const u = t / samples;
       const pt = evalCubicBezier(p0, p1, p2, p3, u);
-      result.push([pt[0], pt[1]]);
+      result.push([pt[0], pt[1], pt[2] ?? 0]); // Include Z for 3D support
     }
   }
 
   // Handle non-Bezier (simple line segment) fallback
   if (result.length === 0 && points.length >= 2) {
     for (const p of points) {
-      result.push([p[0], p[1]]);
+      result.push([p[0], p[1], p[2] ?? 0]); // Include Z for 3D support
     }
   }
 
@@ -314,7 +314,7 @@ export function buildEarcutFillGeometry(
     const v = outline[indices[i]];
     positions[i * 3] = v[0];
     positions[i * 3 + 1] = v[1];
-    positions[i * 3 + 2] = 0;
+    positions[i * 3 + 2] = v[2] ?? 0; // Use Z for 3D support
   }
 
   const geometry = new THREE.BufferGeometry();
@@ -387,7 +387,7 @@ function buildEarcutFillGeometryMulti(
 
     for (const idx of indices) {
       const v = allVerts[idx];
-      allPositions.push(v[0], v[1], 0);
+      allPositions.push(v[0], v[1], v[2] ?? 0); // Use Z for 3D support
     }
   }
 

--- a/src/core/VMobjectGeometry.ts
+++ b/src/core/VMobjectGeometry.ts
@@ -152,7 +152,7 @@ export function sampleBezierOutline(points: number[][], samplesPerSegment: numbe
  * Sample Bezier path into 3D points (preserves z).
  * Same logic as sampleBezierOutline but returns [x, y, z] instead of [x, y].
  */
-export function sampleBezierOutline3D(points: number[][], samplesPerSegment: number): number[][] {
+function sampleBezierOutline3D(points: number[][], samplesPerSegment: number): number[][] {
   const result: number[][] = [];
 
   for (let i = 0; i + 3 < points.length; i += 3) {
@@ -196,7 +196,7 @@ export function sampleBezierOutline3D(points: number[][], samplesPerSegment: num
  * Project 3D outline points to 2D plane for triangulation.
  * Returns both 2D projected points and the plane basis for reconstruction.
  */
-export function projectOutlineToPlane(outline3D: number[][]): {
+function projectOutlineToPlane(outline3D: number[][]): {
   outline2D: number[][];
   origin: number[];
   v1: number[];

--- a/src/core/VMobjectGeometry.ts
+++ b/src/core/VMobjectGeometry.ts
@@ -11,7 +11,13 @@
 
 import * as THREE from 'three';
 import { triangulatePolygon } from '../utils/triangulate';
-import { evalCubicBezier } from '../utils/math';
+import {
+  evalCubicBezier,
+  selectScatteredPoints,
+  extractVectorsFrom3Points,
+  orthonormalizeBasis,
+  projectToPlane,
+} from '../utils/math';
 import type { Point } from './VMobjectCurves';
 
 // -----------------------------------------------------------------------
@@ -140,6 +146,92 @@ export function sampleBezierOutline(points: number[][], samplesPerSegment: numbe
   }
 
   return result;
+}
+
+/**
+ * Sample Bezier path into 3D points (preserves z).
+ * Same logic as sampleBezierOutline but returns [x, y, z] instead of [x, y].
+ */
+export function sampleBezierOutline3D(points: number[][], samplesPerSegment: number): number[][] {
+  const result: number[][] = [];
+
+  for (let i = 0; i + 3 < points.length; i += 3) {
+    const p0 = points[i];
+    const p1 = points[i + 1];
+    const p2 = points[i + 2];
+    const p3 = points[i + 3];
+
+    const samples = isNearlyLinear(p0, p1, p2, p3) ? 1 : samplesPerSegment;
+
+    const startT = i === 0 ? 0 : 1;
+    for (let t = startT; t <= samples; t++) {
+      const u = t / samples;
+      const pt = evalCubicBezier(p0, p1, p2, p3, u);
+      result.push(pt);
+    }
+  }
+
+  if (result.length === 0 && points.length >= 2) {
+    for (const p of points) {
+      result.push([p[0], p[1], p[2] ?? 0]);
+    }
+  }
+
+  // Remove closing duplicate
+  if (result.length > 1) {
+    const first = result[0];
+    const last = result[result.length - 1];
+    const dx = first[0] - last[0];
+    const dy = first[1] - last[1];
+    const dz = (first[2] ?? 0) - (last[2] ?? 0);
+    if (dx * dx + dy * dy + dz * dz < 1e-8) {
+      result.pop();
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Project 3D outline points to 2D plane for triangulation.
+ * Returns both 2D projected points and the plane basis for reconstruction.
+ */
+export function projectOutlineToPlane(outline3D: number[][]): {
+  outline2D: number[][];
+  origin: number[];
+  v1: number[];
+  v2: number[];
+} {
+  if (outline3D.length < 3) {
+    return {
+      outline2D: outline3D.map((p) => [p[0], p[1]]),
+      origin: [0, 0, 0],
+      v1: [1, 0, 0],
+      v2: [0, 1, 0],
+    };
+  }
+
+  // Get plane basis from scattered points
+  const indices = selectScatteredPoints(outline3D);
+  const scattered = indices.map((i) => outline3D[i]);
+  const vectors = extractVectorsFrom3Points(scattered);
+
+  if (!vectors) {
+    return {
+      outline2D: outline3D.map((p) => [p[0], p[1]]),
+      origin: [0, 0, 0],
+      v1: [1, 0, 0],
+      v2: [0, 1, 0],
+    };
+  }
+
+  const { v1, v2 } = orthonormalizeBasis(vectors.v1, vectors.v2);
+  const origin = scattered[0];
+
+  // Project all points to 2D
+  const outline2D = outline3D.map((p) => projectToPlane(p, origin, v1, v2));
+
+  return { outline2D, origin, v1, v2 };
 }
 
 // -----------------------------------------------------------------------
@@ -295,12 +387,15 @@ export function buildEarcutFillGeometry(
     return buildEarcutFillGeometryMulti(points3D, subpathLengths, visiblePoints);
   }
 
-  // Sample Bezier curves into a dense polyline for triangulation.
-  const outline = sampleBezierOutline(points3D, 8);
-  if (outline.length < 3) return null;
+  // Sample Bezier curves into 3D polyline, then project to plane for triangulation
+  const outline3D = sampleBezierOutline3D(points3D, 8);
+  if (outline3D.length < 3) return null;
+
+  // Project to plane and get 2D coordinates for earcut
+  const { outline2D } = projectOutlineToPlane(outline3D);
 
   // Triangulate with earcut
-  const indices = triangulatePolygon(outline);
+  const indices = triangulatePolygon(outline2D);
 
   if (indices.length === 0) {
     // Earcut couldn't triangulate -- fall back to THREE.ShapeGeometry
@@ -308,13 +403,13 @@ export function buildEarcutFillGeometry(
     return new THREE.ShapeGeometry(shape);
   }
 
-  // Create BufferGeometry from earcut output
+  // Create BufferGeometry using original 3D points (not projected 2D)
   const positions = new Float32Array(indices.length * 3);
   for (let i = 0; i < indices.length; i++) {
-    const v = outline[indices[i]];
+    const v = outline3D[indices[i]];
     positions[i * 3] = v[0];
     positions[i * 3 + 1] = v[1];
-    positions[i * 3 + 2] = v[2] ?? 0; // Use Z for 3D support
+    positions[i * 3 + 2] = v[2] ?? 0;
   }
 
   const geometry = new THREE.BufferGeometry();
@@ -334,29 +429,41 @@ function buildEarcutFillGeometryMulti(
 ): THREE.BufferGeometry | null {
   void visiblePoints; // kept for API compatibility
 
-  // Sample each subpath into a 2D ring
+  // Sample each subpath into 3D rings, collecting all points for plane computation
   let offset = 0;
-  const rings: number[][][] = [];
+  const rings3D: number[][][] = [];
+  const allPoints3D: number[][] = [];
 
   for (const len of subpathLengths) {
     const subPoints = points3D.slice(offset, offset + len);
     offset += len;
 
-    const ring = sampleBezierOutline(subPoints, 8);
+    const ring = sampleBezierOutline3D(subPoints, 8);
     if (ring.length >= 3) {
-      rings.push(ring);
+      rings3D.push(ring);
+      allPoints3D.push(...ring);
     }
   }
 
-  if (rings.length === 0) return null;
+  if (rings3D.length === 0) return null;
+
+  // Compute ONE shared plane basis from all sampled points.
+  // This keeps containment (hole classification) and triangulation in the
+  // same 2D coordinate system even when the whole shape is rotated in 3D.
+  const { origin, v1, v2 } = projectOutlineToPlane(allPoints3D);
+
+  // Project each 3D ring to 2D using the shared plane basis
+  const rings2D: number[][][] = rings3D.map((ring) =>
+    ring.map((p) => projectToPlane(p, origin, v1, v2)),
+  );
 
   // Determine containment: for each ring, check if it's inside another ring.
-  const isHoleOf = new Array<number>(rings.length).fill(-1);
+  const isHoleOf = new Array<number>(rings2D.length).fill(-1);
 
-  for (let i = 0; i < rings.length; i++) {
-    for (let j = 0; j < rings.length; j++) {
+  for (let i = 0; i < rings2D.length; i++) {
+    for (let j = 0; j < rings2D.length; j++) {
       if (i === j) continue;
-      if (pointInPolygon(rings[i][0], rings[j])) {
+      if (pointInPolygon(rings2D[i][0], rings2D[j])) {
         isHoleOf[i] = j;
         break;
       }
@@ -366,14 +473,18 @@ function buildEarcutFillGeometryMulti(
   // Collect outer rings (not holes) and their associated holes
   const allPositions: number[] = [];
 
-  for (let i = 0; i < rings.length; i++) {
+  for (let i = 0; i < rings2D.length; i++) {
     if (isHoleOf[i] >= 0) continue;
 
-    const outerRing = rings[i];
+    const outerRing = rings2D[i];
+    const outerRing3D = rings3D[i];
     const holeRings: number[][][] = [];
-    for (let j = 0; j < rings.length; j++) {
+    const holeRings3D: number[][][] = [];
+
+    for (let j = 0; j < rings2D.length; j++) {
       if (isHoleOf[j] === i) {
-        holeRings.push(rings[j]);
+        holeRings.push(rings2D[j]);
+        holeRings3D.push(rings3D[j]);
       }
     }
 
@@ -381,13 +492,15 @@ function buildEarcutFillGeometryMulti(
     if (indices.length === 0) continue;
 
     const allVerts: number[][] = [...outerRing];
-    for (const hole of holeRings) {
-      allVerts.push(...hole);
+    const allVerts3D: number[][] = [...outerRing3D];
+    for (let h = 0; h < holeRings.length; h++) {
+      allVerts.push(...holeRings[h]);
+      allVerts3D.push(...holeRings3D[h]);
     }
 
     for (const idx of indices) {
-      const v = allVerts[idx];
-      allPositions.push(v[0], v[1], v[2] ?? 0); // Use Z for 3D support
+      const v = allVerts3D[idx];
+      allPositions.push(v[0], v[1], v[2] ?? 0);
     }
   }
 

--- a/src/core/circle-rotate-3d.test.ts
+++ b/src/core/circle-rotate-3d.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { Circle } from '../../src/index';
+
+describe('Circle rotate in 3D', () => {
+  it('rotate around X axis should transform both stroke and fill mesh', () => {
+    const circle = new Circle({
+      radius: 1,
+      color: '#ff0000',
+      fillOpacity: 0.7,
+      strokeWidth: 2,
+    });
+
+    // Force initial geometry build
+    circle.getThreeObject();
+
+    // Rotate around X axis
+    circle.rotate(Math.PI / 12, { axis: [1, 0, 0] });
+
+    // Verify points were transformed (Z values change)
+    const pointsAfter = circle.getPoints();
+    expect(pointsAfter[0][2]).toBeCloseTo(0, 5); // first point on X axis stays at Z=0
+    expect(pointsAfter[1][2]).not.toBeCloseTo(0, 5); // other points get Z values
+    expect(pointsAfter[2][2]).not.toBeCloseTo(0, 5);
+
+    // Get the Three.js objects after rotation
+    const threeObject = circle.getThreeObject();
+
+    // Find the fill mesh (Mesh that is NOT a Line2)
+    const fillMesh = threeObject.children.find(
+      (c) => c instanceof THREE.Mesh && !(c as any).isLine2,
+    ) as THREE.Mesh;
+
+    // Find the stroke (Line2)
+    const stroke = threeObject.children.find((c) => (c as any).isLine2) as any;
+
+    // Check stroke has Z values
+    const strokePositions = stroke?.geometry?.attributes?.instanceStart?.array;
+    let strokeHasNonZeroZ = false;
+    for (let i = 2; i < strokePositions.length; i += 3) {
+      if (Math.abs(strokePositions[i]) > 0.001) {
+        strokeHasNonZeroZ = true;
+        break;
+      }
+    }
+    expect(strokeHasNonZeroZ).toBe(true);
+
+    // Check fill mesh geometry has Z values
+    const positions = fillMesh?.geometry?.attributes?.position?.array;
+    expect(positions).toBeDefined();
+
+    let fillHasNonZeroZ = false;
+    for (let i = 2; i < positions.length; i += 3) {
+      if (Math.abs(positions[i]) > 0.001) {
+        fillHasNonZeroZ = true;
+        break;
+      }
+    }
+    expect(fillHasNonZeroZ).toBe(true);
+
+    // Verify no double rotation (group rotation should be identity)
+    expect(threeObject.rotation.x).toBeCloseTo(0, 5);
+  });
+});

--- a/src/utils/math-scattered.test.ts
+++ b/src/utils/math-scattered.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { selectScatteredPoints, extractVectorsFrom3Points } from './math';
+
+describe('selectScatteredPoints', () => {
+  it('returns [] for empty', () => {
+    expect(selectScatteredPoints([])).toEqual([]);
+  });
+
+  it('returns [0] for single point', () => {
+    expect(selectScatteredPoints([[1, 2]])).toEqual([0]);
+  });
+
+  it('returns [0, 1] for two points', () => {
+    expect(
+      selectScatteredPoints([
+        [0, 0],
+        [1, 1],
+      ]),
+    ).toEqual([0, 1]);
+  });
+
+  it('selects opposite corners of square', () => {
+    const square = [
+      [0, 0],
+      [1, 0],
+      [1, 1],
+      [0, 1],
+    ];
+    const indices = selectScatteredPoints(square);
+    expect(indices[0]).toBe(0);
+    expect(indices[1]).toBe(2); // opposite corner
+  });
+});
+
+describe('extractVectorsFrom3Points', () => {
+  it('returns null for < 3 points', () => {
+    expect(extractVectorsFrom3Points([])).toBeNull();
+    expect(extractVectorsFrom3Points([[0, 0]])).toBeNull();
+  });
+
+  it('extracts vectors from 3 points', () => {
+    const result = extractVectorsFrom3Points([
+      [0, 0, 0],
+      [1, 0, 0],
+      [0, 1, 0],
+    ]);
+    expect(result!.v1).toEqual([1, 0, 0]);
+    expect(result!.v2).toEqual([0, 1, 0]);
+  });
+
+  it('handles 2D points', () => {
+    const result = extractVectorsFrom3Points([
+      [0, 0],
+      [2, 0],
+      [0, 3],
+    ]);
+    expect(result!.v1).toEqual([2, 0, 0]);
+    expect(result!.v2).toEqual([0, 3, 0]);
+  });
+});

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -82,14 +82,6 @@ export function pointToCoords(
 }
 
 /**
- * Evaluate a cubic Bezier curve at parameter t.
- * Uses the standard cubic Bernstein polynomial:
- *   B(t) = (1-t)^3 * p0 + 3*(1-t)^2*t * p1 + 3*(1-t)*t^2 * p2 + t^3 * p3
- *
- * The z-component uses nullish coalescing (p[2] ?? 0) so that 2D points
- * (without an explicit z) are handled safely.
- */
-/**
  * Apply a 2x2 or 3x3 transformation matrix to a single point,
  * relative to an aboutPoint (defaults to origin).
  *
@@ -121,6 +113,14 @@ export function transformPointByMatrix(
   return [nx + aboutPoint[0], ny + aboutPoint[1], nz + aboutPoint[2]];
 }
 
+/**
+ * Evaluate a cubic Bezier curve at parameter t.
+ * Uses the standard cubic Bernstein polynomial:
+ *   B(t) = (1-t)^3 * p0 + 3*(1-t)^2*t * p1 + 3*(1-t)*t^2 * p2 + t^3 * p3
+ *
+ * The z-component uses nullish coalescing (p[2] ?? 0) so that 2D points
+ * (without an explicit z) are handled safely.
+ */
 export function evalCubicBezier(
   p0: number[],
   p1: number[],
@@ -142,4 +142,117 @@ export function evalCubicBezier(
       (p2[2] ?? 0) * 3 * mt * t2 +
       (p3[2] ?? 0) * t3,
   ];
+}
+
+// ---------------------------------------------------------------------------
+// Plane basis extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Select 3 maximally scattered points from a point set.
+ *
+ * Algorithm: first point → furthest from first → furthest from both.
+ * This tends to pick a wide triangle, which gives a more stable plane basis.
+ *
+ * @returns Indices of 3 scattered points (fewer if not enough input)
+ */
+export function selectScatteredPoints(points: number[][]): number[] {
+  const n = points.length;
+  if (n < 3) return n === 0 ? [] : n === 1 ? [0] : [0, 1];
+
+  const dist2 = (i: number, j: number) => {
+    const dx = points[i][0] - points[j][0];
+    const dy = points[i][1] - points[j][1];
+    const dz = (points[i][2] ?? 0) - (points[j][2] ?? 0);
+    return dx * dx + dy * dy + dz * dz;
+  };
+
+  // Find point furthest from 0
+  let i1 = 1;
+  for (let i = 2; i < n; i++) if (dist2(0, i) > dist2(0, i1)) i1 = i;
+
+  // Find point furthest from both 0 and i1
+  let i2 = i1 === 0 ? 1 : 0;
+  for (let i = 0; i < n; i++) {
+    if (i === 0 || i === i1) continue;
+    if (dist2(0, i) + dist2(i1, i) > dist2(0, i2) + dist2(i1, i2)) i2 = i;
+  }
+
+  return [0, i1, i2];
+}
+
+/**
+ * Extract two vectors from 3 points [p0, p1, p2]: v1 = p1-p0, v2 = p2-p0.
+ * These span the plane containing the points.
+ * Returns null if < 3 points.
+ */
+export function extractVectorsFrom3Points(
+  points: number[][],
+): { v1: number[]; v2: number[] } | null {
+  if (points.length < 3) return null;
+  const [p0, p1, p2] = points;
+  return {
+    v1: [p1[0] - p0[0], p1[1] - p0[1], (p1[2] ?? 0) - (p0[2] ?? 0)],
+    v2: [p2[0] - p0[0], p2[1] - p0[1], (p2[2] ?? 0) - (p0[2] ?? 0)],
+  };
+}
+
+/**
+ * Project a 3D point onto a 2D plane basis.
+ *
+ * @param point - 3D point to project
+ * @param origin - Plane origin point
+ * @param v1 - First basis vector (becomes x-axis)
+ * @param v2 - Second basis vector (becomes y-axis)
+ * @returns [u, v] coordinates on the plane
+ */
+export function projectToPlane(
+  point: number[],
+  origin: number[],
+  v1: number[],
+  v2: number[],
+): [number, number] {
+  const dx = point[0] - origin[0];
+  const dy = point[1] - origin[1];
+  const dz = (point[2] ?? 0) - (origin[2] ?? 0);
+  // Dot products with basis vectors
+  const u = dx * v1[0] + dy * v1[1] + dz * v1[2];
+  const v = dx * v2[0] + dy * v2[1] + dz * v2[2];
+  return [u, v];
+}
+
+/**
+ * Get orthonormalized basis vectors from two spanning vectors.
+ * Uses Gram-Schmidt: normalizes v1, then makes v2 orthogonal to v1 and normalizes.
+ *
+ * @returns Object with orthonormal v1, v2 and the original (for reversal)
+ */
+export function orthonormalizeBasis(
+  v1: number[],
+  v2: number[],
+): {
+  v1: number[];
+  v2: number[];
+} {
+  const len1 = Math.sqrt(v1[0] ** 2 + v1[1] ** 2 + v1[2] ** 2);
+  if (len1 < 1e-10) {
+    return { v1: [1, 0, 0], v2: [0, 1, 0] };
+  }
+  const u1 = [v1[0] / len1, v1[1] / len1, v1[2] / len1];
+
+  // v2' = v2 - (v2·u1) * u1
+  const dot = v2[0] * u1[0] + v2[1] * u1[1] + v2[2] * u1[2];
+  const v2p = [v2[0] - dot * u1[0], v2[1] - dot * u1[1], v2[2] - dot * u1[2]];
+
+  const len2 = Math.sqrt(v2p[0] ** 2 + v2p[1] ** 2 + v2p[2] ** 2);
+  if (len2 < 1e-10) {
+    // v1 and v2 were collinear, pick perpendicular
+    const perp = Math.abs(u1[2]) < 0.9 ? [0, 0, 1] : [1, 0, 0];
+    const perpDot = perp[0] * u1[0] + perp[1] * u1[1] + perp[2] * u1[2];
+    const u2 = [perp[0] - perpDot * u1[0], perp[1] - perpDot * u1[1], perp[2] - perpDot * u1[2]];
+    const u2len = Math.sqrt(u2[0] ** 2 + u2[1] ** 2 + u2[2] ** 2);
+    return { v1: u1, v2: [u2[0] / u2len, u2[1] / u2len, u2[2] / u2len] };
+  }
+
+  return { v1: u1, v2: [v2p[0] / len2, v2p[1] / len2, v2p[2] / len2] };
 }


### PR DESCRIPTION
## Summary

When rotating a VMobject (like Circle) in 3D, and using camera orbit conrols. the contour (stroke) would rotate correctly but the fill mesh would not. This was because:

1. sampleBezierOutline() dropped Z coordinates, returning only [x, y]
2. buildEarcutFillGeometry() hardcoded Z=0 in the output positions

## Changes

Fix by preserving Z coordinates throughout the fill geometry pipeline:
- sampleBezierOutline() now returns [x, y, z] points
- buildEarcutFillGeometry() uses z from sampled outline
- buildEarcutFillGeometryMulti() uses z from vertices

Add test verifying both stroke and fill mesh have correct Z values after 3D rotation.

## Testing
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Types check (`npm run typecheck`)

## Related Issues
fixes this:

<img width="658" height="589" alt="image" src="https://github.com/user-attachments/assets/3eac5271-0cb3-4660-904f-2912c2a7fcd3" />

