### PR TITLE
fix(animate-proxy): chained animate.shift / scale now accumulate (#252)

### DIFF
--- a/examples/animate_shift_chained.html
+++ b/examples/animate_shift_chained.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ManimWeb - Chained animate.shift (issue #252)</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #1a1a2e;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+      color: #eee;
+      gap: 16px;
+    }
+    #container { border: 2px solid #333; border-radius: 8px; overflow: hidden; }
+    .controls { display: flex; gap: 10px; }
+    button {
+      padding: 10px 20px;
+      background: #e94560;
+      border: none;
+      border-radius: 4px;
+      color: white;
+      cursor: pointer;
+      font-size: 14px;
+    }
+    button:hover { background: #ff6b6b; }
+    pre {
+      background: #0f1023;
+      padding: 8px 12px;
+      border-radius: 4px;
+      font-size: 13px;
+      max-width: 760px;
+      white-space: pre-wrap;
+    }
+    h2 { font-size: 16px; font-weight: 500; }
+  </style>
+</head>
+<body>
+  <h2>Issue #252: chained <code>animate.shift</code> / <code>animate.scale</code> now accumulate</h2>
+  <div id="container"></div>
+  <div class="controls">
+    <button id="playBtn">Play</button>
+    <button id="resetBtn">Reset</button>
+  </div>
+  <pre id="log">Click "Play".</pre>
+
+  <script type="module">
+    import { Scene, Circle, Square } from '../src/index.ts';
+
+    const log = document.getElementById('log');
+    const append = (s) => { log.textContent += '\n' + s; };
+
+    const container = document.getElementById('container');
+    const scene = new Scene(container, {
+      width: 800,
+      height: 450,
+      backgroundColor: '#1a1a2e',
+    });
+
+    document.getElementById('playBtn').addEventListener('click', async () => {
+      scene.clear();
+      log.textContent = 'Repro from https://github.com/maloyan/manim-web/issues/252';
+
+      const circle = new Circle({ radius: 0.6, color: '#e94560', strokeWidth: 4 });
+      circle.shift([-3, 1.2, 0]);
+      const square = new Square({ sideLength: 1, color: '#00d4ff', strokeWidth: 4 });
+      square.shift([-3, -1.2, 0]);
+
+      scene.add(circle);
+      scene.add(square);
+      await scene.wait(0.2);
+
+      append(`circle.getCenter() = ${JSON.stringify(circle.getCenter().map((v) => +v.toFixed(2)))}`);
+      append(`square.getCenter() = ${JSON.stringify(square.getCenter().map((v) => +v.toFixed(2)))}`);
+
+      // Three consecutive animate.shift calls — each should add to the previous.
+      for (let i = 1; i <= 3; i++) {
+        await scene.play(circle.animate.shift([1.5, 0, 0]).withDuration(0.6));
+        await scene.play(square.animate.shift([1.5, 0, 0]).withDuration(0.6));
+        append(
+          `after shift #${i}: circle.x=${circle.getCenter()[0].toFixed(2)}, ` +
+          `square.x=${square.getCenter()[0].toFixed(2)}`,
+        );
+      }
+
+      // And consecutive animate.scale calls accumulate too.
+      await scene.wait(0.3);
+      for (let i = 1; i <= 2; i++) {
+        await scene.play(circle.animate.scale(0.8).withDuration(0.4));
+        append(`after scale #${i}: circle.radius=${circle.getRadius().toFixed(3)}`);
+      }
+    });
+
+    document.getElementById('resetBtn').addEventListener('click', () => {
+      scene.clear();
+      log.textContent = 'Click "Play".';
+    });
+  </script>
+</body>
+</html>

--- a/src/core/AnimateProxy.ts
+++ b/src/core/AnimateProxy.ts
@@ -9,6 +9,7 @@
  */
 
 import { Mobject, type Vector3Tuple, type MobjectStyle, registerAnimateProxy } from './Mobject';
+import { VGroup } from './VGroup';
 import { Animation, type AnimationOptions } from '../animation/Animation';
 import { type RateFunction, smooth } from '../rate-functions';
 import { Transform } from '../animation/transform/Transform';
@@ -21,6 +22,7 @@ export class AnimateProxy extends Animation {
   private _calls: RecordedCall[] = [];
   private _innerTransform: Transform | null = null;
   private _overrideAnimation: Animation | null = null;
+  private _originalState: Mobject | null = null;
 
   constructor(mobject: Mobject, options: AnimationOptions = {}) {
     super(mobject, {
@@ -166,6 +168,9 @@ export class AnimateProxy extends Animation {
       }
     }
 
+    // Snapshot source so finish() can replay calls on it (see finish()).
+    this._originalState = this._source.copy();
+
     // Standard path: copy mobject, apply all recorded calls, use as Transform target
     const target = this._source.copy();
     for (const [methodName, args] of this._calls) {
@@ -203,6 +208,30 @@ export class AnimateProxy extends Animation {
       this._overrideAnimation.finish();
     } else if (this._innerTransform) {
       this._innerTransform.finish();
+      // Transform writes target points/position back to source, but a leaf
+      // VMobject's geometry-specific logical state (e.g. Circle._centerPoint,
+      // _radius) is never synced — chained animate.shift/scale would then
+      // operate on stale state (issue #252). Revert and replay calls so the
+      // source's full state stays self-consistent.
+      //
+      // Skipped for VGroups: state lives in children, which Transform's VGroup
+      // branch already updates in place — replay would double-shift. This
+      // assumes no current VGroup subclass overrides shift/scale to mutate
+      // parent-level numeric state; one that did would need its own re-sync.
+      if (this._originalState && !(this._source instanceof VGroup)) {
+        this._source.become(this._originalState);
+        for (const [methodName, args] of this._calls) {
+          const method = (this._source as unknown as Record<string, (...a: unknown[]) => unknown>)[
+            methodName
+          ];
+          if (typeof method !== 'function') {
+            throw new Error(
+              `AnimateProxy: method "${methodName}" not found on ${this._source.constructor.name}`,
+            );
+          }
+          method.apply(this._source, args);
+        }
+      }
     }
     super.finish();
   }

--- a/src/core/animate-proxy.test.ts
+++ b/src/core/animate-proxy.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Circle } from '../mobjects/geometry/Circle';
+import { Rectangle } from '../mobjects/geometry/Rectangle';
 import { AnimateProxy } from './AnimateProxy';
 import { Animation } from '../animation/Animation';
 import { linear } from '../rate-functions';
@@ -109,6 +110,101 @@ describe('AnimateProxy', () => {
     const startFirstX = startPoints[0]?.[0] ?? 0;
     const endFirstX = endPoints[0]?.[0] ?? 0;
     expect(Math.abs(endFirstX)).toBeGreaterThan(Math.abs(startFirstX) * 1.5);
+  });
+
+  describe('chained animations (issue #252)', () => {
+    it('accumulates consecutive animate.shift on a Circle', () => {
+      const c = new Circle({ radius: 1 });
+      const startCenter = c.getCenter();
+
+      let proxy = c.animate.shift([1, 0, 0]);
+      proxy.begin();
+      proxy.finish();
+      expect(c.getCenter()[0]).toBeCloseTo(startCenter[0] + 1, 2);
+      expect(c.getCircleCenter()[0]).toBeCloseTo(startCenter[0] + 1, 2);
+
+      proxy = c.animate.shift([1, 0, 0]);
+      proxy.begin();
+      proxy.finish();
+      expect(c.getCenter()[0]).toBeCloseTo(startCenter[0] + 2, 2);
+      expect(c.getCircleCenter()[0]).toBeCloseTo(startCenter[0] + 2, 2);
+    });
+
+    it('accumulates consecutive animate.scale on a Circle', () => {
+      const c = new Circle({ radius: 1 });
+
+      let proxy = c.animate.scale(2);
+      proxy.begin();
+      proxy.finish();
+      expect(c.getRadius()).toBeCloseTo(2, 2);
+
+      proxy = c.animate.scale(2);
+      proxy.begin();
+      proxy.finish();
+      expect(c.getRadius()).toBeCloseTo(4, 2);
+    });
+
+    it('keeps logical state in sync with visual state after animate.shift', () => {
+      const c = new Circle({ radius: 1 });
+      const proxy = c.animate.shift([3, 2, 0]);
+      proxy.begin();
+      proxy.finish();
+      // Visual center, logical _centerPoint, and shifted-then-rescaled
+      // points should all agree.
+      const visual = c.getCenter();
+      const logical = c.getCircleCenter();
+      expect(logical[0]).toBeCloseTo(visual[0], 2);
+      expect(logical[1]).toBeCloseTo(visual[1], 2);
+    });
+
+    it('accumulates consecutive animate.shift on a Rectangle', () => {
+      const r = new Rectangle({ width: 2, height: 1 });
+      const startCenter = r.getCenter();
+
+      let proxy = r.animate.shift([1, 0, 0]);
+      proxy.begin();
+      proxy.finish();
+      expect(r.getCenter()[0]).toBeCloseTo(startCenter[0] + 1, 2);
+      expect(r.getWidth()).toBeCloseTo(2, 2);
+
+      proxy = r.animate.shift([1, 0, 0]);
+      proxy.begin();
+      proxy.finish();
+      expect(r.getCenter()[0]).toBeCloseTo(startCenter[0] + 2, 2);
+      expect(r.getWidth()).toBeCloseTo(2, 2);
+    });
+
+    it('accumulates mixed chained calls in a single animation', () => {
+      const c = new Circle({ radius: 1, color: '#ff0000' });
+      const proxy = c.animate.shift([2, 0, 0]).setColor('#00ff00').scale(2);
+      proxy.begin();
+      proxy.finish();
+
+      expect(c.getCenter()[0]).toBeCloseTo(2, 2);
+      expect(c.getCircleCenter()[0]).toBeCloseTo(2, 2);
+      expect(c.getRadius()).toBeCloseTo(2, 2);
+      expect(c.color).toBe('#00ff00');
+    });
+
+    it('accumulates different methods across separate animations', () => {
+      const c = new Circle({ radius: 1 });
+
+      let proxy = c.animate.shift([1, 0, 0]);
+      proxy.begin();
+      proxy.finish();
+
+      proxy = c.animate.scale(2);
+      proxy.begin();
+      proxy.finish();
+
+      proxy = c.animate.shift([1, 0, 0]);
+      proxy.begin();
+      proxy.finish();
+
+      // Started at (0,0,0) r=1 → +x by 1 → scale 2 (about own center) → +x by 1
+      expect(c.getCircleCenter()[0]).toBeCloseTo(2, 2);
+      expect(c.getRadius()).toBeCloseTo(2, 2);
+    });
   });
 
   describe('animation overrides', () => {


### PR DESCRIPTION
## Summary

Fixes #252 — repeated `animate.shift` (and `animate.scale`) on a `Circle` only applied the first call; subsequent ones replayed from the original position.

**Root cause:** `Circle` (and other geometry classes) hold logical state (`_centerPoint`, `_radius`) used by `_createCopy()` and `_generatePoints()`. `Transform.finish()` writes target points / position back to the source, but knows nothing about subclass private fields — so after the first animation, `source.points` is at `(1, 0, 0)` while `source._centerPoint` is still `[0, 0, 0]`. The next `source.copy()` regenerates from the stale `_centerPoint`, and the second animation visually replays from the origin.

**Fix:** In `AnimateProxy`, snapshot the source at `begin()`, and at `finish()` revert via `become(snapshot)` then replay the recorded calls directly on the source. This keeps the source's full state (logical + visual) self-consistent without needing per-class fixes. Skipped for `VGroup` containers, where state lives in children that `Transform`'s VGroup branch already mutates in place.

## Test plan

- [x] New regression tests in `src/core/animate-proxy.test.ts`:
  - chained `animate.shift` on `Circle` (visual + logical state)
  - chained `animate.scale` on `Circle`
  - chained `animate.shift` on `Rectangle` (same bug pattern, now covered)
  - mixed chained calls in one animation (`shift + setColor + scale`)
  - different methods across separate animations (shift, scale, shift)
- [x] Existing chained-shift coverage on `MathTex` (a VGroup) in `src/mobjects/text/mathtex-animation.test.ts` confirms the VGroup-skip guard
- [x] Full vitest suite: **5826 / 5826 passing**
- [x] Browser repro: `examples/animate_shift_chained.html` — three consecutive `shift(1.5)` and two `scale(0.8)` accumulate visibly and numerically