### PR TITLE
fix(three-d-axes): add c2p/p2c aliases (#257)

### DIFF
--- a/examples/3d-scenes/three_d_axes_c2p.html
+++ b/examples/3d-scenes/three_d_axes_c2p.html
@@ -41,9 +41,6 @@
       xRange: [-5, 5, 1],
       yRange: [-5, 5, 1],
       zRange: [-5, 5, 1],
-      xLength: 10,
-      yLength: 10,
-      zLength: 10,
       showLabels: true,
     });
 

--- a/examples/3d-scenes/three_d_axes_c2p.html
+++ b/examples/3d-scenes/three_d_axes_c2p.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ThreeDAxes c2p alias (issue #257)</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { background: #191919; display: flex; justify-content: center; align-items: center; width: 100vw; height: 100vh; overflow: hidden; }
+    #container { width: 100vw; height: 100vh; }
+    .controls-hint { position: fixed; bottom: 20px; left: 20px; color: #888; font-family: monospace; font-size: 14px; pointer-events: none; }
+  </style>
+</head>
+<body>
+  <div id="container"></div>
+  <div class="controls-hint">Drag to orbit, scroll to zoom</div>
+
+  <script type="module">
+    import {
+      ThreeDAxes,
+      Vector3D,
+      Dot3D,
+      ThreeDScene,
+      GREEN,
+      RED,
+      BLUE,
+      YELLOW,
+    } from '../../src/index.ts';
+
+    const scene = new ThreeDScene(document.getElementById('container'), {
+      width: window.innerWidth,
+      height: window.innerHeight,
+      backgroundColor: '#191919',
+      phi: 75 * (Math.PI / 180),
+      theta: -45 * (Math.PI / 180),
+      distance: 20,
+      fov: 30,
+      enableOrbitControls: true,
+    });
+
+    const axes = new ThreeDAxes({
+      xRange: [-5, 5, 1],
+      yRange: [-5, 5, 1],
+      zRange: [-5, 5, 1],
+      xLength: 10,
+      yLength: 10,
+      zLength: 10,
+      showLabels: true,
+    });
+
+    // Reproduction from issue #257: this previously threw
+    // "axes.c2p is not a function".
+    const vec = new Vector3D({ end: axes.c2p(1, 1, 1), color: GREEN });
+
+    // Verify c2p matches coordsToPoint by placing dots at the same logical
+    // coordinate using both APIs. They should overlap exactly.
+    const dotC2p = new Dot3D({ point: axes.c2p(2, 1, 3), color: RED, radius: 0.15 });
+    const dotCoords = new Dot3D({ point: axes.coordsToPoint(2, 1, 3), color: BLUE, radius: 0.1 });
+
+    // Demonstrate p2c round-trip: take a scene-space point, convert to graph
+    // coords with p2c, then back with c2p. Should land in the same place.
+    const roundTrip = axes.c2p(...axes.p2c([-2, -1, 2]));
+    const dotRoundTrip = new Dot3D({ point: roundTrip, color: YELLOW, radius: 0.15 });
+
+    scene.add(axes, vec, dotC2p, dotCoords, dotRoundTrip);
+
+    await scene.wait(Infinity);
+  </script>
+</body>
+</html>

--- a/src/mobjects/three-d/ThreeDAxes.test.ts
+++ b/src/mobjects/three-d/ThreeDAxes.test.ts
@@ -338,3 +338,49 @@ describe('ThreeDAxes coordsToPoint aligns with scene coordinates (issue #256)', 
     expect(zEnd).toEqual([0, 0, 5]);
   });
 });
