### PR TITLE
fix(draggable): stop Z sliding when X/Y constraint clamps in 3D (#260)

### DIFF
--- a/examples/3d-scenes/draggable_constraints_3d.html
+++ b/examples/3d-scenes/draggable_constraints_3d.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Draggable constraints in 3D (issue #260)</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #191919;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+      color: #eee;
+      padding: 20px;
+      gap: 12px;
+    }
+    h1 { font-size: 18px; font-weight: 500; }
+    p { font-size: 13px; color: #aaa; max-width: 720px; text-align: center; }
+    #container { width: 720px; height: 540px; border: 1px solid #333; border-radius: 4px; }
+    .pos { font-family: ui-monospace, monospace; font-size: 13px; color: #8ec07c; }
+  </style>
+</head>
+<body>
+  <h1>Draggable Dot3D with constrainX / constrainY = [-3, 3] (issue #260)</h1>
+  <p>
+    Drag the dot. Try moving it past the [-3, 3] box: it must stop at the
+    boundary, not slide along the camera-facing plane in Z.
+  </p>
+  <div class="pos" id="pos">position: (1.000, 1.000, 1.000)</div>
+  <div id="container"></div>
+
+  <script type="module" src="./draggable_constraints_3d.ts"></script>
+</body>
+</html>

--- a/examples/3d-scenes/draggable_constraints_3d.ts
+++ b/examples/3d-scenes/draggable_constraints_3d.ts
@@ -1,0 +1,38 @@
+import { Dot3D, ThreeDAxes, ThreeDScene, makeDraggable } from '../../src/index';
+
+const container = document.getElementById('container') as HTMLElement;
+const posLabel = document.getElementById('pos') as HTMLElement;
+
+const scene = new ThreeDScene(container, {
+  width: 720,
+  height: 540,
+  backgroundColor: '#191919',
+  phi: 75 * (Math.PI / 180),
+  theta: -45 * (Math.PI / 180),
+  distance: 20,
+  fov: 30,
+  enableOrbitControls: true,
+});
+
+const axes = new ThreeDAxes({
+  xRange: [-5, 5, 1],
+  yRange: [-5, 5, 1],
+  zRange: [-5, 5, 1],
+  xLength: 10,
+  yLength: 10,
+  zLength: 10,
+  showLabels: true,
+});
+
+const dot = new Dot3D({ radius: 0.15, color: '#fb4934' }).moveTo(axes.coordsToPoint(1, 1, 1));
+
+makeDraggable(dot, scene, {
+  constrainX: [-3, 3],
+  constrainY: [-3, 3],
+  onDrag: (_m, pos) => {
+    posLabel.textContent = `position: (${pos[0].toFixed(3)}, ${pos[1].toFixed(3)}, ${pos[2].toFixed(3)})`;
+  },
+});
+
+scene.add(axes, dot);
+scene.wait(Infinity);

--- a/src/interaction/Draggable.ts
+++ b/src/interaction/Draggable.ts
@@ -219,13 +219,25 @@ export class Draggable {
 
     let newX = worldPos[0];
     let newY = worldPos[1];
+    let xClamped = false;
+    let yClamped = false;
 
     // Apply constraints
     if (this._options.constrainX) {
-      newX = Math.max(this._options.constrainX[0], Math.min(this._options.constrainX[1], newX));
+      const clamped = Math.max(
+        this._options.constrainX[0],
+        Math.min(this._options.constrainX[1], newX),
+      );
+      xClamped = clamped !== newX;
+      newX = clamped;
     }
     if (this._options.constrainY) {
-      newY = Math.max(this._options.constrainY[0], Math.min(this._options.constrainY[1], newY));
+      const clamped = Math.max(
+        this._options.constrainY[0],
+        Math.min(this._options.constrainY[1], newY),
+      );
+      yClamped = clamped !== newY;
+      newY = clamped;
     }
 
     // Apply snap to grid
@@ -235,7 +247,16 @@ export class Draggable {
       newY = Math.round(newY / grid) * grid;
     }
 
-    const newZ = this._scene instanceof ThreeDScene ? worldPos[2] : this._mobject.position.z;
+    // In 3D, the drag plane is perpendicular to the camera, so cursor motion
+    // produces deltas in all three world axes. When X or Y is clamped by a
+    // constraint, the unclamped Z would otherwise let the object slide along
+    // the constraint boundary. Freeze Z to the last position in that case.
+    let newZ: number;
+    if (this._scene instanceof ThreeDScene) {
+      newZ = xClamped || yClamped ? this._lastPosition[2] : worldPos[2];
+    } else {
+      newZ = this._mobject.position.z;
+    }
     const newPos: Vector3Tuple = [newX, newY, newZ];
     const delta: Vector3Tuple = [
       newPos[0] - this._lastPosition[0],

--- a/src/interaction/interaction.test.ts
+++ b/src/interaction/interaction.test.ts
@@ -1143,6 +1143,117 @@ describe('Draggable in 3D scene', () => {
     scene._canvas.remove();
   });
 
+  it('does not slide along Z when X constraint is hit (issue #260)', () => {
+    const scene = createMock3DScene();
+
+    // Tilt camera so the drag plane is NOT axis-aligned. With this camera,
+    // moving the cursor in screen-space produces deltas in X, Y, and Z.
+    const cam = scene.camera3D.getCamera() as THREE.PerspectiveCamera;
+    cam.position.set(10, 10, 10);
+    cam.lookAt(0, 0, 0);
+    cam.updateMatrixWorld();
+
+    const mob = createMockMobject({ center: [1, 1, 1], bounds: { width: 0.5, height: 0.5 } });
+    const draggable = new Draggable(mob as any, scene as any, {
+      constrainX: [-5, 5],
+      constrainY: [-5, 5],
+    });
+
+    const canvas = scene.getCanvas();
+
+    // Project object center to screen
+    const objVec = new THREE.Vector3(1, 1, 1).project(cam);
+    const startX = ((objVec.x + 1) / 2) * 800;
+    const startY = ((-objVec.y + 1) / 2) * 600;
+
+    fireMouseEvent(canvas, 'mousedown', { clientX: startX, clientY: startY });
+    expect(draggable.isDragging).toBe(true);
+
+    // Drag far enough that X constraint must clamp
+    fireMouseEvent(window as any, 'mousemove', { clientX: startX + 400, clientY: startY });
+
+    const calls = mob.moveTo.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const firstPos = calls[0][0];
+
+    // X must be clamped within the constraint
+    expect(firstPos[0]).toBeLessThanOrEqual(5);
+    expect(firstPos[0]).toBeGreaterThanOrEqual(-5);
+    // Z must NOT have slid away from the starting Z (the bug was Z drifting
+    // along the constraint boundary). When clamped, Z stays at last position.
+    expect(firstPos[2]).toBeCloseTo(1, 5);
+
+    draggable.dispose();
+    scene._canvas.remove();
+  });
+
+  it('does not slide along Z when Y constraint is hit (issue #260)', () => {
+    const scene = createMock3DScene();
+    const cam = scene.camera3D.getCamera() as THREE.PerspectiveCamera;
+    cam.position.set(10, 10, 10);
+    cam.lookAt(0, 0, 0);
+    cam.updateMatrixWorld();
+
+    const mob = createMockMobject({ center: [1, 1, 1], bounds: { width: 0.5, height: 0.5 } });
+    const draggable = new Draggable(mob as any, scene as any, {
+      constrainY: [-5, 5],
+    });
+
+    const canvas = scene.getCanvas();
+    const objVec = new THREE.Vector3(1, 1, 1).project(cam);
+    const startX = ((objVec.x + 1) / 2) * 800;
+    const startY = ((-objVec.y + 1) / 2) * 600;
+
+    fireMouseEvent(canvas, 'mousedown', { clientX: startX, clientY: startY });
+
+    // Drag upward enough that Y constraint must clamp
+    fireMouseEvent(window as any, 'mousemove', { clientX: startX, clientY: startY - 400 });
+
+    const calls = mob.moveTo.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const firstPos = calls[0][0];
+
+    expect(firstPos[1]).toBeLessThanOrEqual(5);
+    expect(firstPos[1]).toBeGreaterThanOrEqual(-5);
+    // Z must remain at starting Z, no sliding
+    expect(firstPos[2]).toBeCloseTo(1, 5);
+
+    draggable.dispose();
+    scene._canvas.remove();
+  });
+
+  it('still allows free Z motion when no constraint is hit', () => {
+    const scene = createMock3DScene();
+    const cam = scene.camera3D.getCamera() as THREE.PerspectiveCamera;
+    cam.position.set(10, 10, 10);
+    cam.lookAt(0, 0, 0);
+    cam.updateMatrixWorld();
+
+    const mob = createMockMobject({ center: [0, 0, 0], bounds: { width: 0.5, height: 0.5 } });
+    const draggable = new Draggable(mob as any, scene as any, {
+      constrainX: [-5, 5],
+      constrainY: [-5, 5],
+    });
+
+    const canvas = scene.getCanvas();
+    const objVec = new THREE.Vector3(0, 0, 0).project(cam);
+    const startX = ((objVec.x + 1) / 2) * 800;
+    const startY = ((-objVec.y + 1) / 2) * 600;
+
+    fireMouseEvent(canvas, 'mousedown', { clientX: startX, clientY: startY });
+
+    // Small drag well within constraints
+    fireMouseEvent(window as any, 'mousemove', { clientX: startX + 20, clientY: startY - 10 });
+
+    const calls = mob.moveTo.mock.calls;
+    const pos = calls[calls.length - 1][0];
+    // Z should have moved (constraint did not engage)
+    expect(pos[2]).not.toBe(0);
+
+    draggable.dispose();
+    scene._canvas.remove();
+  });
+
   it('hit-tests using 3D distance instead of 2D bounding box', () => {
     const scene = createMock3DScene();
     // Place object at origin


### PR DESCRIPTION
## Summary
- In 3D scenes, the drag plane is perpendicular to the camera, so cursor motion produces deltas in **all three** world axes — not just X and Y.
- `_updateDrag` clamped X / Y per `constrainX` / `constrainY` but copied Z straight from the raycast intersection. When the user dragged past a bound, Z kept changing → object **slid along the constraint plane**.
- Fix: track whether the X or Y clamp actually engaged. If it did, freeze Z to `_lastPosition[2]` so blocked drag motion does not leak into Z.
- 2D behavior is untouched (Z was never read from `worldPos` in 2D).

Closes #260

## Test plan
- [x] `npx vitest run src/interaction/interaction.test.ts` — 91 pass (3 new 3D-constraint tests for issue #260)
- [x] Full suite `npx vitest run` — 5844 pass
- [x] `npm run build` clean
- [x] New example `examples/3d-scenes/draggable_constraints_3d.html` reproduces the original repro from #260; dot now stops at the constrained boundary instead of sliding in Z