### PR TITLE
Fix doc example issues (zoom text, underline, MathTex fontSize, =)

### DIFF
--- a/docs/src/components/examples/BooleanOperationsExample.tsx
+++ b/docs/src/components/examples/BooleanOperationsExample.tsx
@@ -3,7 +3,31 @@ import React from 'react';
 import ManimExample from '../ManimExample';
 
 async function animate(scene: any) {
-  const { BLUE, Difference, DOWN, Ellipse, Exclusion, FadeIn, GREEN, Group, Intersection, LEFT, MoveToTarget, ORANGE, PINK, RED, RIGHT, Scene, Text, Underline, UP, Union, WHITE, YELLOW, scaleVec } = await import('manim-web');
+  const {
+    BLUE,
+    Difference,
+    DOWN,
+    Ellipse,
+    Exclusion,
+    FadeIn,
+    GREEN,
+    Group,
+    Intersection,
+    LEFT,
+    MoveToTarget,
+    ORANGE,
+    PINK,
+    RED,
+    RIGHT,
+    Scene,
+    Text,
+    Underline,
+    UP,
+    Union,
+    WHITE,
+    YELLOW,
+    scaleVec,
+  } = await import('manim-web');
 
   const ellipse1 = new Ellipse({
     width: 4.0,
@@ -21,7 +45,7 @@ async function animate(scene: any) {
   }).nextTo(ellipse1, UP);
   const ellipse_group = new Group(bool_ops_text, ellipse1, ellipse2).moveTo(scaleVec(3, LEFT));
   // Create underline AFTER group is positioned so it uses the text's final position
-  const underline = new Underline(bool_ops_text, { color: WHITE, strokeWidth: 2, buff: -0.25 });
+  const underline = new Underline(bool_ops_text, { color: WHITE, strokeWidth: 2, buff: 0.05 });
   ellipse_group.add(underline);
   await scene.play(new FadeIn(ellipse_group));
 

--- a/docs/src/components/examples/MathTexPartExample.tsx
+++ b/docs/src/components/examples/MathTexPartExample.tsx
@@ -9,7 +9,7 @@ async function animate(scene: any) {
   const equation = new MathTex({
     latex: ['x^2', '+', 'y^2', '=', 'r^2'],
     color: WHITE,
-    fontSize: 1.5,
+    fontSize: 60,
   });
   await equation.waitForRender();
 

--- a/docs/src/components/examples/MatrixHelpersExample.tsx
+++ b/docs/src/components/examples/MatrixHelpersExample.tsx
@@ -10,24 +10,24 @@ async function animate(scene: any) {
   const m0 = new MathTex({
     latex: '\\begin{bmatrix} \\pi & 0 \\\\ -1 & 1 \\end{bmatrix}',
     color: WHITE,
-    fontSize: 1,
+    fontSize: 40,
   });
 
   const m1 = new MathTex({
     latex: '\\begin{pmatrix} 2 & 0 \\\\ 12 & -1 \\end{pmatrix}',
     color: WHITE,
-    fontSize: 1,
+    fontSize: 40,
   });
 
   const m2 = new MathTex({
     latex: '\\left\\{ \\begin{matrix} 3.46 & 2.12 \\\\ 33.22 & 12.33 \\end{matrix} \\right\\}',
     color: WHITE,
-    fontSize: 1,
+    fontSize: 40,
   });
 
-  const piTex = new MathTex({ latex: '\\pi', color: TEAL_A, fontSize: 1 });
-  const leftAngle = new MathTex({ latex: '\\Bigg\\langle', color: WHITE, fontSize: 1 });
-  const rightAngle = new MathTex({ latex: '\\Bigg\\rangle', color: WHITE, fontSize: 1 });
+  const piTex = new MathTex({ latex: '\\pi', color: TEAL_A, fontSize: 80 });
+  const leftAngle = new MathTex({ latex: '\\Bigg\\langle', color: WHITE, fontSize: 40 });
+  const rightAngle = new MathTex({ latex: '\\Bigg\\rangle', color: WHITE, fontSize: 40 });
 
   // Wait for all MathTex renders before positioning
   await Promise.all([
@@ -85,7 +85,7 @@ async function animate(scene: any) {
   const detTex = new MathTex({
     latex: '\\text{det} \\left( \\begin{bmatrix} 2 & 0 \\\\ -1 & 1 \\end{bmatrix} \\right) = 3',
     color: WHITE,
-    fontSize: 1,
+    fontSize: 48,
   });
   await detTex.waitForRender();
   await scene.play(new FadeIn(detTex, { duration: 1.5 }));

--- a/docs/src/components/examples/MovingZoomedSceneAroundExample.tsx
+++ b/docs/src/components/examples/MovingZoomedSceneAroundExample.tsx
@@ -71,7 +71,7 @@ async function animate(scene: any) {
   // Pop-out animation: display pops from frame position to its shifted position
   await scene.play(scene.getZoomedDisplayPopOutAnimation(), unfoldCamera);
 
-  zoomedCameraText.nextTo(zoomedDisplayFrame, DOWN);
+  zoomedCameraText.nextTo(zoomedDisplay, DOWN);
   await scene.play(new FadeIn(zoomedCameraText, { shift: UP }));
 
   // Scale frame and display non-uniformly

--- a/docs/src/components/examples/TexTemplateExample.tsx
+++ b/docs/src/components/examples/TexTemplateExample.tsx
@@ -15,7 +15,7 @@ async function animate(scene: any) {
   const tex1 = new MathTex({
     latex: '\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}',
     color: WHITE,
-    fontSize: 1,
+    fontSize: 36,
   });
   await tex1.waitForRender();
   tex1.moveTo([0.5, 1.2, 0]);
@@ -28,7 +28,7 @@ async function animate(scene: any) {
   const tex2 = new MathTex({
     latex: '\\sum_{n=1}^{N} \\frac{1}{n^2} = \\frac{\\pi^2}{6}',
     color: BLUE,
-    fontSize: 1,
+    fontSize: 36,
   });
   await tex2.waitForRender();
   tex2.moveTo([0.5, -0.5, 0]);

--- a/examples/boolean_operations.ts
+++ b/examples/boolean_operations.ts
@@ -48,7 +48,7 @@ async function booleanOperations(scene) {
   }).nextTo(ellipse1, UP);
   const ellipse_group = new Group(bool_ops_text, ellipse1, ellipse2).moveTo(scaleVec(3, LEFT));
   // Create underline AFTER group is positioned so it uses the text's final position
-  const underline = new Underline(bool_ops_text, { color: WHITE, strokeWidth: 2, buff: -0.25 });
+  const underline = new Underline(bool_ops_text, { color: WHITE, strokeWidth: 2, buff: 0.05 });
   ellipse_group.add(underline);
   await scene.play(new FadeIn(ellipse_group));
 

--- a/examples/moving_zoomed_scene_around.ts
+++ b/examples/moving_zoomed_scene_around.ts
@@ -81,7 +81,7 @@ async function movingZoomedSceneAround(scene: ZoomedScene) {
   // Pop-out animation: display pops from frame position to its shifted position
   await scene.play(scene.getZoomedDisplayPopOutAnimation(), unfoldCamera);
 
-  zoomedCameraText.nextTo(zoomedDisplayFrame, DOWN);
+  zoomedCameraText.nextTo(zoomedDisplay, DOWN);
   await scene.play(new FadeIn(zoomedCameraText, { shift: UP }));
 
   // Scale frame and display non-uniformly

--- a/src/core/VMobjectGeometry.ts
+++ b/src/core/VMobjectGeometry.ts
@@ -211,6 +211,27 @@ function projectOutlineToPlane(outline3D: number[][]): {
     };
   }
 
+  // Fast path: when the shape lies in the XY plane (z ≈ 0 everywhere) the
+  // standard basis is already correct, and computing one from scattered
+  // points can pick three nearly-collinear samples for thin glyphs (e.g. the
+  // two horizontal bars of `=`), collapsing v2 onto Z and projecting every
+  // point to the same line.
+  let zMin = outline3D[0][2] ?? 0;
+  let zMax = zMin;
+  for (let i = 1; i < outline3D.length; i++) {
+    const z = outline3D[i][2] ?? 0;
+    if (z < zMin) zMin = z;
+    if (z > zMax) zMax = z;
+  }
+  if (zMax - zMin < 1e-6) {
+    return {
+      outline2D: outline3D.map((p) => [p[0], p[1]]),
+      origin: [0, 0, zMin],
+      v1: [1, 0, 0],
+      v2: [0, 1, 0],
+    };
+  }
+
   // Get plane basis from scattered points
   const indices = selectScatteredPoints(outline3D);
   const scattered = indices.map((i) => outline3D[i]);

--- a/src/mobjects/text/MathTex.ts
+++ b/src/mobjects/text/MathTex.ts
@@ -346,11 +346,14 @@ export class MathTex extends VGroup {
       }
     }
 
-    // Render each part separately to count how many glyphs it produces
+    // Render each part separately to count how many glyphs it produces.
+    // Use the same displayMode as the full render so MathJax produces matching
+    // glyph counts (operators rendered alone in inline mode can drop or add
+    // wrapper paths, throwing off the per-part assignment).
     const partGlyphCounts: number[] = [];
     for (const partLatex of latexParts) {
       const partResult = await renderLatexToSVG(partLatex, {
-        displayMode: false,
+        displayMode: this._displayMode,
         color: this._color,
         macros: this._macros,
       });


### PR DESCRIPTION
## Summary

Fixes the 5 doc example regressions reported plus a related multi-subpath glyph rendering bug uncovered while debugging.

- **MovingZoomedScene** (`graphing#moving-zoomed-scene-around`): "Zoomed camera" text was anchored to the displayFrame, but the nested child Mobject's `getCenter()` returns origin between renders (Box3.setFromObject only refreshes self matrixWorld). Anchor on `zoomedDisplay` (top-level) instead.
- **BooleanOperations** (`animations#boolean-operations`): Underline `buff: -0.25` placed the line above the bottom edge → strikethrough. Use `0.05`.
- **MatrixHelpers / TeX Templates / MathTex Parts** (`new#matrix-helpers`, `new#tex-templates`, `new#mathtex-parts`): fontSize was set to `1` / `1.5` thinking it was a scale factor. The pt-based default flipped back to `48` in #5270f23 leaving these examples invisible. Restored 36–80.
- **MathTex `=` invisible**: standalone `MathTex({ latex: '=' })` rendered nothing. `projectOutlineToPlane` (added in #285) picked 3 nearly-collinear scattered points for thin glyphs (`=`'s two horizontal bars), collapsing v2 onto Z and projecting every point to the same line. Take a fast path with the standard XY basis when all points are coplanar in z.
- **MathTex multi-part glyph counts**: per-part rendering used `displayMode: false` while the full expression used the user's displayMode, producing different glyph counts for operators and shifting glyph assignment to the wrong parts. Match displayMode.

## Test plan

- [x] `npx vitest run src/utils/math-scattered.test.ts src/core/VMobjectGeometry.test.ts src/core/circle-rotate-3d.test.ts src/mobjects/text/mathtex-svg.test.ts` — 23/23 pass
- [x] Manual: each of the 5 doc pages renders correctly via `npm run docs && npm run serve`
- [x] Manual: `MathTex({ latex: '=' })` renders standalone