+
+describe('ThreeDAxes c2p / p2c aliases (issue #257)', () => {
+  it('c2p exists as a function', () => {
+    const axes = new ThreeDAxes();
+    expect(typeof axes.c2p).toBe('function');
+  });
+
+  it('p2c exists as a function', () => {
+    const axes = new ThreeDAxes();
+    expect(typeof axes.p2c).toBe('function');
+  });
+
+  it('c2p produces the same result as coordsToPoint', () => {
+    const axes = new ThreeDAxes();
+    const cases: Array<[number, number, number]> = [
+      [0, 0, 0],
+      [1, 1, 1],
+      [3, -2, 4],
+      [-5, 5, 0],
+    ];
+    for (const [x, y, z] of cases) {
+      expect(axes.c2p(x, y, z)).toEqual(axes.coordsToPoint(x, y, z));
+    }
+  });
+
+  it('p2c produces the same result as pointToCoords', () => {
+    const axes = new ThreeDAxes();
+    const cases: Array<[number, number, number]> = [
+      [0, 0, 0],
+      [1, 2, 3],
+      [-4, 5, -6],
+    ];
+    for (const point of cases) {
+      expect(axes.p2c(point)).toEqual(axes.pointToCoords(point));
+    }
+  });
+
+  it('p2c is the inverse of c2p', () => {
+    const axes = new ThreeDAxes();
+    const original: [number, number, number] = [1, 1, 1];
+    const back = axes.p2c(axes.c2p(...original));
+    expect(back[0]).toBeCloseTo(original[0]);
+    expect(back[1]).toBeCloseTo(original[1]);
+    expect(back[2]).toBeCloseTo(original[2]);
+  });
+});

--- a/src/mobjects/three-d/ThreeDAxes.ts
+++ b/src/mobjects/three-d/ThreeDAxes.ts
@@ -375,6 +375,13 @@ export class ThreeDAxes extends Group {
   }
 
   /**
+   * Alias for coordsToPoint (matches Python Manim's c2p shorthand)
+   */
+  c2p(x: number, y: number, z: number): Vector3Tuple {
+    return this.coordsToPoint(x, y, z);
+  }
+
+  /**
    * Convert visual point coordinates (scene space) to graph coordinates.
    */
   pointToCoords(point: Vector3Tuple): Vector3Tuple {
@@ -382,6 +389,13 @@ export class ThreeDAxes extends Group {
     const ty = point[1] - this.position.y;
     const tz = point[2] - this.position.z;
     return [tx, ty, tz];
+  }
+
+  /**
+   * Alias for pointToCoords (matches Python Manim's p2c shorthand)
+   */
+  p2c(point: Vector3Tuple): Vector3Tuple {
+    return this.pointToCoords(point);
   }
 
   /**


### PR DESCRIPTION
## Summary
Closes #257.

`ThreeDAxes` exposed `coordsToPoint(x, y, z)` / `pointToCoords(point)` but no `c2p` / `p2c` shorthand, so the example from the issue threw `TypeError: axes.c2p is not a function`. The 2D `Axes` class already defines `c2p` as a one-line alias — the same pattern is now mirrored on `ThreeDAxes`, plus a matching `p2c` for symmetry with Python Manim.

- `ThreeDAxes.c2p(x, y, z)` → `coordsToPoint(x, y, z)`
- `ThreeDAxes.p2c(point)` → `pointToCoords(point)`

`NumberPlane` and `ComplexPlane` were unaffected — they extend 2D `Axes` and inherit `c2p` correctly.

## Test plan
- [x] New unit tests in `ThreeDAxes.test.ts` assert `c2p === coordsToPoint` and `p2c === pointToCoords` over several inputs and that `p2c ∘ c2p` is identity.
- [x] Full `ThreeDAxes` test file passes (31 tests).
- [x] Reproduction example added at `examples/3d-scenes/three_d_axes_c2p.html` mirroring the snippet in the issue (Vector3D from origin to `axes.c2p(1, 1, 1)` plus dots demonstrating `c2p`/`p2c` parity). Verified loading in the browser produces the green vector to (1,1,1) and round-trip dots overlap as expected.
- [x] Pre-existing test failures on main (mathjax import resolution from #300) are unchanged by this PR.