### PR TITLE
chore: release 0.3.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The power of [3Blue1Brown's Manim](https://github.com/3b1b/manim) — in the bro
         Scene,
         Circle,
         Create,
-    } from "https://cdn.jsdelivr.net/npm/manim-web@0.3.18/dist/manim-web.browser.js";
+    } from "https://cdn.jsdelivr.net/npm/manim-web@latest/dist/manim-web.browser.js";
 
     const options = { width: 500, height: 300 };
     const scene = new Scene(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manim-web",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manim-web",
-      "version": "0.3.19",
+      "version": "0.3.20",
       "license": "MIT",
       "dependencies": {
         "earcut": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manim-web",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "Manim-like mathematical animation library for the web",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bump to 0.3.20
- Pin README CDN snippet to `@latest` so it tracks future releases

Notable fixes since 0.3.19 (#294):
- multi-subpath glyph fill (e.g. `=`) renders correctly
- multi-part MathTex glyph counts use the full's displayMode
- doc example regressions (fontSize, underline buff, zoom text anchor)

Release workflow auto-tags + publishes on merge.