### PR TITLE
Fix sphere opacity not working in 3D scenes (#255)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The power of [3Blue1Brown's Manim](https://github.com/3b1b/manim) — in the bro
         Scene,
         Circle,
         Create,
-    } from "https://cdn.jsdelivr.net/npm/manim-web@0.3.18/dist/manim-web.browser.js";
+    } from "https://cdn.jsdelivr.net/npm/manim-web@latest/dist/manim-web.browser.js";
 
     const options = { width: 500, height: 300 };
     const scene = new Scene(

--- a/examples/3d-scenes/sphere_opacity.html
+++ b/examples/3d-scenes/sphere_opacity.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Sphere Opacity Repro (issue #255)</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #191919;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+      color: #eee;
+      padding: 20px;
+      gap: 12px;
+    }
+    h1 { font-size: 18px; font-weight: 500; }
+    .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+    .panel { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+    .panel .container { width: 280px; height: 220px; border: 1px solid #333; border-radius: 4px; overflow: hidden; }
+    .panel small { color: #aaa; }
+    .row-label { font-size: 14px; color: #ddd; margin-top: 8px; }
+  </style>
+</head>
+<body>
+  <h1>Sphere opacity over PolarPlane (issue #255 — fixed)</h1>
+
+  <div class="row-label">Sphere added FIRST (the bug case): scene.add(sphere, plane)</div>
+  <div class="grid">
+    <div class="panel"><small>opacity 0.02</small><div id="a02" class="container"></div></div>
+    <div class="panel"><small>opacity 0.3</small><div id="a30" class="container"></div></div>
+    <div class="panel"><small>opacity 0.7</small><div id="a70" class="container"></div></div>
+  </div>
+
+  <div class="row-label">Sphere added SECOND (control): scene.add(plane, sphere)</div>
+  <div class="grid">
+    <div class="panel"><small>opacity 0.02</small><div id="b02" class="container"></div></div>
+    <div class="panel"><small>opacity 0.3</small><div id="b30" class="container"></div></div>
+    <div class="panel"><small>opacity 0.7</small><div id="b70" class="container"></div></div>
+  </div>
+
+  <script type="module" src="./sphere_opacity.ts"></script>
+</body>
+</html>

--- a/examples/3d-scenes/sphere_opacity.ts
+++ b/examples/3d-scenes/sphere_opacity.ts
@@ -1,0 +1,40 @@
+import { PolarPlane, Sphere, ThreeDScene, WHITE } from '../../src/index';
+
+function makeScene(containerId: string, opacity: number, sphereFirst: boolean) {
+  const container = document.getElementById(containerId) as HTMLElement;
+  const scene = new ThreeDScene(container, {
+    width: 280,
+    height: 220,
+    backgroundColor: '#191919',
+    phi: 75 * (Math.PI / 180),
+    theta: -45 * (Math.PI / 180),
+    distance: 18,
+    fov: 30,
+    enableOrbitControls: false,
+  });
+
+  const plane = new PolarPlane({
+    gridStrokeWidth: 2,
+    gridOpacity: 0.25,
+    gridColor: WHITE,
+    includeAngleLabels: false,
+  });
+  plane.rotation.x = -Math.PI / 2;
+  const sphere = new Sphere({ radius: 1.2, color: WHITE, opacity });
+
+  if (sphereFirst) scene.add(sphere, plane);
+  else scene.add(plane, sphere);
+
+  // Pin radius labels to face the camera (otherwise the parent's -PI/2 X
+  // rotation flips the label quads and the canvas texture reads mirrored).
+  plane.billboardLabels();
+
+  scene.wait(Infinity);
+}
+
+makeScene('a02', 0.02, true);
+makeScene('a30', 0.3, true);
+makeScene('a70', 0.7, true);
+makeScene('b02', 0.02, false);
+makeScene('b30', 0.3, false);
+makeScene('b70', 0.7, false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manim-web",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manim-web",
-      "version": "0.3.19",
+      "version": "0.3.20",
       "license": "MIT",
       "dependencies": {
         "earcut": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manim-web",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "Manim-like mathematical animation library for the web",
   "type": "module",
   "main": "dist/index.js",

--- a/src/core/ThreeDScene.ts
+++ b/src/core/ThreeDScene.ts
@@ -178,26 +178,46 @@ export class ThreeDScene extends Scene {
   }
 
   /**
-   * Override add to re-enable depth testing for proper 3D occlusion.
-   * The base Scene disables depthTest for 2D render-order layering,
-   * but 3D scenes need depth testing for correct visibility.
+   * Override add for 3D-correct material/render setup (issue #255):
+   *  - depthTest=true on every material (base Scene disables it for 2D layering)
+   *  - depthWrite=!transparent (transparent meshes must not occlude later
+   *    transparent fragments behind them)
+   *  - renderOrder reset to 0 so Three.js sorts transparent objects by camera
+   *    distance instead of add order (base Scene stamps an incrementing
+   *    renderOrder for 2D z-ordering, which defeats 3D depth sort)
+   *
+   * Auto-render is suppressed inside super.add() and run once at the end,
+   * after settings are applied, so the first visible frame is correct.
    */
   add(...mobjects: Mobject[]): this {
-    super.add(...mobjects);
-    for (const mobject of mobjects) {
-      const threeObj = mobject.getThreeObject();
-      threeObj.traverse((child) => {
-        const mesh = child as THREE.Mesh;
-        if (mesh.material) {
-          const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
-          for (const m of mats) {
-            m.depthTest = true;
-            m.depthWrite = true;
-          }
-        }
-      });
+    const wasAuto = this._autoRender;
+    this._autoRender = false;
+    const newMobs = new Set(mobjects.filter((m) => !this.mobjects.has(m)));
+    try {
+      super.add(...mobjects);
+      for (const mob of mobjects) ThreeDScene._applyDepthSettings(mob, newMobs.has(mob));
+      if (wasAuto) this._render();
+    } finally {
+      this._autoRender = wasAuto;
     }
     return this;
+  }
+
+  /**
+   * Apply 3D-correct material defaults: depthTest=true,
+   * depthWrite=!transparent, and (on initial add only) renderOrder=0 so
+   * Three.js sorts transparents by camera distance.
+   */
+  private static _applyDepthSettings(mob: Mobject, resetRenderOrder = false): void {
+    mob.getThreeObject().traverse((c) => {
+      if (resetRenderOrder) c.renderOrder = 0;
+      const mat = (c as THREE.Mesh).material;
+      if (!mat) return;
+      (Array.isArray(mat) ? mat : [mat]).forEach((m) => {
+        m.depthTest = true;
+        m.depthWrite = !m.transparent;
+      });
+    });
   }
 
   /**
@@ -438,21 +458,20 @@ export class ThreeDScene extends Scene {
    */
   addFixedInFrameMobjects(...mobjects: Mobject[]): this {
     for (const mob of mobjects) {
+      const threeObj = mob.getThreeObject();
       // Remove from fixed-orientation if present (mutually exclusive)
       if (this._fixedOrientationMobjects.has(mob)) {
         this._fixedOrientationMobjects.delete(mob);
-        const threeObj = mob.getThreeObject();
         threeObj.quaternion.identity();
         threeObj.position.copy(mob.position);
       }
       this._fixedMobjects.add(mob);
-      // Ensure the Three.js object is initialized
-      const threeObj = mob.getThreeObject();
       this._hudScene.add(threeObj);
+      // HUD bypasses Scene.add(), so apply 3D depth/renderOrder defaults
+      // here so transparent fixed-in-frame mobjects render correctly (#255).
+      ThreeDScene._applyDepthSettings(mob, true);
     }
-    if (this._fixedMobjects.size > 0) {
-      this.render();
-    }
+    if (this._fixedMobjects.size > 0) this.render();
     return this;
   }
 
@@ -566,23 +585,16 @@ export class ThreeDScene extends Scene {
       this._lastRenderTime = now;
     }
 
-    // Sync dirty mobjects in the main scene
-    for (const mob of this.mobjects) {
-      if (mob._dirty) {
-        mob._syncToThree();
-        mob._dirty = false;
-      }
-    }
-
-    // Sync fixed (HUD) mobjects
-    if (this._fixedMobjects) {
-      for (const mob of this._fixedMobjects) {
-        if (mob._dirty) {
-          mob._syncToThree();
-          mob._dirty = false;
-        }
-      }
-    }
+    // Sync dirty mobjects (main + HUD): re-applying depth settings so
+    // runtime opacity changes flip depthWrite correctly (issue #255).
+    const syncDirty = (mob: Mobject): void => {
+      if (!mob._dirty) return;
+      mob._syncToThree();
+      ThreeDScene._applyDepthSettings(mob);
+      mob._dirty = false;
+    };
+    for (const mob of this.mobjects) syncDirty(mob);
+    if (this._fixedMobjects) for (const mob of this._fixedMobjects) syncDirty(mob);
 
     // Apply billboard rotation to fixed-orientation mobjects around their
     // current world center. We can't just set `quaternion = camQuat` on the
@@ -625,9 +637,11 @@ export class ThreeDScene extends Scene {
     threeRenderer.autoClear = true;
     threeRenderer.render(this.threeScene, this._camera3D.getCamera());
 
-    // Pass 2: HUD overlay (no clear, composites on top)
+    // Pass 2: HUD overlay (composites on top; depth cleared so HUD has its
+    // own depth buffer independent of the 3D scene)
     if (this._fixedMobjects && this._fixedMobjects.size > 0) {
       threeRenderer.autoClear = false;
+      threeRenderer.clearDepth();
       threeRenderer.render(this._hudScene, this._hudCamera);
       threeRenderer.autoClear = true;
     }

--- a/src/mobjects/graphing/ComplexPlane.ts
+++ b/src/mobjects/graphing/ComplexPlane.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import * as THREE from 'three';
 import { Group } from '../../core/Group';
 import { Mobject, Vector3Tuple } from '../../core/Mobject';
 import { VMobject } from '../../core/VMobject';
@@ -804,6 +805,45 @@ export class PolarPlane extends Group {
    */
   getRadiusLabels(): Group {
     return this._radiusLabels;
+  }
+
+  /**
+   * Pin angle and radius labels to face the camera in a 3D scene.
+   *
+   * When the plane is rotated for 3D use (e.g. `plane.rotation.x = -PI/2`
+   * to lay it flat on the ground) the Text label quads inherit the
+   * rotation and end up facing the wrong way — the canvas texture reads
+   * mirrored to the camera.
+   *
+   * Mirrors the `ThreeDAxes` `billboardLabels` pattern: installs an
+   * `onBeforeRender` hook on each label mesh that compensates for any
+   * ancestor rotation so the mesh's *world* quaternion equals the
+   * camera's every draw. Labels stay in the plane's Mobject hierarchy
+   * (no re-parenting), so `scene.remove(plane)` cleans them up
+   * automatically and there's no scene-graph / Mobject-tree mismatch.
+   *
+   * Idempotent: re-calling replaces any prior hook on the same meshes.
+   */
+  billboardLabels(): this {
+    for (const label of [...this._angleLabels.children, ...this._radiusLabels.children]) {
+      label.getThreeObject().traverse((child) => {
+        if (!(child instanceof THREE.Mesh)) return;
+        child.onBeforeRender = (_renderer, _scene, camera) => {
+          const parent = child.parent;
+          if (parent) {
+            parent.updateMatrixWorld(true);
+            const parentWorldQuat = new THREE.Quaternion();
+            parent.getWorldQuaternion(parentWorldQuat);
+            child.quaternion.copy(parentWorldQuat.invert()).multiply(camera.quaternion);
+          } else {
+            child.quaternion.copy(camera.quaternion);
+          }
+          child.updateMatrix();
+          child.updateMatrixWorld(true);
+        };
+      });
+    }
+    return this;
   }
 
   /**

--- a/src/mobjects/three-d/Sphere.test.ts
+++ b/src/mobjects/three-d/Sphere.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Regression tests for transparent 3D mesh rendering (issue #255).
+ *
+ * Before the fix, ThreeDScene.add() force-set depthWrite=true on every
+ * mesh material, including transparent ones. A transparent sphere added
+ * before a transparent plane would write its depth values and occlude
+ * the plane behind it — making opacity look like "darker but still
+ * opaque" and making the result depend on add order.
+ *
+ * The Three.js canonical recipe for transparent meshes is
+ * `transparent: true, depthWrite: false`: depth-test against opaque
+ * geometry, but don't write depth so further transparent fragments
+ * behind aren't rejected.
+ */
+import * as THREE from 'three';
+import { describe, it, expect } from 'vitest';
+import { ThreeDScene } from '../../core/ThreeDScene';
+import { Sphere } from './Sphere';
+
+function getMaterial(sphere: Sphere): THREE.MeshStandardMaterial {
+  const mesh = sphere.getThreeObject() as THREE.Mesh;
+  return mesh.material as THREE.MeshStandardMaterial;
+}
+
+describe('Sphere opacity / depthWrite (issue #255)', () => {
+  it('opaque sphere keeps depthWrite enabled after add', () => {
+    const scene = ThreeDScene.createHeadless();
+    const sphere = new Sphere({ radius: 1, opacity: 1 });
+    scene.add(sphere);
+
+    const mat = getMaterial(sphere);
+    expect(mat.transparent).toBe(false);
+    expect(mat.depthTest).toBe(true);
+    expect(mat.depthWrite).toBe(true);
+
+    scene.dispose();
+  });
+
+  it('transparent sphere has depthWrite disabled after add', () => {
+    const scene = ThreeDScene.createHeadless();
+    const sphere = new Sphere({ radius: 1, opacity: 0.02 });
+    scene.add(sphere);
+
+    const mat = getMaterial(sphere);
+    expect(mat.transparent).toBe(true);
+    expect(mat.depthTest).toBe(true);
+    expect(mat.depthWrite).toBe(false);
+
+    scene.dispose();
+  });
+
+  it('depthWrite is independent of add order for transparent meshes', () => {
+    const scene = ThreeDScene.createHeadless();
+    const a = new Sphere({ radius: 1, opacity: 0.3 });
+    const b = new Sphere({ radius: 2, opacity: 0.3 });
+
+    scene.add(a, b);
+    expect(getMaterial(a).depthWrite).toBe(false);
+    expect(getMaterial(b).depthWrite).toBe(false);
+
+    const scene2 = ThreeDScene.createHeadless();
+    const c = new Sphere({ radius: 1, opacity: 0.3 });
+    const d = new Sphere({ radius: 2, opacity: 0.3 });
+    scene2.add(d, c);
+    expect(getMaterial(c).depthWrite).toBe(false);
+    expect(getMaterial(d).depthWrite).toBe(false);
+
+    scene.dispose();
+    scene2.dispose();
+  });
+
+  it('runtime opacity change flips depthWrite on next render sync', () => {
+    const scene = ThreeDScene.createHeadless();
+    const sphere = new Sphere({ radius: 1, opacity: 1 });
+    scene.add(sphere);
+
+    expect(getMaterial(sphere).depthWrite).toBe(true);
+
+    sphere.setStrokeOpacity(0.5);
+    scene.render();
+
+    const mat = getMaterial(sphere);
+    expect(mat.transparent).toBe(true);
+    expect(mat.depthWrite).toBe(false);
+
+    scene.dispose();
+  });
+
+  it('3D add resets renderOrder to 0 so Three.js sorts transparents by distance', () => {
+    const scene = ThreeDScene.createHeadless();
+    const a = new Sphere({ radius: 1, opacity: 0.3 });
+    const b = new Sphere({ radius: 2, opacity: 0.3 });
+    scene.add(a, b);
+
+    expect(a.getThreeObject().renderOrder).toBe(0);
+    expect(b.getThreeObject().renderOrder).toBe(0);
+
+    scene.dispose();
+  });
+
+  it('addFixedInFrameMobjects applies depth settings to HUD spheres (#255)', () => {
+    const scene = ThreeDScene.createHeadless();
+    const hudSphere = new Sphere({ radius: 0.5, opacity: 0.5 });
+    scene.addFixedInFrameMobjects(hudSphere);
+
+    const mat = getMaterial(hudSphere);
+    expect(mat.transparent).toBe(true);
+    expect(mat.depthTest).toBe(true);
+    expect(mat.depthWrite).toBe(false);
+    expect(hudSphere.getThreeObject().renderOrder).toBe(0);
+
+    scene.dispose();
+  });
+
+  it('addForegroundMobject still gets a high renderOrder after 3D reset', () => {
+    const scene = ThreeDScene.createHeadless();
+    const fg = new Sphere({ radius: 1, opacity: 1 });
+    scene.addForegroundMobject(fg);
+
+    expect(fg.getThreeObject().renderOrder).toBeGreaterThanOrEqual(10000);
+
+    scene.dispose();
+  });
+
+  it('re-adding an existing foreground mobject does not clobber its renderOrder', () => {
+    const scene = ThreeDScene.createHeadless();
+    const fg = new Sphere({ radius: 1, opacity: 1 });
+    scene.addForegroundMobject(fg);
+    const fgRO = fg.getThreeObject().renderOrder;
+    expect(fgRO).toBeGreaterThanOrEqual(10000);
+
+    scene.add(fg);
+    expect(fg.getThreeObject().renderOrder).toBe(fgRO);
+
+    scene.dispose();
+  });
+
+  it('runtime opacity restore re-enables depthWrite on next render sync', () => {
+    const scene = ThreeDScene.createHeadless();
+    const sphere = new Sphere({ radius: 1, opacity: 0.5 });
+    scene.add(sphere);
+
+    expect(getMaterial(sphere).depthWrite).toBe(false);
+
+    sphere.setStrokeOpacity(1);
+    scene.render();
+
+    const mat = getMaterial(sphere);
+    expect(mat.transparent).toBe(false);
+    expect(mat.depthWrite).toBe(true);
+
+    scene.dispose();
+  });
+});


### PR DESCRIPTION
Closes #255.

## The bug
Setting `opacity < 1` on a `Sphere` (or any 3D mobject) made it darker but not transparent — the sphere occluded objects behind it via the depth buffer. The result also depended on `scene.add()` order, which it shouldn't.

## Root cause
`ThreeDScene.add()` was force-setting `material.depthWrite = true` on every mesh, including transparent ones. Three.js's canonical recipe for transparent meshes is `transparent: true, depthWrite: false` — they should depth-test against opaque geometry but not write depth, so further transparent fragments behind aren't rejected.

A second, related defect: `Scene.add()` stamps an incrementing `renderOrder` on every mobject for 2D z-ordering. In a 3D scene that overrides Three.js's transparent depth sort, so blending order was add-order dependent. Three more lifecycle gaps fell out of an iterative review:

- `super.add()` auto-renders before the depth fix could apply, so the first visible frame was stale.
- `addFixedInFrameMobjects()` (HUD) bypassed the fix entirely — pinned transparent mobjects had `depthWrite=true`.
- The HUD pass rendered with `autoClear=false` and no depth clear, mixing HUD depth with the 3D scene.
- Re-adding an already-foreground mobject via `scene.add()` clobbered its high `renderOrder`.

## The fix
**`src/core/ThreeDScene.ts`:**
- `add()` now applies `depthTest=true, depthWrite=!transparent` and resets `renderOrder=0` to all newly-added mobjects (only new ones, so foreground re-add is preserved).
- Auto-render is suppressed inside `super.add()` and run once at the end after settings are applied (with `try/finally` to restore on throw).
- Per-frame dirty sync re-applies depth settings (without touching renderOrder) so runtime opacity changes flip `depthWrite` correctly during animations.
- `addFixedInFrameMobjects()` calls the same helper for HUD mobjects.
- The HUD render pass calls `clearDepth()` before drawing so it has its own depth buffer.

**`src/mobjects/graphing/ComplexPlane.ts`:**
The issue reporter also noted that the polar plane's labels appeared mirrored when the plane was rotated horizontal in 3D. New `PolarPlane.billboardLabels()` method installs an `onBeforeRender` hook on each label mesh (mirroring the existing `ThreeDAxes` pattern) that compensates for ancestor rotation so labels always face the camera. Labels stay in the plane's mobject hierarchy — no reparenting, no ownership split, automatic cleanup on `scene.remove(plane)`.

## Tests
9 new regression tests in `src/mobjects/three-d/Sphere.test.ts` cover:
- opaque vs transparent depthWrite after add
- order-independence for two transparent spheres
- runtime opacity 1↔0.5 flips depthWrite on next render
- renderOrder reset to 0 on new mobs
- foreground mobject keeps `renderOrder >= 10000`
- re-adding foreground mobject doesn't clobber renderOrder
- HUD path applies depth defaults

## Demo
`examples/3d-scenes/sphere_opacity.html` shows the original repro at three opacity levels (0.02, 0.3, 0.7) in both add orders side by side. Top and bottom rows are visually identical → fix is order-independent. Polar plane gridlines (and the radius labels "1", "2", "3") are clearly visible through the transparent sphere at every opacity.

## Verification
- `npx vitest run`: 5820/5820 pass
- `npm run lint`: clean
- `npm run typecheck`: clean
- 4-pass independent code review by codex (gpt-5.5 xhigh) caught and fixed: renderOrder defeating sort, auto-render timing, HUD bypass, HUD depth clear, foreground re-add idempotency, billboard ownership/lifecycle.