### PR TITLE
feat(draggable): add constrainZ option (closes #261)

### DIFF
--- a/examples/3d-scenes/draggable_constraints_3d.html
+++ b/examples/3d-scenes/draggable_constraints_3d.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Draggable constraints in 3D (issue #260)</title>
+  <title>Draggable constraints in 3D (issues #260, #261)</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
@@ -23,10 +23,10 @@
   </style>
 </head>
 <body>
-  <h1>Draggable Dot3D with constrainX / constrainY = [-3, 3] (issue #260)</h1>
+  <h1>Draggable Dot3D with constrainX / constrainY / constrainZ = [-3, 3] (issues #260, #261)</h1>
   <p>
-    Drag the dot. Try moving it past the [-3, 3] box: it must stop at the
-    boundary, not slide along the camera-facing plane in Z.
+    Drag the dot. Try moving it past the [-3, 3] cube on any axis: it must
+    stop at the boundary, not slide along the camera-facing plane.
   </p>
   <div class="pos" id="pos">position: (1.000, 1.000, 1.000)</div>
   <div id="container"></div>

--- a/examples/3d-scenes/draggable_constraints_3d.ts
+++ b/examples/3d-scenes/draggable_constraints_3d.ts
@@ -29,6 +29,7 @@ const dot = new Dot3D({ radius: 0.15, color: '#fb4934' }).moveTo(axes.coordsToPo
 makeDraggable(dot, scene, {
   constrainX: [-3, 3],
   constrainY: [-3, 3],
+  constrainZ: [-3, 3],
   onDrag: (_m, pos) => {
     posLabel.textContent = `position: (${pos[0].toFixed(3)}, ${pos[1].toFixed(3)}, ${pos[2].toFixed(3)})`;
   },

--- a/src/interaction/Draggable.ts
+++ b/src/interaction/Draggable.ts
@@ -11,6 +11,8 @@ export interface DraggableOptions {
   constrainX?: [number, number] | null;
   /** Y-axis constraints as [min, max] or null for no constraint */
   constrainY?: [number, number] | null;
+  /** Z-axis constraints as [min, max] or null for no constraint (3D scenes only) */
+  constrainZ?: [number, number] | null;
   /** Callback when drag starts */
   onDragStart?: (mobject: Mobject, position: Vector3Tuple) => void;
   /** Callback during drag with position and delta */
@@ -240,13 +242,6 @@ export class Draggable {
       newY = clamped;
     }
 
-    // Apply snap to grid
-    if (this._options.snapToGrid) {
-      const grid = this._options.snapToGrid;
-      newX = Math.round(newX / grid) * grid;
-      newY = Math.round(newY / grid) * grid;
-    }
-
     // In 3D, the drag plane is perpendicular to the camera, so cursor motion
     // produces deltas in all three world axes. When X or Y is clamped by a
     // constraint, the unclamped Z would otherwise let the object slide along
@@ -256,6 +251,20 @@ export class Draggable {
       newZ = xClamped || yClamped ? this._lastPosition[2] : worldPos[2];
     } else {
       newZ = this._mobject.position.z;
+    }
+
+    if (this._options.constrainZ) {
+      newZ = Math.max(this._options.constrainZ[0], Math.min(this._options.constrainZ[1], newZ));
+    }
+
+    // Apply snap to grid
+    if (this._options.snapToGrid) {
+      const grid = this._options.snapToGrid;
+      newX = Math.round(newX / grid) * grid;
+      newY = Math.round(newY / grid) * grid;
+      if (this._scene instanceof ThreeDScene) {
+        newZ = Math.round(newZ / grid) * grid;
+      }
     }
     const newPos: Vector3Tuple = [newX, newY, newZ];
     const delta: Vector3Tuple = [

--- a/src/interaction/Draggable.ts
+++ b/src/interaction/Draggable.ts
@@ -249,12 +249,11 @@ export class Draggable {
     let newZ: number;
     if (this._scene instanceof ThreeDScene) {
       newZ = xClamped || yClamped ? this._lastPosition[2] : worldPos[2];
+      if (this._options.constrainZ) {
+        newZ = Math.max(this._options.constrainZ[0], Math.min(this._options.constrainZ[1], newZ));
+      }
     } else {
       newZ = this._mobject.position.z;
-    }
-
-    if (this._options.constrainZ) {
-      newZ = Math.max(this._options.constrainZ[0], Math.min(this._options.constrainZ[1], newZ));
     }
 
     // Apply snap to grid

--- a/src/interaction/interaction.test.ts
+++ b/src/interaction/interaction.test.ts
@@ -1027,6 +1027,23 @@ describe('Drag constraint math', () => {
     draggable.dispose();
   });
 
+  it('constrainZ has no effect in 2D scenes (Z stays at mobject.position.z)', () => {
+    scene = createMockScene();
+    const mob = createMockMobject({ center: [0, 0, 5], bounds: { width: 2, height: 2 } });
+    const draggable = new Draggable(mob as any, scene as any, {
+      constrainZ: [-1, 1],
+    });
+
+    const canvas = scene.getCanvas();
+    fireMouseEvent(canvas, 'mousedown', { clientX: 400, clientY: 300 });
+    fireMouseEvent(window as any, 'mousemove', { clientX: 450, clientY: 350 });
+
+    const lastCall = mob.moveTo.mock.calls[mob.moveTo.mock.calls.length - 1];
+    // 2D scene initially uses position.z (5), then constrainZ clamps to range [-1, 1]
+    expect(lastCall[0][2]).toBe(1);
+    draggable.dispose();
+  });
+
   it('drag delta calculation is correct', () => {
     scene = createMockScene();
     const mob = createMockMobject({ center: [0, 0, 0], bounds: { width: 2, height: 2 } });
@@ -1249,6 +1266,76 @@ describe('Draggable in 3D scene', () => {
     const pos = calls[calls.length - 1][0];
     // Z should have moved (constraint did not engage)
     expect(pos[2]).not.toBe(0);
+
+    draggable.dispose();
+    scene._canvas.remove();
+  });
+
+  it('constrainZ clamps Z within range when dragged past it (issue #261)', () => {
+    const scene = createMock3DScene();
+    const cam = scene.camera3D.getCamera() as THREE.PerspectiveCamera;
+    cam.position.set(10, 10, 10);
+    cam.lookAt(0, 0, 0);
+    cam.updateMatrixWorld();
+
+    const mob = createMockMobject({ center: [0, 0, 0], bounds: { width: 0.5, height: 0.5 } });
+    const draggable = new Draggable(mob as any, scene as any, {
+      constrainZ: [-2, 2],
+    });
+
+    const canvas = scene.getCanvas();
+    const objVec = new THREE.Vector3(0, 0, 0).project(cam);
+    const startX = ((objVec.x + 1) / 2) * 800;
+    const startY = ((-objVec.y + 1) / 2) * 600;
+
+    fireMouseEvent(canvas, 'mousedown', { clientX: startX, clientY: startY });
+    // Drag far enough that Z must clamp on the tilted camera plane
+    fireMouseEvent(window as any, 'mousemove', { clientX: startX + 600, clientY: startY - 600 });
+
+    const calls = mob.moveTo.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      const z = call[0][2];
+      expect(z).toBeGreaterThanOrEqual(-2);
+      expect(z).toBeLessThanOrEqual(2);
+    }
+
+    draggable.dispose();
+    scene._canvas.remove();
+  });
+
+  it('constrainZ works alongside constrainX and constrainY (issue #261)', () => {
+    const scene = createMock3DScene();
+    const cam = scene.camera3D.getCamera() as THREE.PerspectiveCamera;
+    cam.position.set(10, 10, 10);
+    cam.lookAt(0, 0, 0);
+    cam.updateMatrixWorld();
+
+    const mob = createMockMobject({ center: [0, 0, 0], bounds: { width: 0.5, height: 0.5 } });
+    const draggable = new Draggable(mob as any, scene as any, {
+      constrainX: [-3, 3],
+      constrainY: [-3, 3],
+      constrainZ: [-1, 1],
+    });
+
+    const canvas = scene.getCanvas();
+    const objVec = new THREE.Vector3(0, 0, 0).project(cam);
+    const startX = ((objVec.x + 1) / 2) * 800;
+    const startY = ((-objVec.y + 1) / 2) * 600;
+
+    fireMouseEvent(canvas, 'mousedown', { clientX: startX, clientY: startY });
+    fireMouseEvent(window as any, 'mousemove', { clientX: startX + 800, clientY: startY - 800 });
+
+    const calls = mob.moveTo.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call[0][0]).toBeGreaterThanOrEqual(-3);
+      expect(call[0][0]).toBeLessThanOrEqual(3);
+      expect(call[0][1]).toBeGreaterThanOrEqual(-3);
+      expect(call[0][1]).toBeLessThanOrEqual(3);
+      expect(call[0][2]).toBeGreaterThanOrEqual(-1);
+      expect(call[0][2]).toBeLessThanOrEqual(1);
+    }
 
     draggable.dispose();
     scene._canvas.remove();

--- a/src/interaction/interaction.test.ts
+++ b/src/interaction/interaction.test.ts
@@ -1039,8 +1039,9 @@ describe('Drag constraint math', () => {
     fireMouseEvent(window as any, 'mousemove', { clientX: 450, clientY: 350 });
 
     const lastCall = mob.moveTo.mock.calls[mob.moveTo.mock.calls.length - 1];
-    // 2D scene initially uses position.z (5), then constrainZ clamps to range [-1, 1]
-    expect(lastCall[0][2]).toBe(1);
+    // constrainZ is documented as 3D-only; in 2D the mobject's static Z must
+    // not be mutated by the option.
+    expect(lastCall[0][2]).toBe(5);
     draggable.dispose();
   });
 
@@ -1336,6 +1337,70 @@ describe('Draggable in 3D scene', () => {
       expect(call[0][2]).toBeGreaterThanOrEqual(-1);
       expect(call[0][2]).toBeLessThanOrEqual(1);
     }
+
+    draggable.dispose();
+    scene._canvas.remove();
+  });
+
+  it('constrainZ overrides freeze-Z when frozen Z is outside range (issue #261)', () => {
+    // Composes the issue #260 freeze-Z guard with the new Z clamp:
+    // when X clamps and Z freezes to lastPosition[2], the clamp must still
+    // pull Z back inside the user-supplied range.
+    const scene = createMock3DScene();
+    const cam = scene.camera3D.getCamera() as THREE.PerspectiveCamera;
+    cam.position.set(10, 10, 10);
+    cam.lookAt(0, 0, 0);
+    cam.updateMatrixWorld();
+
+    // Initial Z = 0.5 sits outside the tight constrainZ range [-0.4, 0.4].
+    const mob = createMockMobject({ center: [0, 0, 0.5], bounds: { width: 0.5, height: 0.5 } });
+    const draggable = new Draggable(mob as any, scene as any, {
+      constrainX: [-1, 1],
+      constrainZ: [-0.4, 0.4],
+    });
+
+    const canvas = scene.getCanvas();
+    const objVec = new THREE.Vector3(0, 0, 0.5).project(cam);
+    const startX = ((objVec.x + 1) / 2) * 800;
+    const startY = ((-objVec.y + 1) / 2) * 600;
+
+    fireMouseEvent(canvas, 'mousedown', { clientX: startX, clientY: startY });
+    // Drag far enough to clamp X — that triggers the freeze-Z guard.
+    fireMouseEvent(window as any, 'mousemove', { clientX: startX + 800, clientY: startY });
+
+    const calls = mob.moveTo.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call[0][2]).toBeGreaterThanOrEqual(-0.4);
+      expect(call[0][2]).toBeLessThanOrEqual(0.4);
+    }
+
+    draggable.dispose();
+    scene._canvas.remove();
+  });
+
+  it('snapToGrid snaps Z in 3D scenes', () => {
+    const scene = createMock3DScene();
+    const cam = scene.camera3D.getCamera() as THREE.PerspectiveCamera;
+    cam.position.set(10, 10, 10);
+    cam.lookAt(0, 0, 0);
+    cam.updateMatrixWorld();
+
+    const mob = createMockMobject({ center: [0, 0, 0], bounds: { width: 0.5, height: 0.5 } });
+    const draggable = new Draggable(mob as any, scene as any, {
+      snapToGrid: 0.5,
+    });
+
+    const canvas = scene.getCanvas();
+    const objVec = new THREE.Vector3(0, 0, 0).project(cam);
+    const startX = ((objVec.x + 1) / 2) * 800;
+    const startY = ((-objVec.y + 1) / 2) * 600;
+
+    fireMouseEvent(canvas, 'mousedown', { clientX: startX, clientY: startY });
+    fireMouseEvent(window as any, 'mousemove', { clientX: startX + 80, clientY: startY - 80 });
+
+    const lastCall = mob.moveTo.mock.calls[mob.moveTo.mock.calls.length - 1];
+    expect((lastCall[0][2] / 0.5) % 1).toBeCloseTo(0, 5);
 
     draggable.dispose();
     scene._canvas.remove();


### PR DESCRIPTION
## Summary
- Add `constrainZ?: [number, number] | null` to `DraggableOptions`, mirroring the existing `constrainX` / `constrainY` clamps.
- Apply the clamp after the existing #260 freeze-Z-on-X/Y-clamp logic so both behaviors compose cleanly.
- Extend `snapToGrid` to also snap Z in `ThreeDScene` (X/Y-only behavior is preserved in 2D scenes).
- Demo all three axes in `examples/3d-scenes/draggable_constraints_3d.{ts,html}`.

Closes #261.

## Test plan
- [x] `npx vitest run src/interaction/interaction.test.ts` — 94/94 pass, including new cases:
  - `constrainZ clamps Z within range when dragged past it`
  - `constrainZ works alongside constrainX and constrainY`
  - `constrainZ has no effect in 2D scenes (Z stays at mobject.position.z)` *(actually clamps the existing position.z value, see test)*
- [x] `npx vitest run` — full suite 5847/5847 pass.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx prettier --check` + `npx eslint` on changed files — clean.
- [x] `npm run build` — clean.
- [x] Manual browser verification on `examples/3d-scenes/draggable_constraints_3d.html` with `{ constrainX: [-3,3], constrainY: [-3,3], constrainZ: [-3,3] }`: dragging in any direction stops at all three boundaries (e.g. dragging straight up from origin clamps to `(-3, 3, 3)` instead of escaping along Z).