### PR TITLE
fix(transform): ReplacementTransform now replaces in scene (#308)

### DIFF
--- a/examples/replacement_transform.html
+++ b/examples/replacement_transform.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script>if (new URLSearchParams(location.search).has('embed')) document.documentElement.classList.add('embed')</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ManimWeb - ReplacementTransform vs Transform</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #1a1a2e;
+      color: #eaeaea;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+      gap: 16px;
+      padding: 24px;
+    }
+    #container {
+      border: 2px solid #333;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .controls { display: flex; gap: 10px; }
+    button {
+      padding: 10px 20px;
+      background: #e94560;
+      border: none;
+      border-radius: 4px;
+      color: white;
+      cursor: pointer;
+      font-size: 14px;
+    }
+    button:hover { background: #ff6b6b; }
+    button:disabled { background: #666; cursor: not-allowed; }
+    #status {
+      font-size: 13px;
+      font-family: ui-monospace, monospace;
+      max-width: 800px;
+      white-space: pre-wrap;
+    }
+    html.embed, html.embed body { margin:0!important;padding:0!important;overflow:hidden;background:#000!important;width:100%;height:100%; }
+    html.embed body { display:flex;justify-content:center;align-items:center; }
+    html.embed .controls, html.embed h1, html.embed #status { display:none!important; }
+    html.embed #container { border:none!important;border-radius:0!important;width:100vw;height:100vh;display:flex;justify-content:center;align-items:center; }
+  </style>
+</head>
+<body>
+  <h1>ReplacementTransform vs Transform (issue #308)</h1>
+  <div id="container"></div>
+  <div class="controls">
+    <button id="playBtn">Play</button>
+    <button id="resetBtn">Reset</button>
+  </div>
+  <pre id="status">Press Play. After each animation the scene's mobject set is logged.</pre>
+  <script type="module" src="./replacement_transform.ts"></script>
+</body>
+</html>

--- a/examples/replacement_transform.ts
+++ b/examples/replacement_transform.ts
@@ -37,24 +37,38 @@ document.getElementById('playBtn')!.addEventListener('click', async () => {
   scene.clear();
 
   // Plain Transform: morphs visuals but the SOURCE stays in the scene.
-  const a = new Circle({ radius: 1, color: RED }).shift([-2.5, 0, 0]);
-  const aTarget = new Square({ sideLength: 1.5, color: GREEN }).shift([-2.5, 0, 0]);
+  const a = new Circle({ radius: 1.4, color: RED, fillOpacity: 0.9, strokeWidth: 6 }).shift([
+    -3, 0, 0,
+  ]);
+  const aTarget = new Square({
+    sideLength: 2.2,
+    color: GREEN,
+    fillOpacity: 0.9,
+    strokeWidth: 6,
+  }).shift([-3, 0, 0]);
   scene.add(a);
   describe('before Transform');
-  await scene.play(new Transform(a, aTarget));
+  await scene.play(new Transform(a, aTarget, { duration: 1.2 }));
   describe('after  Transform     ');
 
-  await scene.wait(0.4);
+  await scene.wait(0.6);
 
   // ReplacementTransform: source removed, target added (issue #308 fix).
-  const b = new Circle({ radius: 1, color: BLUE }).shift([2.5, 0, 0]);
-  const bTarget = new Square({ sideLength: 1.5, color: YELLOW }).shift([2.5, 0, 0]);
+  const b = new Circle({ radius: 1.4, color: BLUE, fillOpacity: 0.9, strokeWidth: 6 }).shift([
+    3, 0, 0,
+  ]);
+  const bTarget = new Square({
+    sideLength: 2.2,
+    color: YELLOW,
+    fillOpacity: 0.9,
+    strokeWidth: 6,
+  }).shift([3, 0, 0]);
   scene.add(b);
   describe('before ReplacementTx');
-  await scene.play(new ReplacementTransform(b, bTarget));
+  await scene.play(new ReplacementTransform(b, bTarget, { duration: 1.2 }));
   describe('after  ReplacementTx');
 
-  await scene.wait(0.6);
+  await scene.wait(0.8);
 
   busy = false;
   (document.getElementById('playBtn') as HTMLButtonElement).disabled = false;

--- a/examples/replacement_transform.ts
+++ b/examples/replacement_transform.ts
@@ -1,0 +1,70 @@
+import {
+  Scene,
+  Circle,
+  Square,
+  Transform,
+  ReplacementTransform,
+  BLACK,
+  RED,
+  BLUE,
+  GREEN,
+  YELLOW,
+} from '../src/index.ts';
+
+const container = document.getElementById('container') as HTMLElement;
+const status = document.getElementById('status') as HTMLPreElement;
+const scene = new Scene(container, { width: 800, height: 450, backgroundColor: BLACK });
+
+let busy = false;
+
+function log(msg: string) {
+  status.textContent = `${msg}\n${status.textContent}`.slice(0, 4000);
+}
+
+function describe(label: string) {
+  const names: string[] = [];
+  for (const m of scene.mobjects) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    names.push((m as any).constructor.name);
+  }
+  log(`${label}: scene has ${names.length} mobjects -> [${names.join(', ')}]`);
+}
+
+document.getElementById('playBtn')!.addEventListener('click', async () => {
+  if (busy) return;
+  busy = true;
+  (document.getElementById('playBtn') as HTMLButtonElement).disabled = true;
+  scene.clear();
+
+  // Plain Transform: morphs visuals but the SOURCE stays in the scene.
+  const a = new Circle({ radius: 1, color: RED }).shift([-2.5, 0, 0]);
+  const aTarget = new Square({ sideLength: 1.5, color: GREEN }).shift([-2.5, 0, 0]);
+  scene.add(a);
+  describe('before Transform');
+  await scene.play(new Transform(a, aTarget));
+  describe('after  Transform     ');
+
+  await scene.wait(0.4);
+
+  // ReplacementTransform: source removed, target added (issue #308 fix).
+  const b = new Circle({ radius: 1, color: BLUE }).shift([2.5, 0, 0]);
+  const bTarget = new Square({ sideLength: 1.5, color: YELLOW }).shift([2.5, 0, 0]);
+  scene.add(b);
+  describe('before ReplacementTx');
+  await scene.play(new ReplacementTransform(b, bTarget));
+  describe('after  ReplacementTx');
+
+  await scene.wait(0.6);
+
+  busy = false;
+  (document.getElementById('playBtn') as HTMLButtonElement).disabled = false;
+});
+
+document.getElementById('resetBtn')!.addEventListener('click', () => {
+  scene.clear();
+  status.textContent = 'cleared.';
+});
+
+if (new URLSearchParams(window.location.search).has('embed')) {
+  setTimeout(() => (document.getElementById('playBtn') as HTMLButtonElement).click(), 400);
+}

--- a/src/animation/Animation.ts
+++ b/src/animation/Animation.ts
@@ -18,6 +18,15 @@ export interface AnimationOptions {
   shift?: [number, number, number];
 }
 
+/**
+ * Minimal scene surface needed by Animation.cleanUpFromScene().
+ * Declared here (not imported from core/Scene) to avoid a core→animation cycle.
+ */
+export interface AnimationScene {
+  add(...mobjects: Mobject[]): void;
+  remove(...mobjects: Mobject[]): void;
+}
+
 export abstract class Animation {
   /** The mobject being animated */
   readonly mobject: Mobject;
@@ -106,6 +115,18 @@ export abstract class Animation {
    */
   finish(): void {
     this._isFinished = true;
+  }
+
+  /**
+   * Hook called by Scene after the animation finishes, before the next play().
+   * Default: removes `mobject` if `remover` is set (FadeOut, Write({remover:true})).
+   * Override for animations that need to mutate scene membership — e.g.
+   * ReplacementTransform swaps source for target.
+   */
+  cleanUpFromScene(scene: AnimationScene): void {
+    if (this.remover) {
+      scene.remove(this.mobject);
+    }
   }
 
   /**

--- a/src/animation/transform.test.ts
+++ b/src/animation/transform.test.ts
@@ -503,6 +503,54 @@ describe('ReplacementTransform', () => {
     rt.finish();
     expect(rt.isFinished()).toBe(true);
   });
+
+  describe('cleanUpFromScene (issue #308)', () => {
+    function makeFakeScene() {
+      const set = new Set<Mobject>();
+      return {
+        set,
+        scene: {
+          add: (...ms: Mobject[]) => ms.forEach((m) => set.add(m)),
+          remove: (...ms: Mobject[]) => ms.forEach((m) => set.delete(m)),
+        },
+      };
+    }
+
+    it('removes source and adds target after the animation', () => {
+      const { c1, c2 } = makePair();
+      const { set, scene } = makeFakeScene();
+      scene.add(c1);
+      const rt = new ReplacementTransform(c1, c2);
+      rt.begin();
+      rt.finish();
+      rt.cleanUpFromScene(scene);
+      expect(set.has(c1)).toBe(false);
+      expect(set.has(c2)).toBe(true);
+    });
+
+    it('plain Transform leaves scene membership unchanged', () => {
+      const { c1, c2 } = makePair();
+      const { set, scene } = makeFakeScene();
+      scene.add(c1);
+      const t = new Transform(c1, c2);
+      t.begin();
+      t.finish();
+      t.cleanUpFromScene(scene);
+      expect(set.has(c1)).toBe(true);
+      expect(set.has(c2)).toBe(false);
+    });
+
+    it('adding target is idempotent if it was already in the scene', () => {
+      const { c1, c2 } = makePair();
+      const { set, scene } = makeFakeScene();
+      scene.add(c1);
+      scene.add(c2);
+      const rt = new ReplacementTransform(c1, c2);
+      rt.cleanUpFromScene(scene);
+      expect(set.has(c1)).toBe(false);
+      expect(set.has(c2)).toBe(true);
+    });
+  });
 });
 
 describe('MoveToTarget', () => {

--- a/src/animation/transform/Transform.ts
+++ b/src/animation/transform/Transform.ts
@@ -5,7 +5,7 @@
 import { Mobject } from '../../core/Mobject';
 import { VMobject } from '../../core/VMobject';
 import { VGroup } from '../../core/VGroup';
-import { Animation, AnimationOptions } from '../Animation';
+import { Animation, AnimationOptions, AnimationScene } from '../Animation';
 import { ImageMobject } from '../../mobjects/image';
 import { MathTexImage } from '../../mobjects/text/MathTexImage';
 import { Text } from '../../mobjects/text/Text';
@@ -73,7 +73,18 @@ export function transform(
   return new Transform(mobject, target, options);
 }
 
-export class ReplacementTransform extends Transform {}
+/**
+ * Like Transform but also swaps `mobject` for `target` in the scene when done.
+ * Matches Python manim's ReplacementTransform: after the animation, the scene
+ * contains `target` and not the original `mobject`.
+ */
+export class ReplacementTransform extends Transform {
+  override cleanUpFromScene(scene: AnimationScene): void {
+    super.cleanUpFromScene(scene);
+    scene.remove(this.mobject);
+    scene.add(this.target);
+  }
+}
 export function replacementTransform(
   mobject: Mobject,
   target: Mobject,

--- a/src/core/Headless.test.ts
+++ b/src/core/Headless.test.ts
@@ -5,6 +5,8 @@ import { ThreeDScene } from './ThreeDScene';
 import { ZoomedScene } from './ZoomedScene';
 import { Circle } from '../mobjects/geometry/Circle';
 import { FadeIn } from '../animation/fading/FadeIn';
+import { FadeOut } from '../animation/fading/FadeOut';
+import { ReplacementTransform } from '../animation/transform/Transform';
 import { Text } from '../mobjects/text/Text';
 import { Code } from '../mobjects/text/Code';
 import { DecimalNumber } from '../mobjects/text/DecimalNumber';
@@ -137,6 +139,29 @@ describe('Scene headless mode', () => {
     const circle = new Circle();
     scene.add(circle);
     await scene.play(new FadeIn(circle, { duration: 0.1 }));
+    scene.dispose();
+  });
+
+  it('FadeOut still removes mobject after play (remover regression)', async () => {
+    const scene = Scene.createHeadless();
+    const circle = new Circle();
+    scene.add(circle);
+    expect(scene.mobjects.has(circle)).toBe(true);
+    await scene.play(new FadeOut(circle, { duration: 0.1 }));
+    expect(scene.mobjects.has(circle)).toBe(false);
+    scene.dispose();
+  });
+
+  it('ReplacementTransform swaps source for target in scene (issue #308)', async () => {
+    const scene = Scene.createHeadless();
+    const src = new Circle({ radius: 1 });
+    const dst = new Circle({ radius: 2 });
+    scene.add(src);
+    expect(scene.mobjects.has(src)).toBe(true);
+    expect(scene.mobjects.has(dst)).toBe(false);
+    await scene.play(new ReplacementTransform(src, dst, { duration: 0.1 }));
+    expect(scene.mobjects.has(src)).toBe(false);
+    expect(scene.mobjects.has(dst)).toBe(true);
     scene.dispose();
   });
 

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -568,11 +568,10 @@ export class Scene {
       this._playPromiseResolve = resolve;
     });
 
-    // Remove mobjects whose animations have remover=true (e.g. FadeOut)
+    // Let each animation update scene membership (handles `remover`,
+    // and overrides like ReplacementTransform that swap source for target).
     for (const animation of allAnimations) {
-      if (animation.remover) {
-        this.remove(animation.mobject);
-      }
+      animation.cleanUpFromScene(this);
     }
   }
 


### PR DESCRIPTION
## Summary

- Closes #308: `ReplacementTransform` now actually replaces the source mobject with the target in the scene, matching Python manim semantics.
- Adds an `Animation.cleanUpFromScene(scene)` hook (mirrors Python manim's `clean_up_from_scene`). Default impl honors the existing `remover` flag, so `FadeOut`, `Write({remover:true})` etc. are unchanged.
- `Scene.play()` now calls `animation.cleanUpFromScene(this)` after each animation finishes instead of inlining the `remover` check.
- `ReplacementTransform` overrides the hook: `scene.remove(this.mobject); scene.add(this.target)`.
- Avoids a `core → animation` import cycle by declaring a structural `AnimationScene` interface in `src/animation/Animation.ts`.

## Test plan

- [x] Unit tests in `src/animation/transform.test.ts` for the new `cleanUpFromScene` behavior on `ReplacementTransform` (swap, plain `Transform` leaves scene unchanged, idempotent when target already present).
- [x] Headless integration tests in `src/core/Headless.test.ts`:
  - `FadeOut` still removes the mobject (regression for `remover`).
  - `await scene.play(new ReplacementTransform(src, dst))` ends with `dst` in `scene.mobjects` and `src` removed.
- [x] Full suite: 5869 tests passing.
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint` clean on touched files.
- [x] Manual browser run of `examples/replacement_transform.html` via vite confirms scene state after each animation:
  - `before Transform: [Circle]` → `after Transform: [Circle]` (source kept, as expected).
  - `before ReplacementTx: [Circle, Circle]` → `after ReplacementTx: [Circle, Square]` (source removed, target added).
