### PR TITLE
fix(text): flush canvas font cache after FontFace.add (closes #309)

### DIFF
--- a/src/mobjects/text/Text.ts
+++ b/src/mobjects/text/Text.ts
@@ -78,6 +78,13 @@ let fontFaceIdCounter = 0;
 /**
  * Load a font URL as a CSS @font-face rule (cached).
  * Returns the unique font-family name assigned to this URL.
+ *
+ * Why the extra `document.fonts.load(...)` call:
+ * `face.load()` + `document.fonts.add(face)` is enough for `measureText`,
+ * but Canvas 2D's `fillText` font matching is lazy — until the font has
+ * been used in DOM layout or explicitly resolved via `document.fonts.load`,
+ * the first draw after add can fall back to the previous family. This
+ * showed up as wrong-font flickers in `Create`/`Transform` (issue #309).
  */
 async function loadFontFace(url: string): Promise<string> {
   // Font loading unavailable in non-DOM environments
@@ -93,9 +100,11 @@ async function loadFontFace(url: string): Promise<string> {
 
   const familyName = `ManimFont_${fontFaceIdCounter++}`;
   const face = new FontFace(familyName, `url(${url})`);
-  const loadPromise = face.load().then(() => {
+  const loadPromise = (async () => {
+    await face.load();
     document.fonts.add(face);
-  });
+    await document.fonts.load(`1em '${familyName}'`);
+  })();
 
   fontFaceCache.set(url, { familyName, loadPromise });
   await loadPromise;

--- a/src/mobjects/text/text.test.ts
+++ b/src/mobjects/text/text.test.ts
@@ -617,6 +617,72 @@ describe('Text', () => {
       const result = await t.loadGlyphs();
       expect(result).toBeNull();
     });
+
+    /**
+     * Regression for issue #309: loadGlyphs must register the FontFace with
+     * document.fonts AND await document.fonts.load(...) before resolving, so
+     * Canvas 2D's `fillText` actually uses the loaded family on its first
+     * draw instead of falling back. Without the explicit `fonts.load` call,
+     * the first Create/Transform frame can render with the wrong font.
+     */
+    it('loadGlyphs awaits document.fonts.load to flush canvas font cache (issue #309)', async () => {
+      const calls: string[] = [];
+      const fakeFace = {
+        family: '',
+        load: vi.fn(async function (this: { family: string }) {
+          calls.push('face.load');
+          return this;
+        }),
+      };
+      const FakeFontFace = vi.fn(function (this: typeof fakeFace, family: string) {
+        Object.assign(this, fakeFace, { family });
+      }) as unknown as typeof FontFace;
+      const fakeFonts = {
+        add: vi.fn(() => {
+          calls.push('fonts.add');
+        }),
+        load: vi.fn(async (spec: string) => {
+          calls.push(`fonts.load:${spec}`);
+          return [];
+        }),
+      };
+
+      const g = globalThis as unknown as {
+        FontFace: typeof FontFace;
+        document: { fonts: typeof fakeFonts };
+      };
+      const origFontFace = g.FontFace;
+      const origFonts = g.document.fonts;
+      g.FontFace = FakeFontFace;
+      g.document.fonts = fakeFonts;
+
+      try {
+        // Use a unique URL so the per-URL cache in Text.ts does not return
+        // a stale entry from an earlier test run.
+        const url = `http://example.com/font-${Date.now()}-${Math.random()}.ttf`;
+        const t = new Text({ text: 'Hi', fontUrl: url });
+        // loadGlyphs also constructs a TextGlyphGroup which calls opentype.load.
+        // We only need to verify the FontFace registration sequence, so we await
+        // a microtask cycle and inspect the call ordering instead of waiting for
+        // opentype (which would fail without a real font URL).
+        const promise = t.loadGlyphs();
+        // Force the promise chain to advance through await points.
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        // Tear down the awaited opentype.load to avoid hanging the test.
+        promise.catch(() => {});
+
+        expect(calls.indexOf('face.load')).toBeGreaterThanOrEqual(0);
+        expect(calls.indexOf('fonts.add')).toBeGreaterThan(calls.indexOf('face.load'));
+        const loadCallIdx = calls.findIndex((c) => c.startsWith('fonts.load:'));
+        expect(loadCallIdx).toBeGreaterThan(calls.indexOf('fonts.add'));
+        expect(fakeFonts.load).toHaveBeenCalledWith(expect.stringMatching(/^1em '/));
+      } finally {
+        g.FontFace = origFontFace;
+        g.document.fonts = origFonts;
+      }
+    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Closes #309. Fixes wrong/default font on the first `Create` frame and the brief font flicker before `Transform` settles when a `Text` uses `fontUrl` + `loadGlyphs()`.
- Adds a regression test asserting the FontFace registration ordering.

## Root cause
`face.load()` + `document.fonts.add(face)` populates `measureText` but Canvas 2D's `fillText` font matching is lazy in Chromium — until the family has been resolved via `document.fonts.load(...)` or used in DOM layout, the first `fillText` after `add` can still fall back to the previous family. The first `_renderToCanvas` after `loadGlyphs()` therefore sized the canvas correctly but rendered glyphs with the fallback font on the first frame.

## Fix
In the `loadFontFace` helper inside `src/mobjects/text/Text.ts`, after `face.load()` and `document.fonts.add(face)`, also `await document.fonts.load(\`1em '<family>'\`)` so the canvas font cache is guaranteed populated before the cached `loadPromise` resolves.

## Verification
- Reproduced both bug scenarios from the issue locally with the user's exact snippets — wrong-font frame on `Create` and flicker on `Transform` both gone after the fix.
- Confirmed `b._canvas` after `loadGlyphs()` is pixel-identical to a fresh canvas drawn with the same loaded family (diff = 0).
- Full vitest suite passes (5870 tests).
- `tsc --noEmit` clean, `eslint` clean on touched files, `npm run build` succeeds.

## Test plan
- [x] Manual repro of issue #309 Bug 1 (`Create`) shows correct font from frame 0
- [x] Manual repro of issue #309 Bug 2 (`Write` -> `Transform`) shows correct font on both source and target with no flicker
- [x] Pixel-diff check between `Text` canvas and a fresh canvas with the same family is 0
- [x] `npx vitest run` — all 5870 tests pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds

## Files
- `src/mobjects/text/Text.ts` — wrap FontFace registration in an inline async IIFE that also awaits `document.fonts.load`
- `src/mobjects/text/text.test.ts` — add regression test asserting `face.load` -> `fonts.add` -> `fonts.load` ordering