### PR TITLE
chore: release v0.3.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manim-web",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manim-web",
-      "version": "0.3.20",
+      "version": "0.3.21",
       "license": "MIT",
       "dependencies": {
         "@mathjax/src": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manim-web",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Manim-like mathematical animation library for the web",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Release v0.3.21.

### Changes since v0.3.20

- fix(transform): ReplacementTransform now replaces in scene (#308) (#325)
- Fix/mathteximage transform size sync (#323)
- rm examples (#322)
- Fix/transform compound alignment (#319)
- chore(deps-dev): bump vite-plugin-dts from 4.5.4 to 5.0.0 (#315)
- chore(deps-dev): bump knip from 6.7.0 to 6.11.0 (#314)
- chore(deps-dev): bump eslint from 10.2.1 to 10.3.0 (#313)
- chore(deps-dev): bump typescript-eslint from 8.59.0 to 8.59.1 (#312)
- chore(deps): bump opentype.js from 1.3.4 to 1.3.5 (#311)
- fix: Transform for ImageMobject and Text with geometry morphing (#307)
- feat(draggable): add constrainZ option (closes #261) (#304)
- Fix/transform per pair morph fade (#303)
- fix(draggable): freeze Z when X/Y constraint clamps in 3D scenes (#302)
- fix(three-d-axes): add c2p/p2c aliases (#257) (#301)
- fix(transform): preserve compound path metadata at finish (#298)
- feat: migrate mathjax-full 3.2.2 -> @mathjax/src 4.1.1 (#300)
- fix(animate-proxy): keep geometry state in sync after chained transforms (#299)
- Fix sphere opacity not working in 3D scenes (#255) (#297)

Auto-publishes to npm and creates GitHub release on merge via `.github/workflows/release.yml`.
