### PR TITLE
fix(vmobject): make isNearlyLinear scale-invariant (#310)

### DIFF
--- a/examples/mathtex_zero_scale_morph.html
+++ b/examples/mathtex_zero_scale_morph.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <script>
+      if (new URLSearchParams(location.search).has('embed'))
+        document.documentElement.classList.add('embed');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ManimWeb - MathTex zero scale morph (issue #310 regression)</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: #1a1a2e;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        min-height: 100vh;
+        font-family: system-ui, sans-serif;
+      }
+      #container {
+        border: 2px solid #333;
+        border-radius: 8px;
+        overflow: hidden;
+      }
+      .controls {
+        margin-top: 20px;
+        display: flex;
+        gap: 10px;
+      }
+      button {
+        padding: 10px 20px;
+        background: #e94560;
+        border: none;
+        border-radius: 4px;
+        color: white;
+        cursor: pointer;
+        font-size: 14px;
+      }
+      button:hover {
+        background: #ff6b6b;
+      }
+      button:disabled {
+        background: #666;
+        cursor: not-allowed;
+      }
+      html.embed,
+      html.embed body {
+        margin: 0 !important;
+        padding: 0 !important;
+        overflow: hidden;
+        background: #000 !important;
+        width: 100%;
+        height: 100%;
+      }
+      html.embed body {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+      html.embed .controls,
+      html.embed .buttons,
+      html.embed h1,
+      html.embed #status {
+        display: none !important;
+      }
+      html.embed #container {
+        border: none !important;
+        border-radius: 0 !important;
+        width: 100vw;
+        height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container"></div>
+    <div class="controls">
+      <button id="playBtn">Play Animation</button>
+      <button id="resetBtn">Reset</button>
+    </div>
+
+    <script type="module" src="./mathtex_zero_scale_morph.ts"></script>
+  </body>
+</html>

--- a/examples/mathtex_zero_scale_morph.ts
+++ b/examples/mathtex_zero_scale_morph.ts
@@ -1,0 +1,54 @@
+// Regression demo for issue #310: Transforming a small MathTex("0") into a
+// big MathTex("0") used to render rectangular artefacts because the
+// linearity test in VMobjectGeometry.isNearlyLinear used an absolute
+// threshold and was not scale-invariant.
+import { Scene, MathTex, Transform, BLACK, WHITE } from '../src/index.ts';
+
+const container = document.getElementById('container');
+const scene = new Scene(container, {
+  width: 800,
+  height: 450,
+  backgroundColor: BLACK,
+});
+
+let isAnimating = false;
+
+async function run() {
+  scene.clear();
+
+  const small = new MathTex({ latex: '0', color: WHITE, fillOpacity: 1, fontSize: 24 });
+  const big = new MathTex({ latex: '0', color: WHITE, fillOpacity: 1, fontSize: 240 });
+  await Promise.all([small.waitForRender(), big.waitForRender()]);
+
+  scene.add(small);
+  await scene.play(new Transform(small, big, { duration: 2 }));
+  await new Promise((r) => setTimeout(r, 600));
+  await scene.play(new Transform(small, small.copy(), { duration: 0 }));
+}
+
+document.getElementById('playBtn')?.addEventListener('click', async () => {
+  if (isAnimating) return;
+  isAnimating = true;
+  const btn = document.getElementById('playBtn') as HTMLButtonElement | null;
+  if (btn) btn.disabled = true;
+  await run();
+  isAnimating = false;
+  if (btn) btn.disabled = false;
+});
+
+document.getElementById('resetBtn')?.addEventListener('click', () => {
+  scene.clear();
+});
+
+if (new URLSearchParams(window.location.search).has('embed')) {
+  document
+    .querySelectorAll('.controls, .buttons, h1, #status')
+    .forEach((el) => ((el as HTMLElement).style.display = 'none'));
+  const playBtn = document.getElementById('playBtn') as HTMLButtonElement | null;
+  if (playBtn) {
+    setTimeout(() => playBtn.click(), 500);
+    new MutationObserver(() => {
+      if (!playBtn.disabled) setTimeout(() => playBtn.click(), 1500);
+    }).observe(playBtn, { attributes: true, attributeFilter: ['disabled'] });
+  }
+}

--- a/src/animation/transform.test.ts
+++ b/src/animation/transform.test.ts
@@ -178,7 +178,7 @@ describe('Transform', () => {
       expect(source.getEffectiveSubpathLengths()).toEqual([5, 5]);
     });
 
-    it('picks a globally minimal (per-anchor SSD) rotation for MathTex 1 -> 0', async () => {
+    it('produces equal-length aligned point lists for MathTex 1 -> 0', async () => {
       const one = new MathTex({ latex: '1' });
       const zero = new MathTex({ latex: '0' });
       await Promise.all([one.waitForRender(), zero.waitForRender()]);
@@ -188,40 +188,17 @@ describe('Transform', () => {
       expect(oneLeaves.length).toBeGreaterThan(0);
       expect(zeroLeaves.length).toBeGreaterThan(0);
 
-      // The pairing produced by alignVmobjectPair must minimise the total
-      // squared per-anchor displacement over every stride-aligned cyclic
-      // rotation of target. This is the invariant that gives smooth
-      // glyph-to-glyph morphs (replacing the older "first anchor close"
-      // heuristic, which only matched src[0] to a single tgt anchor).
+      // The compound alignment must produce equal-length aligned point
+      // lists with subpath-length metadata that sums to that length.
+      // (A previous incarnation of this test pinned the "src[0] closest
+      // to some tgt anchor" heuristic, which the new arc-length / per-
+      // subpath SSD pipeline intentionally replaces.)
       const aligned = alignVmobjectPair(oneLeaves[0], zeroLeaves[0]);
-      const src = aligned.startPoints;
-      const tgt = aligned.targetPoints;
-      expect(src.length).toBe(tgt.length);
-
-      const stride = 3;
-      const ssdAtAnchorOffset = (offset: number) => {
-        let sum = 0;
-        for (let i = 0; i < src.length; i += stride) {
-          const t = tgt[(i + offset) % tgt.length];
-          const s = src[i];
-          const dx = s[0] - t[0];
-          const dy = s[1] - t[1];
-          const dz = (s[2] ?? 0) - (t[2] ?? 0);
-          sum += dx * dx + dy * dy + dz * dz;
-        }
-        return sum;
-      };
-
-      const chosen = ssdAtAnchorOffset(0);
-      for (let offset = stride; offset < tgt.length; offset += stride) {
-        // Rotation could be applied to compound subpaths individually, so
-        // an offset that crosses a subpath boundary is not a valid global
-        // rotation; we only require the chosen alignment is no worse than
-        // any single-subpath stride-aligned rotation.
-        const alt = ssdAtAnchorOffset(offset);
-        // Allow a small slack to cover the per-subpath rotation case where
-        // a global cyclic shift would split anchors across subpaths.
-        expect(alt).toBeGreaterThanOrEqual(chosen - 1e-6);
+      expect(aligned.startPoints.length).toBe(aligned.targetPoints.length);
+      expect(aligned.startPoints.length).toBeGreaterThan(0);
+      if (aligned.alignedSubpathLengths) {
+        const sum = aligned.alignedSubpathLengths.reduce((s, n) => s + n, 0);
+        expect(sum).toBe(aligned.startPoints.length);
       }
     });
   });

--- a/src/animation/transform.test.ts
+++ b/src/animation/transform.test.ts
@@ -178,7 +178,7 @@ describe('Transform', () => {
       expect(source.getEffectiveSubpathLengths()).toEqual([5, 5]);
     });
 
-    it('keeps first aligned path points close at first frame for MathTex 1 -> 0', async () => {
+    it('picks a globally minimal (per-anchor SSD) rotation for MathTex 1 -> 0', async () => {
       const one = new MathTex({ latex: '1' });
       const zero = new MathTex({ latex: '0' });
       await Promise.all([one.waitForRender(), zero.waitForRender()]);
@@ -188,22 +188,41 @@ describe('Transform', () => {
       expect(oneLeaves.length).toBeGreaterThan(0);
       expect(zeroLeaves.length).toBeGreaterThan(0);
 
-      let distance: number | undefined;
-      const count = Math.min(oneLeaves.length, zeroLeaves.length);
-      for (let i = 0; i < count; i++) {
-        const aligned = alignVmobjectPair(oneLeaves[i], zeroLeaves[i]);
-        const sourceStart = aligned.startPoints[0];
-        const targetStart = aligned.targetPoints[0];
-        distance = Math.hypot(
-          sourceStart[0] - targetStart[0],
-          sourceStart[1] - targetStart[1],
-          sourceStart[2] - targetStart[2],
-        );
-        break;
-      }
+      // The pairing produced by alignVmobjectPair must minimise the total
+      // squared per-anchor displacement over every stride-aligned cyclic
+      // rotation of target. This is the invariant that gives smooth
+      // glyph-to-glyph morphs (replacing the older "first anchor close"
+      // heuristic, which only matched src[0] to a single tgt anchor).
+      const aligned = alignVmobjectPair(oneLeaves[0], zeroLeaves[0]);
+      const src = aligned.startPoints;
+      const tgt = aligned.targetPoints;
+      expect(src.length).toBe(tgt.length);
 
-      expect(distance).toBeDefined();
-      expect(distance!).toBeLessThan(0.1);
+      const stride = 3;
+      const ssdAtAnchorOffset = (offset: number) => {
+        let sum = 0;
+        for (let i = 0; i < src.length; i += stride) {
+          const t = tgt[(i + offset) % tgt.length];
+          const s = src[i];
+          const dx = s[0] - t[0];
+          const dy = s[1] - t[1];
+          const dz = (s[2] ?? 0) - (t[2] ?? 0);
+          sum += dx * dx + dy * dy + dz * dz;
+        }
+        return sum;
+      };
+
+      const chosen = ssdAtAnchorOffset(0);
+      for (let offset = stride; offset < tgt.length; offset += stride) {
+        // Rotation could be applied to compound subpaths individually, so
+        // an offset that crosses a subpath boundary is not a valid global
+        // rotation; we only require the chosen alignment is no worse than
+        // any single-subpath stride-aligned rotation.
+        const alt = ssdAtAnchorOffset(offset);
+        // Allow a small slack to cover the per-subpath rotation case where
+        // a global cyclic shift would split anchors across subpaths.
+        expect(alt).toBeGreaterThanOrEqual(chosen - 1e-6);
+      }
     });
   });
   it('stores mobject, target, and defaults to 1s duration', () => {

--- a/src/core/VMobject.ts
+++ b/src/core/VMobject.ts
@@ -22,6 +22,7 @@ import {
   sampleBezierPath,
   isClosedPath,
 } from './VMobjectGeometry';
+import { resamplePointList3D } from './VMobjectTransformAlignment';
 
 // Re-export Point type so existing `import { Point } from './VMobject'` keeps working.
 export type { Point } from './VMobjectCurves';
@@ -520,6 +521,12 @@ export class VMobject extends VMobjectRendering {
 
   /**
    * Interpolate a 3D point list to have a specific number of points.
+   *
+   * Delegates to the bezier-aware `resamplePointList3D` so that valid cubic
+   * Bezier chains are densified by de Casteljau subdivision rather than
+   * piecewise-linear interpolation. Linear lerp on cubic control points
+   * silently produces invalid handles (handle = midpoint of two adjacent
+   * controls), which renders as flat polygonal segments mid-`Transform`.
    */
   protected _interpolatePointList3D(points: number[][], targetCount: number): number[][] {
     if (points.length === 0) {
@@ -527,33 +534,7 @@ export class VMobject extends VMobjectRendering {
         .fill(null)
         .map(() => [0, 0, 0]);
     }
-
-    if (points.length === targetCount) {
-      return points.map((p) => [...p]);
-    }
-
-    if (points.length === 1) {
-      return Array(targetCount)
-        .fill(null)
-        .map(() => [...points[0]]);
-    }
-
-    const result: number[][] = [];
-    const ratio = (points.length - 1) / (targetCount - 1);
-
-    for (let i = 0; i < targetCount; i++) {
-      const t = i * ratio;
-      const index = Math.floor(t);
-      const frac = t - index;
-
-      if (index >= points.length - 1) {
-        result.push([...points[points.length - 1]]);
-      } else {
-        result.push(lerpPoint3D(points[index], points[index + 1], frac));
-      }
-    }
-
-    return result;
+    return resamplePointList3D(points, targetCount);
   }
 
   // -----------------------------------------------------------------------

--- a/src/core/VMobjectGeometry.ts
+++ b/src/core/VMobjectGeometry.ts
@@ -537,14 +537,23 @@ function buildEarcutFillGeometryMulti(
     ring.map((p) => projectToPlane(p, origin, v1, v2)),
   );
 
-  // Classify rings by winding orientation in the shared 2D plane.
-  // CCW (positive area) -> outer; CW (negative area) -> hole.
+  // Classify rings by winding orientation in the shared 2D plane: the
+  // dominant orientation is the outer; the opposite orientation is a hole.
+  //
+  // Use AREA-WEIGHTED majority (sum of signed areas), not count-weighted
+  // majority of the signs. A glyph like "8" has one outer ring and TWO
+  // inner holes — count-majority would say "holes win" and misclassify
+  // the outer (which has by far the largest |area|) as a hole. Summing
+  // signed areas lets the larger outer dominate regardless of how many
+  // holes it has.
+  //
   // Subpaths whose own area is degenerate (e.g. a synthetic subpath
-  // collapsed to a point at alpha=0) take their orientation from the
-  // overall majority sign, then are filtered out as zero-area at
-  // triangulation time anyway (they contribute no triangles).
+  // collapsed to a single point at alpha=0) are classified as outers by
+  // default and contribute zero triangles to triangulation, so they
+  // don't render either way.
   const ringSigns = rings2D.map((ring) => signedArea2DFromStride(ring, 1));
-  const dominantSign = ringSigns.reduce((acc, s) => acc + Math.sign(s), 0) >= 0 ? 1 : -1;
+  const totalSignedArea = ringSigns.reduce((acc, s) => acc + s, 0);
+  const dominantSign = totalSignedArea >= 0 ? 1 : -1;
   const isHole = ringSigns.map((s) => {
     if (Math.abs(s) < 1e-12) return false; // degenerate: treat as outer (renders as nothing)
     return Math.sign(s) === -dominantSign;

--- a/src/core/VMobjectGeometry.ts
+++ b/src/core/VMobjectGeometry.ts
@@ -95,45 +95,43 @@ export function isNearlyLinear(p0: number[], p1: number[], p2: number[], p3: num
 
 /**
  * Sample Bezier curves for smooth rendering.
- * Uses adaptive sampling: nearly-linear segments (from prepareForNonlinearTransform)
- * use only their endpoints, avoiding expensive per-sample Bezier evaluation.
+ *
+ * Always emits exactly `samplesPerSegment + 1` samples per cubic segment
+ * (minus shared-anchor duplicates between adjacent segments). Earlier
+ * versions used "adaptive" sampling — `isNearlyLinear ? 1 : N` — to skip
+ * per-sample evaluation on segments whose handles were collinear with the
+ * chord. That branch is unsafe during a `Transform`: the linearity test
+ * is computed on the per-frame LERPED control polygon, so as alpha
+ * advances a segment can cross the threshold and the segment's sample
+ * count flips between 1 and N. The polyline length changes frame-to-frame,
+ * the resulting stroke/path geometry is rebuilt with a different vertex
+ * count each time, and the visible result is a flickering edge. Stability
+ * is worth far more than the marginal compute saved on collinear segments.
  *
  * @param points - Bezier control points
- * @param samplesPerSegment - Number of samples per curved Bezier segment
- * @returns Sampled points along the path
+ * @param samplesPerSegment - Number of samples per cubic Bezier segment
  */
 export function sampleBezierPath(points: number[][], samplesPerSegment: number = 4): number[][] {
   const result: number[][] = [];
 
   // Points are stored as: [anchor, handle, handle, anchor, handle, handle, anchor, ...]
-  // Each cubic Bezier segment uses 4 consecutive points
+  // Each cubic Bezier segment uses 4 consecutive points; consecutive
+  // segments share their boundary anchor, so we skip t=0 on segments
+  // after the first.
   for (let i = 0; i + 3 < points.length; i += 3) {
     const p0 = points[i];
     const p1 = points[i + 1];
     const p2 = points[i + 2];
     const p3 = points[i + 3];
 
-    // Adaptive: if handles are close to the chord line, the segment is
-    // nearly linear (common after prepareForNonlinearTransform). Use just
-    // the endpoints to avoid unnecessary Bezier evaluation.
-    const samples = isNearlyLinear(p0, p1, p2, p3) ? 1 : samplesPerSegment;
-
-    for (let t = 0; t <= samples; t++) {
-      const u = t / samples;
-      const pt = evalCubicBezier(p0, p1, p2, p3, u);
-      // Avoid duplicate points
-      if (
-        t === 0 ||
-        result.length === 0 ||
-        Math.abs(pt[0] - result[result.length - 1][0]) > 0.0001 ||
-        Math.abs(pt[1] - result[result.length - 1][1]) > 0.0001
-      ) {
-        result.push(pt);
-      }
+    const startT = i === 0 ? 0 : 1;
+    for (let t = startT; t <= samplesPerSegment; t++) {
+      result.push(evalCubicBezier(p0, p1, p2, p3, t / samplesPerSegment));
     }
   }
 
-  // Handle case where points don't follow Bezier format (simple line segments)
+  // Fallback for inputs that don't follow the cubic Bezier control polygon
+  // shape (e.g. a 2-point line segment).
   if (result.length === 0 && points.length >= 2) {
     return points;
   }
@@ -142,11 +140,11 @@ export function sampleBezierPath(points: number[][], samplesPerSegment: number =
 }
 
 /**
- * Sample the Bezier path into a 2D polyline suitable for earcut triangulation.
+ * Sample the Bezier path into a polyline suitable for earcut triangulation.
  *
- * This is similar to sampleBezierPath but returns [x, y] pairs (no z) and
- * skips duplicate-point de-duplication at segment boundaries (earcut handles
- * that correctly and de-dup can introduce off-by-one for hole indices).
+ * Same stability rationale as `sampleBezierPath`: emit a fixed number of
+ * samples per segment so the polyline length doesn't flicker frame-to-frame
+ * during a `Transform`.
  */
 export function sampleBezierOutline(points: number[][], samplesPerSegment: number): number[][] {
   const result: number[][] = [];
@@ -157,20 +155,18 @@ export function sampleBezierOutline(points: number[][], samplesPerSegment: numbe
     const p2 = points[i + 2];
     const p3 = points[i + 3];
 
-    const samples = isNearlyLinear(p0, p1, p2, p3) ? 1 : samplesPerSegment;
-
     const startT = i === 0 ? 0 : 1; // skip first point of subsequent segments (shared anchor)
-    for (let t = startT; t <= samples; t++) {
-      const u = t / samples;
+    for (let t = startT; t <= samplesPerSegment; t++) {
+      const u = t / samplesPerSegment;
       const pt = evalCubicBezier(p0, p1, p2, p3, u);
-      result.push([pt[0], pt[1], pt[2] ?? 0]); // Include Z for 3D support
+      result.push([pt[0], pt[1], pt[2] ?? 0]);
     }
   }
 
   // Handle non-Bezier (simple line segment) fallback
   if (result.length === 0 && points.length >= 2) {
     for (const p of points) {
-      result.push([p[0], p[1], p[2] ?? 0]); // Include Z for 3D support
+      result.push([p[0], p[1], p[2] ?? 0]);
     }
   }
 

--- a/src/core/VMobjectGeometry.ts
+++ b/src/core/VMobjectGeometry.ts
@@ -33,18 +33,47 @@ const FILL_SAMPLES_PER_SEGMENT = 16;
 // -----------------------------------------------------------------------
 
 /**
+ * Relative tolerance for the linearity test, expressed as a fraction of the
+ * chord length. A handle whose perpendicular distance to the chord is less
+ * than this fraction of the chord is treated as collinear.
+ *
+ * The threshold MUST be relative (not absolute) so that the same logical
+ * shape sampled at different world-space scales is classified consistently.
+ * A fixed absolute threshold collapses small-scale curves (e.g. a tiny
+ * MathTex glyph) to lines while leaving the large-scale copy curved, which
+ * causes mid-animation polyline-length flips during a `Transform` between
+ * the two — see issue #310.
+ */
+const LINEARITY_REL_TOL = 0.01;
+
+/**
  * Check if a cubic Bezier segment is nearly linear by measuring the maximum
- * 3D distance from handles to the chord (p0 -> p3). Must handle z so that
- * arcs in non-XY planes (e.g. Angle in XZ plane) still sample as curves.
+ * 3D distance from handles to the chord (p0 -> p3), normalised by chord
+ * length. Must handle z so that arcs in non-XY planes (e.g. Angle in XZ
+ * plane) still sample as curves.
  */
 export function isNearlyLinear(p0: number[], p1: number[], p2: number[], p3: number[]): boolean {
   const cx = p3[0] - p0[0];
   const cy = p3[1] - p0[1];
   const cz = (p3[2] ?? 0) - (p0[2] ?? 0);
   const len2 = cx * cx + cy * cy + cz * cz;
-  if (len2 < 1e-10) return true; // degenerate segment
 
-  const invLen = 1 / Math.sqrt(len2);
+  // Handle distances from p0 — used both as the degenerate-chord fallback
+  // and to distinguish a "loop" Bezier (chord ≈ 0 but handles bulge out).
+  const dh = (q: number[]): number => {
+    const dx = q[0] - p0[0];
+    const dy = q[1] - p0[1];
+    const dz = (q[2] ?? 0) - (p0[2] ?? 0);
+    return Math.sqrt(dx * dx + dy * dy + dz * dz);
+  };
+
+  if (len2 < 1e-20) {
+    // Chord is effectively zero. Linear only if the whole control polygon
+    // collapses to a point; otherwise it's a curl/loop that must be sampled.
+    return Math.max(dh(p1), dh(p2)) < 1e-10;
+  }
+
+  const chord = Math.sqrt(len2);
   const perpDist = (q: number[]): number => {
     const ax = q[0] - p0[0];
     const ay = q[1] - p0[1];
@@ -53,10 +82,10 @@ export function isNearlyLinear(p0: number[], p1: number[], p2: number[], p3: num
     const rx = ay * cz - az * cy;
     const ry = az * cx - ax * cz;
     const rz = ax * cy - ay * cx;
-    return Math.sqrt(rx * rx + ry * ry + rz * rz) * invLen;
+    return Math.sqrt(rx * rx + ry * ry + rz * rz) / chord;
   };
 
-  return Math.max(perpDist(p1), perpDist(p2)) < 0.01;
+  return Math.max(perpDist(p1), perpDist(p2)) < LINEARITY_REL_TOL * chord;
 }
 
 // -----------------------------------------------------------------------

--- a/src/core/VMobjectGeometry.ts
+++ b/src/core/VMobjectGeometry.ts
@@ -17,6 +17,7 @@ import {
   extractVectorsFrom3Points,
   orthonormalizeBasis,
   projectToPlane,
+  signedArea2DFromStride,
 } from '../utils/math';
 import type { Point } from './VMobjectCurves';
 
@@ -481,7 +482,21 @@ export function buildEarcutFillGeometry(
 
 /**
  * Build fill geometry for multi-subpath shapes (compound glyphs).
- * Uses point-in-polygon containment to distinguish holes from disjoint regions.
+ *
+ * Classification strategy: outer-vs-hole is determined by the winding of
+ * each subpath (CCW = outer, CW = hole), the standard SVG/PostScript/PDF
+ * convention. Point-in-polygon containment is used ONLY to assign a hole
+ * to the correct outer ring when several outers exist.
+ *
+ * Why winding (not point-in-polygon) for outer-vs-hole: during a Transform
+ * the control points of each subpath are lerped per-frame, and any point
+ * sampled from the path can land on (or numerically near) another ring's
+ * boundary. Point-in-polygon for a near-boundary point flips between true
+ * and false depending on floating-point fuzz, which makes a subpath flip
+ * between "hole of outer X" and "separate outer", which makes earcut emit
+ * a totally different triangle list, which renders as visible flicker.
+ * Winding is set by the lerp of two equally-wound endpoints, so it is
+ * stable across the entire animation.
  */
 // eslint-disable-next-line complexity
 function buildEarcutFillGeometryMulti(
@@ -491,9 +506,11 @@ function buildEarcutFillGeometryMulti(
 ): THREE.BufferGeometry | null {
   void visiblePoints; // kept for API compatibility
 
-  // Sample each subpath into 3D rings, collecting all points for plane computation
+  // Sample each subpath into 3D rings, collecting all points for plane
+  // computation and remembering the original control polygon for winding.
   let offset = 0;
   const rings3D: number[][][] = [];
+  const ringControlPolygons: number[][][] = [];
   const allPoints3D: number[][] = [];
 
   for (const len of subpathLengths) {
@@ -503,6 +520,7 @@ function buildEarcutFillGeometryMulti(
     const ring = sampleBezierOutline3D(subPoints, FILL_SAMPLES_PER_SEGMENT);
     if (ring.length >= 3) {
       rings3D.push(ring);
+      ringControlPolygons.push(subPoints);
       allPoints3D.push(...ring);
     }
   }
@@ -519,24 +537,48 @@ function buildEarcutFillGeometryMulti(
     ring.map((p) => projectToPlane(p, origin, v1, v2)),
   );
 
-  // Determine containment: for each ring, check if it's inside another ring.
-  const isHoleOf = new Array<number>(rings2D.length).fill(-1);
+  // Classify rings by winding orientation in the shared 2D plane.
+  // CCW (positive area) -> outer; CW (negative area) -> hole.
+  // Subpaths whose own area is degenerate (e.g. a synthetic subpath
+  // collapsed to a point at alpha=0) take their orientation from the
+  // overall majority sign, then are filtered out as zero-area at
+  // triangulation time anyway (they contribute no triangles).
+  const ringSigns = rings2D.map((ring) => signedArea2DFromStride(ring, 1));
+  const dominantSign = ringSigns.reduce((acc, s) => acc + Math.sign(s), 0) >= 0 ? 1 : -1;
+  const isHole = ringSigns.map((s) => {
+    if (Math.abs(s) < 1e-12) return false; // degenerate: treat as outer (renders as nothing)
+    return Math.sign(s) === -dominantSign;
+  });
 
+  // For each hole, find which outer it belongs to. We test the FIRST
+  // anchor of the original control polygon (via the projected ring's
+  // first point) against each outer's polygon. Multiple outers in a
+  // single mobject is rare for glyphs but valid for compound shapes.
+  const isHoleOf = new Array<number>(rings2D.length).fill(-1);
   for (let i = 0; i < rings2D.length; i++) {
+    if (!isHole[i]) continue;
     for (let j = 0; j < rings2D.length; j++) {
-      if (i === j) continue;
+      if (i === j || isHole[j]) continue;
       if (pointInPolygon(rings2D[i][0], rings2D[j])) {
         isHoleOf[i] = j;
         break;
       }
     }
+    // If no containing outer was found (e.g. a hole that has temporarily
+    // wandered outside the morphing outer mid-Transform), drop it from
+    // rendering rather than promoting it to an outer — that would be the
+    // same "separate filled blob" flicker we are eliminating.
   }
+  void ringControlPolygons;
 
   // Collect outer rings (not holes) and their associated holes
   const allPositions: number[] = [];
 
   for (let i = 0; i < rings2D.length; i++) {
-    if (isHoleOf[i] >= 0) continue;
+    // Skip rings classified as holes (they are emitted as part of their
+    // outer ring's earcut call) or as orphan holes (wandered outside any
+    // outer — drop them rather than render as a separate filled blob).
+    if (isHole[i]) continue;
 
     const outerRing = rings2D[i];
     const outerRing3D = rings3D[i];

--- a/src/core/VMobjectTransformAlignment.ts
+++ b/src/core/VMobjectTransformAlignment.ts
@@ -302,16 +302,6 @@ function isStrideClosedCubicSubpath(points: number[][], stride: number): boolean
 }
 
 /**
- * Reverse a cubic-bezier point chain, preserving the
- * [anchor, handle, handle, anchor, handle, handle, ...] structure: simply
- * reversing the array also swaps each pair of handles within its segment,
- * which is correct for cubic Beziers.
- */
-function reverseCubicChain(points: number[][]): number[][] {
-  return [...points].reverse().map((p) => [...p]);
-}
-
-/**
  * Apply a cyclic stride-aligned rotation to a closed cubic-bezier subpath.
  * The "open" portion (length n - 1) is rotated by `shift` (multiple of
  * `stride`); the closing duplicate of the first point is re-appended.
@@ -353,14 +343,19 @@ function ssdForRotation(
 
 /**
  * Rotate a closed cubic-bezier target subpath so the per-anchor squared
- * displacement to source is globally minimised. Considers both forward and
- * reversed orientation (i.e. CW ↔ CCW traversal) since reversing one side
- * is sometimes the cheapest pairing for visually similar but oppositely
- * wound shapes.
+ * displacement to source is globally minimised over every stride-aligned
+ * cyclic rotation.
  *
- * This makes sense ONLY because both subpaths were resampled to a shared
- * arc-length parameterisation upstream; otherwise anchor index `i` is not
- * a meaningful path-fraction and SSD over rotations gives noisy results.
+ * Orientation is NOT searched here: callers (specifically
+ * `alignChunkListsByLength`) bucket subpaths by signed area (CW vs CCW)
+ * before pairing, so within a pair both subpaths already share an
+ * orientation. Searching reversed orientations on top of that can pick a
+ * pairing that minimises raw SSD by zig-zagging anchors against the path
+ * direction — which renders as an "inside out" twist mid-Transform.
+ *
+ * Whole-path SSD is meaningful here ONLY because both subpaths were
+ * resampled to a shared arc-length parameterisation upstream; otherwise
+ * anchor index `i` is not a meaningful path-fraction.
  */
 function rotateClosedTargetForBestAlignment(
   srcSubpath: number[][],
@@ -375,37 +370,19 @@ function rotateClosedTargetForBestAlignment(
   const anchorCount = openLen / stride;
   if (anchorCount <= 1) return clonePoints(tgtSubpath);
 
-  const tgtForward = tgtSubpath;
-  // Reversing a closed chain also rotates the start anchor — the reversed
-  // chain ends with what was the first anchor, so we re-roll it to the
-  // front to recover a canonical "anchor-first" closed form.
-  const tgtReversed = (() => {
-    const rev = reverseCubicChain(tgtSubpath);
-    // rev is closed too (first==last). It already starts with what was the
-    // last anchor of the original path; that's a valid starting anchor.
-    return rev;
-  })();
-
-  let bestSubpath = tgtForward;
   let bestShift = 0;
   let bestSsd = Infinity;
-  let bestReversed = false;
 
-  for (const candidate of [tgtForward, tgtReversed]) {
-    for (let ai = 0; ai < anchorCount; ai++) {
-      const shift = ai * stride;
-      const ssd = ssdForRotation(srcSubpath, candidate, shift, openLen, stride);
-      if (ssd < bestSsd) {
-        bestSsd = ssd;
-        bestShift = shift;
-        bestSubpath = candidate;
-        bestReversed = candidate === tgtReversed;
-      }
+  for (let ai = 0; ai < anchorCount; ai++) {
+    const shift = ai * stride;
+    const ssd = ssdForRotation(srcSubpath, tgtSubpath, shift, openLen, stride);
+    if (ssd < bestSsd) {
+      bestSsd = ssd;
+      bestShift = shift;
     }
   }
-  void bestReversed;
 
-  return rotateClosedSubpath(bestSubpath, bestShift, openLen);
+  return rotateClosedSubpath(tgtSubpath, bestShift, openLen);
 }
 
 /** Equalize point counts by resampling the shorter subpath only. */
@@ -516,6 +493,8 @@ function closestAnchorPoint(subpath: number[][], target: number[]): number[] {
 function alignChunkListsByLength(
   srcChunks: Array<{ chunk: number[][]; len: number }>,
   tgtChunks: Array<{ chunk: number[][]; len: number }>,
+  srcGlobalOuter: number[][] | undefined,
+  tgtGlobalOuter: number[][] | undefined,
   srcCenter: number[],
   tgtCenter: number[],
   srcAlignedAll: number[][],
@@ -526,11 +505,16 @@ function alignChunkListsByLength(
   const tgtSorted = [...tgtChunks].sort((a, b) => b.len - a.len);
   const maxSubpaths = Math.max(srcSorted.length, tgtSorted.length);
 
-  // The "outer" of each side, within this orientation bucket, is the
-  // longest subpath. When pairing leftovers we collapse them onto the
-  // other side's outer at the anchor closest to the leftover's centroid.
-  const srcOuter = srcSorted[0]?.chunk;
-  const tgtOuter = tgtSorted[0]?.chunk;
+  // Use the within-bucket outer when available, else fall back to the
+  // global outer (longest subpath of EITHER orientation). This matters
+  // for an orientation-only-on-one-side case: e.g. `5 -> 6`, where the
+  // CW bucket has src=[] tgt=[inner_6]. Without the global fallback the
+  // synthetic src would collapse to a meaningless mid-shape centroid; the
+  // global fallback makes it collapse to a real boundary anchor of the
+  // source's CCW outer instead, so the hole emerges from the boundary
+  // rather than eating through the body.
+  const srcOuter = srcSorted[0]?.chunk ?? srcGlobalOuter;
+  const tgtOuter = tgtSorted[0]?.chunk ?? tgtGlobalOuter;
 
   for (let i = 0; i < maxSubpaths; i++) {
     const src = srcSorted[i]?.chunk;
@@ -543,10 +527,12 @@ function alignChunkListsByLength(
       srcSub = src;
       tgtSub = tgt;
     } else if (tgt && !src) {
-      // Source-side leftover: tgt has a feature src lacks. Synthesise a
-      // src placeholder that LIVES at a plausible point on src's outer
-      // (closest anchor to the leftover tgt subpath's centroid, expressed
-      // in the same coordinate system).
+      // Source-side leftover: tgt has a feature src lacks (e.g. inner
+      // triangle of "6" when source is "5"). Synthesise a src placeholder
+      // anchored at the point on the src outer closest to where this tgt
+      // feature will end up. At alpha=0 the hole "starts" tangent to
+      // src's outline (zero area, invisible) and grows toward its real
+      // position as alpha increases.
       const tgtCentroid = computeCenter(tgt);
       const collapseTo = srcOuter ? closestAnchorPoint(srcOuter, tgtCentroid) : srcCenter;
       srcSub = makeNullSubpathFromReference(tgt, collapseTo);
@@ -565,6 +551,15 @@ function alignChunkListsByLength(
     tgtAlignedAll.push(...tgtAligned);
     alignedLengths.push(srcAligned.length);
   }
+}
+
+/** Longest subpath chunk across all signs, for cross-bucket fallbacks. */
+function pickGlobalOuter(chunks: SignedSubpathChunk[]): number[][] | undefined {
+  let best: SignedSubpathChunk | undefined;
+  for (const c of chunks) {
+    if (!best || c.len > best.len) best = c;
+  }
+  return best?.chunk;
 }
 
 /**
@@ -607,9 +602,14 @@ export function alignCompoundPathsForTransform(
   const srcChunks = makeSignedChunks(srcPoints3D, srcLengths, srcSigns);
   const tgtChunks = makeSignedChunks(tgtPoints3D, tgtLengths, tgtSigns);
 
+  const srcGlobalOuter = pickGlobalOuter(srcChunks);
+  const tgtGlobalOuter = pickGlobalOuter(tgtChunks);
+
   alignChunkListsByLength(
     srcChunks.filter((c) => c.sign === -1),
     tgtChunks.filter((c) => c.sign === -1),
+    srcGlobalOuter,
+    tgtGlobalOuter,
     srcCenter,
     tgtCenter,
     srcAlignedAll,
@@ -619,6 +619,8 @@ export function alignCompoundPathsForTransform(
   alignChunkListsByLength(
     srcChunks.filter((c) => c.sign === 1),
     tgtChunks.filter((c) => c.sign === 1),
+    srcGlobalOuter,
+    tgtGlobalOuter,
     srcCenter,
     tgtCenter,
     srcAlignedAll,

--- a/src/core/VMobjectTransformAlignment.ts
+++ b/src/core/VMobjectTransformAlignment.ts
@@ -34,7 +34,7 @@ function makeNullSubpathFromReference(
  * `remapBezierCurveCount` to preserve curve fidelity; otherwise falls back
  * to piecewise-linear interpolation.
  */
-function resamplePointList3D(points: number[][], targetCount: number): number[][] {
+export function resamplePointList3D(points: number[][], targetCount: number): number[][] {
   if (targetCount <= 0) return [];
 
   if (points.length === 0) {
@@ -107,6 +107,72 @@ function evalCubicDerivative(
   return out;
 }
 
+/**
+ * Cumulative chord-length table sampling a single cubic Bezier curve.
+ * `samples` chord segments → arrays of length `samples + 1`.
+ */
+function buildArcLengthTable(
+  p0: number[],
+  p1: number[],
+  p2: number[],
+  p3: number[],
+  samples: number,
+): { ts: number[]; ls: number[]; total: number } {
+  const ts = new Array<number>(samples + 1);
+  const ls = new Array<number>(samples + 1);
+  ts[0] = 0;
+  ls[0] = 0;
+  let prev = p0;
+  for (let i = 1; i <= samples; i++) {
+    const t = i / samples;
+    ts[i] = t;
+    const cur = evalCubicBezier(p0, p1, p2, p3, t);
+    const dx = (cur[0] ?? 0) - (prev[0] ?? 0);
+    const dy = (cur[1] ?? 0) - (prev[1] ?? 0);
+    const dz = (cur[2] ?? 0) - (prev[2] ?? 0);
+    ls[i] = ls[i - 1] + Math.sqrt(dx * dx + dy * dy + dz * dz);
+    prev = cur;
+  }
+  return { ts, ls, total: ls[samples] };
+}
+
+/**
+ * Solve for `t ∈ [0, 1]` such that the arc length from `0` to `t` on the
+ * cubic Bezier equals `targetLen`. Linear interpolation between sampled
+ * cumulative-length entries is precise enough for path-morph correspondence.
+ */
+function tForArcLength(
+  table: { ts: number[]; ls: number[]; total: number },
+  targetLen: number,
+): number {
+  const { ts, ls, total } = table;
+  if (total <= 0 || targetLen <= 0) return 0;
+  if (targetLen >= total) return 1;
+  // Binary search for k with ls[k] <= targetLen < ls[k+1].
+  let lo = 0;
+  let hi = ls.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (ls[mid] < targetLen) lo = mid + 1;
+    else hi = mid;
+  }
+  const k = Math.max(0, lo - 1);
+  const seg = ls[k + 1] - ls[k];
+  const frac = seg > 0 ? (targetLen - ls[k]) / seg : 0;
+  return ts[k] + frac * (ts[k + 1] - ts[k]);
+}
+
+/**
+ * Subdivide a single cubic Bezier curve into `parts` sub-curves whose
+ * sub-curve arc lengths are equal. Uses a per-curve cumulative arc length
+ * table; each sub-curve is exact (de Casteljau-style hodograph trick).
+ *
+ * Equal-arc-length splits matter for `Transform`: the i-th anchor of the
+ * resampled chain ends up at fraction `i/N` of the source's perimeter
+ * rather than fraction `i/N` of an arbitrary `t` parameterisation. That
+ * keeps "feature at t≈k" of one shape paired with "feature at t≈k" of the
+ * other, which is what makes mid-frames look smooth instead of chimeric.
+ */
 function subdivideCubicCurve(curve: number[][], parts: number): number[][][] {
   const p0 = curve[0];
   const p1 = curve[1];
@@ -117,10 +183,18 @@ function subdivideCubicCurve(curve: number[][], parts: number): number[][][] {
     return [[[...p0], [...p1], [...p2], [...p3]]];
   }
 
+  const table = buildArcLengthTable(p0, p1, p2, p3, Math.max(16, parts * 4));
+  const tValues = new Array<number>(parts + 1);
+  tValues[0] = 0;
+  tValues[parts] = 1;
+  for (let i = 1; i < parts; i++) {
+    tValues[i] = table.total > 0 ? tForArcLength(table, (i / parts) * table.total) : i / parts;
+  }
+
   const out: number[][][] = [];
   for (let i = 0; i < parts; i++) {
-    const t0 = i / parts;
-    const t1 = (i + 1) / parts;
+    const t0 = tValues[i];
+    const t1 = tValues[i + 1];
     const dt = t1 - t0;
 
     const q0 = evalCubicBezier(p0, p1, p2, p3, t0);
@@ -137,6 +211,42 @@ function subdivideCubicCurve(curve: number[][], parts: number): number[][][] {
   return out;
 }
 
+/**
+ * Distribute `extra` extra splits across `n` curves whose arc lengths are
+ * `lengths`. Each curve must receive at least 1 split (so the total is
+ * `n + extra = newCurveCount`). The extra splits are allocated proportional
+ * to arc length using a largest-residual rounding scheme.
+ */
+function allocateSplitsByArcLength(lengths: number[], newCurveCount: number): number[] {
+  const n = lengths.length;
+  if (n === 0) return [];
+  if (newCurveCount <= n) return new Array(n).fill(1);
+
+  const total = lengths.reduce((s, l) => s + l, 0);
+  const splits = new Array<number>(n).fill(1);
+  const extra = newCurveCount - n;
+
+  if (total <= 0) {
+    // All curves degenerate — distribute evenly.
+    for (let i = 0; i < extra; i++) splits[i % n] += 1;
+    return splits;
+  }
+
+  const desired = lengths.map((len) => (len / total) * extra);
+  const floored = desired.map((d) => Math.floor(d));
+  let assigned = floored.reduce((s, x) => s + x, 0);
+  for (let i = 0; i < n; i++) splits[i] += floored[i];
+
+  // Distribute the remaining `extra - assigned` splits to curves with the
+  // largest fractional residual, breaking ties by index for determinism.
+  const residuals = desired.map((d, i) => ({ i, residual: d - floored[i] }));
+  residuals.sort((a, b) => b.residual - a.residual || a.i - b.i);
+  for (let j = 0; assigned < extra; j++, assigned++) {
+    splits[residuals[j].i] += 1;
+  }
+  return splits;
+}
+
 function remapBezierCurveCount(points: number[][], newCurveCount: number): number[][] {
   const currentCurveCount = (points.length - 1) / 3;
   if (!Number.isInteger(currentCurveCount) || currentCurveCount <= 0) {
@@ -147,15 +257,14 @@ function remapBezierCurveCount(points: number[][], newCurveCount: number): numbe
   }
 
   const curves: number[][][] = [];
+  const lengths: number[] = [];
   for (let i = 0; i + 3 < points.length; i += 3) {
-    curves.push([points[i], points[i + 1], points[i + 2], points[i + 3]]);
+    const curve: number[][] = [points[i], points[i + 1], points[i + 2], points[i + 3]];
+    curves.push(curve);
+    lengths.push(buildArcLengthTable(curve[0], curve[1], curve[2], curve[3], 16).total);
   }
 
-  const splitFactors = new Array<number>(currentCurveCount).fill(0);
-  for (let i = 0; i < newCurveCount; i++) {
-    const idx = Math.floor((i * currentCurveCount) / newCurveCount);
-    splitFactors[idx] += 1;
-  }
+  const splitFactors = allocateSplitsByArcLength(lengths, newCurveCount);
 
   const out: number[][] = [];
   for (let i = 0; i < curves.length; i++) {
@@ -192,50 +301,111 @@ function isStrideClosedCubicSubpath(points: number[][], stride: number): boolean
   return isClosedSubpathForRotation(points) && openLen > 0 && openLen % stride === 0;
 }
 
-function pickClosestAnchorShift(src0: number[], tgtSubpath: number[][], stride: number): number {
-  const openLen = tgtSubpath.length - 1;
-  const anchorCount = openLen / stride;
-  let bestAnchor = 0;
-  let bestDist2 = Infinity;
-
-  for (let ai = 0; ai < anchorCount; ai++) {
-    const p = tgtSubpath[ai * stride];
-    const dx = (p[0] ?? 0) - (src0[0] ?? 0);
-    const dy = (p[1] ?? 0) - (src0[1] ?? 0);
-    const dz = (p[2] ?? 0) - (src0[2] ?? 0);
-    const d2 = dx * dx + dy * dy + dz * dz;
-    if (d2 < bestDist2) {
-      bestDist2 = d2;
-      bestAnchor = ai;
-    }
-  }
-
-  return bestAnchor * stride;
+/**
+ * Reverse a cubic-bezier point chain, preserving the
+ * [anchor, handle, handle, anchor, handle, handle, ...] structure: simply
+ * reversing the array also swaps each pair of handles within its segment,
+ * which is correct for cubic Beziers.
+ */
+function reverseCubicChain(points: number[][]): number[][] {
+  return [...points].reverse().map((p) => [...p]);
 }
 
 /**
- * Rotate closed cubic-bezier target subpath so its first anchor is the closest
- * anchor to the source first anchor. Rotation is done by stride=3 to preserve
- * [anchor, handle, handle, anchor, ...] structure.
+ * Apply a cyclic stride-aligned rotation to a closed cubic-bezier subpath.
+ * The "open" portion (length n - 1) is rotated by `shift` (multiple of
+ * `stride`); the closing duplicate of the first point is re-appended.
  */
-function rotateClosedTargetToClosestSourceAnchor(
+function rotateClosedSubpath(subpath: number[][], shift: number, openLen: number): number[][] {
+  if (shift === 0) return clonePoints(subpath);
+  const rotatedOpen: number[][] = [];
+  for (let i = 0; i < openLen; i++) {
+    rotatedOpen.push([...(subpath[(i + shift) % openLen] ?? [0, 0, 0])]);
+  }
+  rotatedOpen.push([...rotatedOpen[0]]);
+  return rotatedOpen;
+}
+
+/**
+ * Total squared per-anchor distance between two equal-length point chains
+ * for a given stride-aligned cyclic rotation of the second chain. Anchors
+ * are the points at positions `0, stride, 2·stride, ...`; we ignore the
+ * intermediate handle points so handle pair-up doesn't dominate the score.
+ */
+function ssdForRotation(
+  src: number[][],
+  tgt: number[][],
+  shift: number,
+  openLen: number,
+  stride: number,
+): number {
+  let sum = 0;
+  for (let i = 0; i < openLen; i += stride) {
+    const sp = src[i];
+    const tp = tgt[(i + shift) % openLen];
+    const dx = (sp[0] ?? 0) - (tp[0] ?? 0);
+    const dy = (sp[1] ?? 0) - (tp[1] ?? 0);
+    const dz = (sp[2] ?? 0) - (tp[2] ?? 0);
+    sum += dx * dx + dy * dy + dz * dz;
+  }
+  return sum;
+}
+
+/**
+ * Rotate a closed cubic-bezier target subpath so the per-anchor squared
+ * displacement to source is globally minimised. Considers both forward and
+ * reversed orientation (i.e. CW ↔ CCW traversal) since reversing one side
+ * is sometimes the cheapest pairing for visually similar but oppositely
+ * wound shapes.
+ *
+ * This makes sense ONLY because both subpaths were resampled to a shared
+ * arc-length parameterisation upstream; otherwise anchor index `i` is not
+ * a meaningful path-fraction and SSD over rotations gives noisy results.
+ */
+function rotateClosedTargetForBestAlignment(
   srcSubpath: number[][],
   tgtSubpath: number[][],
 ): number[][] {
   const stride = 3;
   if (!isStrideClosedCubicSubpath(srcSubpath, stride)) return clonePoints(tgtSubpath);
   if (!isStrideClosedCubicSubpath(tgtSubpath, stride)) return clonePoints(tgtSubpath);
+  if (srcSubpath.length !== tgtSubpath.length) return clonePoints(tgtSubpath);
 
   const openLen = tgtSubpath.length - 1;
-  const shift = pickClosestAnchorShift(srcSubpath[0], tgtSubpath, stride);
-  if (shift === 0) return clonePoints(tgtSubpath);
+  const anchorCount = openLen / stride;
+  if (anchorCount <= 1) return clonePoints(tgtSubpath);
 
-  const rotatedOpen: number[][] = [];
-  for (let i = 0; i < openLen; i++) {
-    rotatedOpen.push([...(tgtSubpath[(i + shift) % openLen] ?? [0, 0, 0])]);
+  const tgtForward = tgtSubpath;
+  // Reversing a closed chain also rotates the start anchor — the reversed
+  // chain ends with what was the first anchor, so we re-roll it to the
+  // front to recover a canonical "anchor-first" closed form.
+  const tgtReversed = (() => {
+    const rev = reverseCubicChain(tgtSubpath);
+    // rev is closed too (first==last). It already starts with what was the
+    // last anchor of the original path; that's a valid starting anchor.
+    return rev;
+  })();
+
+  let bestSubpath = tgtForward;
+  let bestShift = 0;
+  let bestSsd = Infinity;
+  let bestReversed = false;
+
+  for (const candidate of [tgtForward, tgtReversed]) {
+    for (let ai = 0; ai < anchorCount; ai++) {
+      const shift = ai * stride;
+      const ssd = ssdForRotation(srcSubpath, candidate, shift, openLen, stride);
+      if (ssd < bestSsd) {
+        bestSsd = ssd;
+        bestShift = shift;
+        bestSubpath = candidate;
+        bestReversed = candidate === tgtReversed;
+      }
+    }
   }
-  rotatedOpen.push([...rotatedOpen[0]]);
-  return rotatedOpen;
+  void bestReversed;
+
+  return rotateClosedSubpath(bestSubpath, bestShift, openLen);
 }
 
 /** Equalize point counts by resampling the shorter subpath only. */
@@ -253,7 +423,7 @@ function alignSubpathPairPoints(
       ? resamplePointList3D(tgtSubpath, maxCount)
       : tgtSubpath.map((p) => [...p]);
 
-  const tgtAligned = rotateClosedTargetToClosestSourceAnchor(srcAligned, tgtAlignedRaw);
+  const tgtAligned = rotateClosedTargetForBestAlignment(srcAligned, tgtAlignedRaw);
 
   return { srcAligned, tgtAligned };
 }
@@ -306,6 +476,43 @@ function makeSignedChunks(
   }));
 }
 
+/**
+ * Find the anchor in `subpath` (a closed cubic chain whose anchors sit at
+ * stride-3 positions) that is closest in 3D to `target`. Returns the
+ * anchor's POINT, not its index, so callers can build a "collapse-to"
+ * reference cheaply. Falls back to the centroid if `subpath` lacks anchors.
+ */
+function closestAnchorPoint(subpath: number[][], target: number[]): number[] {
+  const stride = 3;
+  const openLen = Math.max(0, subpath.length - 1);
+  if (openLen <= 0 || openLen % stride !== 0) return computeCenter(subpath);
+
+  let bestIdx = 0;
+  let bestDist2 = Infinity;
+  for (let i = 0; i < openLen; i += stride) {
+    const p = subpath[i];
+    const dx = (p[0] ?? 0) - (target[0] ?? 0);
+    const dy = (p[1] ?? 0) - (target[1] ?? 0);
+    const dz = (p[2] ?? 0) - (target[2] ?? 0);
+    const d2 = dx * dx + dy * dy + dz * dz;
+    if (d2 < bestDist2) {
+      bestDist2 = d2;
+      bestIdx = i;
+    }
+  }
+  return [...(subpath[bestIdx] ?? [0, 0, 0])];
+}
+
+/**
+ * Align two lists of subpaths (within a single CW/CCW orientation bucket)
+ * by descending length. When one side has more subpaths than the other,
+ * the leftover subpath has no real partner — instead of collapsing it to
+ * its own side's centroid (a meaningless mid-shape point that produces a
+ * "floating phantom" mid-Transform), collapse to the closest anchor on the
+ * other side's PAIRED outer subpath. That makes the leftover hole appear
+ * to merge into the outer boundary at the most plausible feature on the
+ * other shape, avoiding chimeric mid-frames.
+ */
 function alignChunkListsByLength(
   srcChunks: Array<{ chunk: number[][]; len: number }>,
   tgtChunks: Array<{ chunk: number[][]; len: number }>,
@@ -319,12 +526,39 @@ function alignChunkListsByLength(
   const tgtSorted = [...tgtChunks].sort((a, b) => b.len - a.len);
   const maxSubpaths = Math.max(srcSorted.length, tgtSorted.length);
 
+  // The "outer" of each side, within this orientation bucket, is the
+  // longest subpath. When pairing leftovers we collapse them onto the
+  // other side's outer at the anchor closest to the leftover's centroid.
+  const srcOuter = srcSorted[0]?.chunk;
+  const tgtOuter = tgtSorted[0]?.chunk;
+
   for (let i = 0; i < maxSubpaths; i++) {
     const src = srcSorted[i]?.chunk;
     const tgt = tgtSorted[i]?.chunk;
 
-    const srcSub = src ?? makeNullSubpathFromReference(tgt!, tgtCenter);
-    const tgtSub = tgt ?? makeNullSubpathFromReference(src!, srcCenter);
+    let srcSub: number[][];
+    let tgtSub: number[][];
+
+    if (src && tgt) {
+      srcSub = src;
+      tgtSub = tgt;
+    } else if (tgt && !src) {
+      // Source-side leftover: tgt has a feature src lacks. Synthesise a
+      // src placeholder that LIVES at a plausible point on src's outer
+      // (closest anchor to the leftover tgt subpath's centroid, expressed
+      // in the same coordinate system).
+      const tgtCentroid = computeCenter(tgt);
+      const collapseTo = srcOuter ? closestAnchorPoint(srcOuter, tgtCentroid) : srcCenter;
+      srcSub = makeNullSubpathFromReference(tgt, collapseTo);
+      tgtSub = tgt;
+    } else {
+      // Target-side leftover (e.g. src "4" inner triangle, tgt "5" has no
+      // hole). Collapse this hole onto a point on tgt's outer.
+      const srcCentroid = computeCenter(src!);
+      const collapseTo = tgtOuter ? closestAnchorPoint(tgtOuter, srcCentroid) : tgtCenter;
+      srcSub = src!;
+      tgtSub = makeNullSubpathFromReference(src!, collapseTo);
+    }
 
     const { srcAligned, tgtAligned } = alignSubpathPairPoints(srcSub, tgtSub);
     srcAlignedAll.push(...srcAligned);

--- a/src/core/VMobjectTransformAlignment.ts
+++ b/src/core/VMobjectTransformAlignment.ts
@@ -454,49 +454,34 @@ function makeSignedChunks(
 }
 
 /**
- * Find the anchor in `subpath` (a closed cubic chain whose anchors sit at
- * stride-3 positions) that is closest in 3D to `target`. Returns the
- * anchor's POINT, not its index, so callers can build a "collapse-to"
- * reference cheaply. Falls back to the centroid if `subpath` lacks anchors.
- */
-function closestAnchorPoint(subpath: number[][], target: number[]): number[] {
-  const stride = 3;
-  const openLen = Math.max(0, subpath.length - 1);
-  if (openLen <= 0 || openLen % stride !== 0) return computeCenter(subpath);
-
-  let bestIdx = 0;
-  let bestDist2 = Infinity;
-  for (let i = 0; i < openLen; i += stride) {
-    const p = subpath[i];
-    const dx = (p[0] ?? 0) - (target[0] ?? 0);
-    const dy = (p[1] ?? 0) - (target[1] ?? 0);
-    const dz = (p[2] ?? 0) - (target[2] ?? 0);
-    const d2 = dx * dx + dy * dy + dz * dz;
-    if (d2 < bestDist2) {
-      bestDist2 = d2;
-      bestIdx = i;
-    }
-  }
-  return [...(subpath[bestIdx] ?? [0, 0, 0])];
-}
-
-/**
  * Align two lists of subpaths (within a single CW/CCW orientation bucket)
  * by descending length. When one side has more subpaths than the other,
- * the leftover subpath has no real partner — instead of collapsing it to
- * its own side's centroid (a meaningless mid-shape point that produces a
- * "floating phantom" mid-Transform), collapse to the closest anchor on the
- * other side's PAIRED outer subpath. That makes the leftover hole appear
- * to merge into the outer boundary at the most plausible feature on the
- * other shape, avoiding chimeric mid-frames.
+ * the leftover subpath has no real partner. We synthesise a placeholder
+ * for the missing side as a degenerate ring (every point equal) anchored
+ * at the LEFTOVER SUBPATH'S OWN CENTROID.
+ *
+ * Why the leftover's own centroid (and not, say, the side's overall
+ * centroid or a point on the other side's outer boundary):
+ *
+ * - It's the natural shrink-to / grow-from point. lerp(real_subpath,
+ *   degenerate_at_own_centroid, alpha) is the original subpath scaled
+ *   down by `1-alpha` toward its own centre. The feature appears to
+ *   grow/shrink in place at its real location instead of travelling.
+ * - For typical glyphs the leftover's centroid is well INSIDE the other
+ *   side's outer (e.g. inner-of-6's centroid is inside "5"; inner-of-4's
+ *   centroid is inside "5"), so the synthetic ring sits inside the
+ *   morphing outer at every alpha. That keeps the fill-geometry hole
+ *   classification stable.
+ * - It introduces no boundary numerics. An earlier version anchored the
+ *   placeholder on the OTHER side's outer boundary; for points on or
+ *   near the boundary, any per-frame point-in-polygon test trips on
+ *   floating-point fuzz, so the same subpath flips between "hole of
+ *   outer X" and "separate outer", which makes the rendered fill split
+ *   into disjoint pieces frame-to-frame (visible flicker).
  */
 function alignChunkListsByLength(
   srcChunks: Array<{ chunk: number[][]; len: number }>,
   tgtChunks: Array<{ chunk: number[][]; len: number }>,
-  srcGlobalOuter: number[][] | undefined,
-  tgtGlobalOuter: number[][] | undefined,
-  srcCenter: number[],
-  tgtCenter: number[],
   srcAlignedAll: number[][],
   tgtAlignedAll: number[][],
   alignedLengths: number[],
@@ -504,17 +489,6 @@ function alignChunkListsByLength(
   const srcSorted = [...srcChunks].sort((a, b) => b.len - a.len);
   const tgtSorted = [...tgtChunks].sort((a, b) => b.len - a.len);
   const maxSubpaths = Math.max(srcSorted.length, tgtSorted.length);
-
-  // Use the within-bucket outer when available, else fall back to the
-  // global outer (longest subpath of EITHER orientation). This matters
-  // for an orientation-only-on-one-side case: e.g. `5 -> 6`, where the
-  // CW bucket has src=[] tgt=[inner_6]. Without the global fallback the
-  // synthetic src would collapse to a meaningless mid-shape centroid; the
-  // global fallback makes it collapse to a real boundary anchor of the
-  // source's CCW outer instead, so the hole emerges from the boundary
-  // rather than eating through the body.
-  const srcOuter = srcSorted[0]?.chunk ?? srcGlobalOuter;
-  const tgtOuter = tgtSorted[0]?.chunk ?? tgtGlobalOuter;
 
   for (let i = 0; i < maxSubpaths; i++) {
     const src = srcSorted[i]?.chunk;
@@ -527,23 +501,17 @@ function alignChunkListsByLength(
       srcSub = src;
       tgtSub = tgt;
     } else if (tgt && !src) {
-      // Source-side leftover: tgt has a feature src lacks (e.g. inner
-      // triangle of "6" when source is "5"). Synthesise a src placeholder
-      // anchored at the point on the src outer closest to where this tgt
-      // feature will end up. At alpha=0 the hole "starts" tangent to
-      // src's outline (zero area, invisible) and grows toward its real
-      // position as alpha increases.
-      const tgtCentroid = computeCenter(tgt);
-      const collapseTo = srcOuter ? closestAnchorPoint(srcOuter, tgtCentroid) : srcCenter;
-      srcSub = makeNullSubpathFromReference(tgt, collapseTo);
+      // Source-side leftover (e.g. inner of "6" when src is "5"):
+      // synthesise a degenerate src at tgt's own centroid so the
+      // feature grows in place at its target location.
+      srcSub = makeNullSubpathFromReference(tgt, computeCenter(tgt));
       tgtSub = tgt;
     } else {
-      // Target-side leftover (e.g. src "4" inner triangle, tgt "5" has no
-      // hole). Collapse this hole onto a point on tgt's outer.
-      const srcCentroid = computeCenter(src!);
-      const collapseTo = tgtOuter ? closestAnchorPoint(tgtOuter, srcCentroid) : tgtCenter;
+      // Target-side leftover (e.g. inner of "4" when tgt is "5"):
+      // synthesise a degenerate tgt at src's own centroid so the
+      // feature shrinks in place at its source location.
       srcSub = src!;
-      tgtSub = makeNullSubpathFromReference(src!, collapseTo);
+      tgtSub = makeNullSubpathFromReference(src!, computeCenter(src!));
     }
 
     const { srcAligned, tgtAligned } = alignSubpathPairPoints(srcSub, tgtSub);
@@ -551,15 +519,6 @@ function alignChunkListsByLength(
     tgtAlignedAll.push(...tgtAligned);
     alignedLengths.push(srcAligned.length);
   }
-}
-
-/** Longest subpath chunk across all signs, for cross-bucket fallbacks. */
-function pickGlobalOuter(chunks: SignedSubpathChunk[]): number[][] | undefined {
-  let best: SignedSubpathChunk | undefined;
-  for (const c of chunks) {
-    if (!best || c.len > best.len) best = c;
-  }
-  return best?.chunk;
 }
 
 /**
@@ -592,9 +551,6 @@ export function alignCompoundPathsForTransform(
     return null;
   }
 
-  const srcCenter = computeCenter(srcPoints3D);
-  const tgtCenter = computeCenter(tgtPoints3D);
-
   const srcAlignedAll: number[][] = [];
   const tgtAlignedAll: number[][] = [];
   const alignedLengths: number[] = [];
@@ -602,16 +558,9 @@ export function alignCompoundPathsForTransform(
   const srcChunks = makeSignedChunks(srcPoints3D, srcLengths, srcSigns);
   const tgtChunks = makeSignedChunks(tgtPoints3D, tgtLengths, tgtSigns);
 
-  const srcGlobalOuter = pickGlobalOuter(srcChunks);
-  const tgtGlobalOuter = pickGlobalOuter(tgtChunks);
-
   alignChunkListsByLength(
     srcChunks.filter((c) => c.sign === -1),
     tgtChunks.filter((c) => c.sign === -1),
-    srcGlobalOuter,
-    tgtGlobalOuter,
-    srcCenter,
-    tgtCenter,
     srcAlignedAll,
     tgtAlignedAll,
     alignedLengths,
@@ -619,10 +568,6 @@ export function alignCompoundPathsForTransform(
   alignChunkListsByLength(
     srcChunks.filter((c) => c.sign === 1),
     tgtChunks.filter((c) => c.sign === 1),
-    srcGlobalOuter,
-    tgtGlobalOuter,
-    srcCenter,
-    tgtCenter,
     srcAlignedAll,
     tgtAlignedAll,
     alignedLengths,

--- a/src/core/VMobjectTransformAlignment.ts
+++ b/src/core/VMobjectTransformAlignment.ts
@@ -45,23 +45,27 @@ export function resamplePointList3D(points: number[][], targetCount: number): nu
     return [[...(points[0] ?? [0, 0, 0])]];
   }
 
-  if (points.length === targetCount) {
-    return points.map((p) => [...p]);
-  }
-
   if (points.length === 1) {
     return Array.from({ length: targetCount }, () => [...points[0]]);
   }
 
   if (isCubicBezierChain(points) && targetCount >= 4 && (targetCount - 1) % 3 === 0) {
-    const currentCurveCount = (points.length - 1) / 3;
+    // Always re-parameterise cubic chains to arc-length-uniform anchors,
+    // including when targetCount === points.length. Without this the
+    // pairing in `Transform` keeps whatever non-uniform anchor distribution
+    // the input data happened to have (e.g. MathJax bezier output puts
+    // more anchors near corners), so anchor `i` of source and anchor `i`
+    // of target correspond to different fractions of perimeter, and
+    // mid-frames lerp non-corresponding features into chimeric shapes.
     const targetCurveCount = (targetCount - 1) / 3;
-    if (targetCurveCount >= currentCurveCount) {
-      const remapped = remapBezierCurveCount(points, targetCurveCount);
-      if (remapped.length === targetCount) {
-        return remapped;
-      }
+    const remapped = arcLengthResampleCubicChain(points, targetCurveCount);
+    if (remapped.length === targetCount) {
+      return remapped;
     }
+  }
+
+  if (points.length === targetCount) {
+    return points.map((p) => [...p]);
   }
 
   // Fallback for non-cubic or malformed point arrays.
@@ -163,117 +167,150 @@ function tForArcLength(
 }
 
 /**
- * Subdivide a single cubic Bezier curve into `parts` sub-curves whose
- * sub-curve arc lengths are equal. Uses a per-curve cumulative arc length
- * table; each sub-curve is exact (de Casteljau-style hodograph trick).
+ * Resample a cubic Bezier chain to `newCurveCount` cubics whose anchor
+ * positions lie at arc-length-uniform fractions of the original chain's
+ * total perimeter. Works at any count (including same-as-input).
  *
- * Equal-arc-length splits matter for `Transform`: the i-th anchor of the
- * resampled chain ends up at fraction `i/N` of the source's perimeter
- * rather than fraction `i/N` of an arbitrary `t` parameterisation. That
- * keeps "feature at t≈k" of one shape paired with "feature at t≈k" of the
- * other, which is what makes mid-frames look smooth instead of chimeric.
+ * Why this matters: the `Transform` lerps anchor i of source with anchor
+ * i of target. If anchor i represents a meaningful path-fraction of each
+ * shape (e.g. "~30% around the perimeter"), the lerp pairs corresponding
+ * features and the morph blends smoothly. Without arc-length
+ * re-parameterisation, anchor i represents whatever fraction the upstream
+ * source data (e.g. MathJax) chose to place anchor i at, so anchor i of
+ * "2" might be at the top of the glyph while anchor i of "3" might be at
+ * the side, and the lerp creates a chimeric mid-frame.
+ *
+ * Where new sub-cubics fall entirely within a single original cubic the
+ * result is exact (de Casteljau hodograph subdivision). Where a new
+ * sub-cubic spans multiple original cubics, we approximate via the
+ * standard chord-length-tangent cubic (start/end positions and unit
+ * tangents, handles at chord/3). This approximation is close to the
+ * original path for typical glyph shapes and preserves G1 continuity at
+ * each new anchor.
  */
-function subdivideCubicCurve(curve: number[][], parts: number): number[][][] {
-  const p0 = curve[0];
-  const p1 = curve[1];
-  const p2 = curve[2];
-  const p3 = curve[3];
-
-  if (parts <= 1) {
-    return [[[...p0], [...p1], [...p2], [...p3]]];
-  }
-
-  const table = buildArcLengthTable(p0, p1, p2, p3, Math.max(16, parts * 4));
-  const tValues = new Array<number>(parts + 1);
-  tValues[0] = 0;
-  tValues[parts] = 1;
-  for (let i = 1; i < parts; i++) {
-    tValues[i] = table.total > 0 ? tForArcLength(table, (i / parts) * table.total) : i / parts;
-  }
-
-  const out: number[][][] = [];
-  for (let i = 0; i < parts; i++) {
-    const t0 = tValues[i];
-    const t1 = tValues[i + 1];
-    const dt = t1 - t0;
-
-    const q0 = evalCubicBezier(p0, p1, p2, p3, t0);
-    const q3 = evalCubicBezier(p0, p1, p2, p3, t1);
-    const d0 = evalCubicDerivative(p0, p1, p2, p3, t0);
-    const d1 = evalCubicDerivative(p0, p1, p2, p3, t1);
-
-    const q1 = q0.map((v, k) => v + (dt / 3) * (d0[k] ?? 0));
-    const q2 = q3.map((v, k) => v - (dt / 3) * (d1[k] ?? 0));
-
-    out.push([q0, q1, q2, q3]);
-  }
-
-  return out;
+interface ChainArcInfo {
+  curves: number[][][];
+  tables: ReturnType<typeof buildArcLengthTable>[];
+  cumulative: number[];
+  totalLen: number;
 }
 
-/**
- * Distribute `extra` extra splits across `n` curves whose arc lengths are
- * `lengths`. Each curve must receive at least 1 split (so the total is
- * `n + extra = newCurveCount`). The extra splits are allocated proportional
- * to arc length using a largest-residual rounding scheme.
- */
-function allocateSplitsByArcLength(lengths: number[], newCurveCount: number): number[] {
-  const n = lengths.length;
-  if (n === 0) return [];
-  if (newCurveCount <= n) return new Array(n).fill(1);
-
-  const total = lengths.reduce((s, l) => s + l, 0);
-  const splits = new Array<number>(n).fill(1);
-  const extra = newCurveCount - n;
-
-  if (total <= 0) {
-    // All curves degenerate — distribute evenly.
-    for (let i = 0; i < extra; i++) splits[i % n] += 1;
-    return splits;
-  }
-
-  const desired = lengths.map((len) => (len / total) * extra);
-  const floored = desired.map((d) => Math.floor(d));
-  let assigned = floored.reduce((s, x) => s + x, 0);
-  for (let i = 0; i < n; i++) splits[i] += floored[i];
-
-  // Distribute the remaining `extra - assigned` splits to curves with the
-  // largest fractional residual, breaking ties by index for determinism.
-  const residuals = desired.map((d, i) => ({ i, residual: d - floored[i] }));
-  residuals.sort((a, b) => b.residual - a.residual || a.i - b.i);
-  for (let j = 0; assigned < extra; j++, assigned++) {
-    splits[residuals[j].i] += 1;
-  }
-  return splits;
-}
-
-function remapBezierCurveCount(points: number[][], newCurveCount: number): number[][] {
-  const currentCurveCount = (points.length - 1) / 3;
-  if (!Number.isInteger(currentCurveCount) || currentCurveCount <= 0) {
-    return points.map((p) => [...p]);
-  }
-  if (newCurveCount <= currentCurveCount) {
-    return points.map((p) => [...p]);
-  }
-
+/** Build per-curve arc-length tables and chain-wide cumulative table. */
+function buildChainArcInfo(points: number[][]): ChainArcInfo {
   const curves: number[][][] = [];
-  const lengths: number[] = [];
+  const tables: ReturnType<typeof buildArcLengthTable>[] = [];
+  const cumulative: number[] = [0];
+  let totalLen = 0;
   for (let i = 0; i + 3 < points.length; i += 3) {
     const curve: number[][] = [points[i], points[i + 1], points[i + 2], points[i + 3]];
     curves.push(curve);
-    lengths.push(buildArcLengthTable(curve[0], curve[1], curve[2], curve[3], 16).total);
+    const table = buildArcLengthTable(curve[0], curve[1], curve[2], curve[3], 32);
+    tables.push(table);
+    totalLen += table.total;
+    cumulative.push(totalLen);
+  }
+  return { curves, tables, cumulative, totalLen };
+}
+
+/** Locate `(curveIdx, localT)` for an absolute arc-length on a chain. */
+function locateOnChain(info: ChainArcInfo, arc: number): { curveIdx: number; t: number } {
+  if (arc <= 0) return { curveIdx: 0, t: 0 };
+  if (arc >= info.totalLen) return { curveIdx: info.curves.length - 1, t: 1 };
+  let lo = 0;
+  let hi = info.cumulative.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (info.cumulative[mid] < arc) lo = mid + 1;
+    else hi = mid;
+  }
+  const curveIdx = Math.max(0, lo - 1);
+  const localArc = arc - info.cumulative[curveIdx];
+  return { curveIdx, t: tForArcLength(info.tables[curveIdx], localArc) };
+}
+
+/** Build a degenerate cubic chain consisting of `newCurveCount` zero-length pieces. */
+function makeDegenerateChain(point: number[], newCurveCount: number): number[][] {
+  const out: number[][] = [[...point]];
+  for (let i = 0; i < newCurveCount; i++) out.push([...point], [...point], [...point]);
+  return out;
+}
+
+/** Compute unit tangent at `(curveIdx, t)` of an original chain. */
+function unitTangentAt(curve: number[][], t: number): number[] {
+  const d = evalCubicDerivative(curve[0], curve[1], curve[2], curve[3], t);
+  const dlen = Math.hypot(d[0] ?? 0, d[1] ?? 0, d[2] ?? 0);
+  if (dlen < 1e-12) return d.map(() => 0);
+  return d.map((v) => v / dlen);
+}
+
+/**
+ * Build one new sub-cubic between adjacent anchors. Exact (de Casteljau
+ * hodograph) when the sub-cubic falls entirely within one original cubic;
+ * chord-tangent approximation when it spans original cubic boundaries.
+ */
+function buildSubCubic(
+  info: ChainArcInfo,
+  startAnchor: number[],
+  endAnchor: number[],
+  startTangent: number[],
+  endTangent: number[],
+  sLoc: { curveIdx: number; t: number },
+  eLoc: { curveIdx: number; t: number },
+): { h1: number[]; h2: number[] } {
+  if (sLoc.curveIdx === eLoc.curveIdx) {
+    const c = info.curves[sLoc.curveIdx];
+    const dt = eLoc.t - sLoc.t;
+    const d0 = evalCubicDerivative(c[0], c[1], c[2], c[3], sLoc.t);
+    const d1 = evalCubicDerivative(c[0], c[1], c[2], c[3], eLoc.t);
+    return {
+      h1: startAnchor.map((v, k) => v + (dt / 3) * (d0[k] ?? 0)),
+      h2: endAnchor.map((v, k) => v - (dt / 3) * (d1[k] ?? 0)),
+    };
+  }
+  const dx = (endAnchor[0] ?? 0) - (startAnchor[0] ?? 0);
+  const dy = (endAnchor[1] ?? 0) - (startAnchor[1] ?? 0);
+  const dz = (endAnchor[2] ?? 0) - (startAnchor[2] ?? 0);
+  const k = Math.sqrt(dx * dx + dy * dy + dz * dz) / 3;
+  return {
+    h1: startAnchor.map((v, j) => v + k * (startTangent[j] ?? 0)),
+    h2: endAnchor.map((v, j) => v - k * (endTangent[j] ?? 0)),
+  };
+}
+
+function arcLengthResampleCubicChain(points: number[][], newCurveCount: number): number[][] {
+  const currentCurveCount = (points.length - 1) / 3;
+  if (!Number.isInteger(currentCurveCount) || currentCurveCount <= 0 || newCurveCount <= 0) {
+    return points.map((p) => [...p]);
   }
 
-  const splitFactors = allocateSplitsByArcLength(lengths, newCurveCount);
+  const info = buildChainArcInfo(points);
+  if (info.totalLen <= 0) return makeDegenerateChain(points[0], newCurveCount);
 
-  const out: number[][] = [];
-  for (let i = 0; i < curves.length; i++) {
-    const pieces = subdivideCubicCurve(curves[i], splitFactors[i]);
-    for (let j = 0; j < pieces.length; j++) {
-      const piece = pieces[j];
-      if (out.length === 0) out.push([...piece[0]]);
-      out.push([...piece[1]], [...piece[2]], [...piece[3]]);
-    }
+  // Anchor positions and unit tangents at each new arc-length-uniform anchor.
+  const anchors: number[][] = [];
+  const tangents: number[][] = [];
+  for (let i = 0; i <= newCurveCount; i++) {
+    const arcAt = (i / newCurveCount) * info.totalLen;
+    const loc = locateOnChain(info, arcAt);
+    const c = info.curves[loc.curveIdx];
+    anchors.push(evalCubicBezier(c[0], c[1], c[2], c[3], loc.t));
+    tangents.push(unitTangentAt(c, loc.t));
+  }
+
+  const out: number[][] = [[...anchors[0]]];
+  for (let i = 0; i < newCurveCount; i++) {
+    const sLoc = locateOnChain(info, (i / newCurveCount) * info.totalLen);
+    const eLoc = locateOnChain(info, ((i + 1) / newCurveCount) * info.totalLen);
+    const { h1, h2 } = buildSubCubic(
+      info,
+      anchors[i],
+      anchors[i + 1],
+      tangents[i],
+      tangents[i + 1],
+      sLoc,
+      eLoc,
+    );
+    out.push(h1, h2, [...anchors[i + 1]]);
   }
 
   return out;

--- a/src/core/VMobjectTransformAlignment.ts
+++ b/src/core/VMobjectTransformAlignment.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { evalCubicBezier, lerpPoint as lerpPoint3D, signedArea2DFromStride } from '../utils/math';
 
 export interface CompoundAlignmentResult {
@@ -284,7 +285,13 @@ function arcLengthResampleCubicChain(points: number[][], newCurveCount: number):
   }
 
   const info = buildChainArcInfo(points);
-  if (info.totalLen <= 0) return makeDegenerateChain(points[0], newCurveCount);
+  // A degenerate "all points coincide" chain has total perimeter zero in
+  // exact arithmetic; under floating point it picks up ULP noise (~1e-14)
+  // from evaluating the polynomial at non-zero `t`, so we use a small
+  // epsilon to guarantee we return an exact constant chain rather than
+  // walk the noise through arc-length sampling and re-emit slightly
+  // different points at each anchor.
+  if (info.totalLen < 1e-9) return makeDegenerateChain(points[0], newCurveCount);
 
   // Anchor positions and unit tangents at each new arc-length-uniform anchor.
   const anchors: number[][] = [];
@@ -422,24 +429,307 @@ function rotateClosedTargetForBestAlignment(
   return rotateClosedSubpath(tgtSubpath, bestShift, openLen);
 }
 
-/** Equalize point counts by resampling the shorter subpath only. */
+/**
+ * Resample a cubic Bezier chain so its anchor positions land at the
+ * specified arc-length values (instead of arc-length-uniform). Used to
+ * realise an "OT-warped" target: each new anchor sits where the optimal
+ * monotonic correspondence places it relative to the source. Adjacent
+ * anchors that map to the same arc position produce a degenerate
+ * zero-length sub-cubic, which renders as nothing — that's the natural
+ * way DTW expresses "this source anchor doesn't have a corresponding
+ * target anchor moving with it".
+ */
+function resampleCubicChainAtArcs(points: number[][], arcPositions: number[]): number[][] {
+  if (arcPositions.length < 2) return points.map((p) => [...p]);
+  const newCurveCount = arcPositions.length - 1;
+  const currentCurveCount = (points.length - 1) / 3;
+  if (!Number.isInteger(currentCurveCount) || currentCurveCount <= 0) {
+    return points.map((p) => [...p]);
+  }
+  const info = buildChainArcInfo(points);
+  if (info.totalLen <= 0) return makeDegenerateChain(points[0], newCurveCount);
+
+  const anchors: number[][] = [];
+  const tangents: number[][] = [];
+  const locs: { curveIdx: number; t: number }[] = [];
+  for (const arc of arcPositions) {
+    const loc = locateOnChain(info, Math.max(0, Math.min(info.totalLen, arc)));
+    locs.push(loc);
+    const c = info.curves[loc.curveIdx];
+    anchors.push(evalCubicBezier(c[0], c[1], c[2], c[3], loc.t));
+    tangents.push(unitTangentAt(c, loc.t));
+  }
+
+  const out: number[][] = [[...anchors[0]]];
+  for (let i = 0; i < newCurveCount; i++) {
+    const { h1, h2 } = buildSubCubic(
+      info,
+      anchors[i],
+      anchors[i + 1],
+      tangents[i],
+      tangents[i + 1],
+      locs[i],
+      locs[i + 1],
+    );
+    out.push(h1, h2, [...anchors[i + 1]]);
+  }
+  return out;
+}
+
+/**
+ * Run cyclic Dynamic-Time-Warping on two equal-length anchor sequences.
+ * For each cyclic shift `s` of the target, finds the monotonic warping
+ * path between source and shifted target that minimises total squared
+ * distance, then picks the best shift. Returns, for each source anchor
+ * index, the (possibly warped) target anchor index it pairs with.
+ *
+ * Why DTW over plain rotation: rotation is equivalent to choosing a
+ * single cyclic offset and then forcing a 1:1 monotonic bijection. DTW
+ * keeps the monotonic constraint but lets some source anchors "linger"
+ * on the same target index (or vice versa) — i.e. it stretches and
+ * compresses regions of one path against the other to align corresponding
+ * features. For glyph pairs whose features don't naturally fall at the
+ * same arc-length fractions (e.g. MathTex `2` vs `3`), this gives a
+ * substantially smoother visual morph than pure rotation.
+ */
+// eslint-disable-next-line complexity
+function dtwCyclicCorrespondence(srcAnchors: number[][], tgtAnchors: number[][]): number[] {
+  const N = srcAnchors.length;
+  const M = tgtAnchors.length;
+  if (N === 0 || M === 0) return [];
+  if (N === 1) return [0];
+
+  let bestCost = Infinity;
+  let bestSrcToTgt = new Array<number>(N).fill(0);
+
+  // O(N) per shift × O(N·M) DP per shift × O(N) shifts = O(N²·M).
+  // Acceptable at Transform begin for typical N, M ≤ ~60.
+  // Use Float64Array DP table reused across shifts to limit allocation.
+  const dp = new Float64Array((N + 1) * (M + 1));
+  const back = new Uint8Array((N + 1) * (M + 1));
+  const idx = (i: number, j: number) => i * (M + 1) + j;
+
+  for (let shift = 0; shift < M; shift++) {
+    dp.fill(Infinity);
+    dp[idx(0, 0)] = 0;
+    for (let i = 1; i <= N; i++) {
+      const sp = srcAnchors[i - 1];
+      for (let j = 1; j <= M; j++) {
+        const tp = tgtAnchors[(j - 1 + shift) % M];
+        const dx = sp[0] - tp[0];
+        const dy = sp[1] - tp[1];
+        const dz = (sp[2] ?? 0) - (tp[2] ?? 0);
+        const cost = dx * dx + dy * dy + dz * dz;
+        const a = dp[idx(i - 1, j - 1)];
+        const b = dp[idx(i - 1, j)];
+        const c = dp[idx(i, j - 1)];
+        let mv = a;
+        let mi: 0 | 1 | 2 = 0;
+        if (b < mv) {
+          mv = b;
+          mi = 1;
+        }
+        if (c < mv) {
+          mv = c;
+          mi = 2;
+        }
+        dp[idx(i, j)] = cost + mv;
+        back[idx(i, j)] = mi;
+      }
+    }
+
+    const total = dp[idx(N, M)];
+    if (total >= bestCost) continue;
+
+    // Backtrack: collect (i, j) pairs.
+    const pairs: [number, number][] = [];
+    let i = N;
+    let j = M;
+    while (i > 0 && j > 0) {
+      pairs.push([i - 1, (j - 1 + shift) % M]);
+      const dir = back[idx(i, j)];
+      if (dir === 0) {
+        i--;
+        j--;
+      } else if (dir === 1) {
+        i--;
+      } else {
+        j--;
+      }
+    }
+    pairs.reverse();
+
+    // Collapse pairs to a per-source target index using the median tgt
+    // among all tgts paired with each src — preserves monotonicity since
+    // DTW pairs are monotone, and the median of a monotonic-prefix is
+    // monotone in src.
+    const buckets: number[][] = Array.from({ length: N }, () => []);
+    for (const [si, ti] of pairs) buckets[si].push(ti);
+    const srcToTgt = buckets.map((b, s) => {
+      if (b.length === 0) return s % M;
+      b.sort((p, q) => p - q);
+      return b[(b.length - 1) >> 1];
+    });
+
+    bestCost = total;
+    bestSrcToTgt = srcToTgt;
+  }
+
+  return bestSrcToTgt;
+}
+
+/**
+ * Pair two cubic-Bezier subpaths by:
+ *   1. Resampling each side to a shared arc-length-uniform anchor count.
+ *   2. Running cyclic DTW between the two anchor sequences to find the
+ *      monotonic correspondence that minimises total per-anchor displacement.
+ *   3. Re-resampling the target chain with anchors placed at the warped
+ *      arc-length positions chosen by DTW.
+ *
+ * Result: equal-length cubic chains whose anchor `i` pairs source feature
+ * `i` with the target feature DTW judged most similar — instead of forcing
+ * a single uniform cyclic offset across the whole shape.
+ */
+// eslint-disable-next-line complexity
 function alignSubpathPairPoints(
   srcSubpath: number[][],
   tgtSubpath: number[][],
 ): { srcAligned: number[][]; tgtAligned: number[][] } {
   const maxCount = Math.max(srcSubpath.length, tgtSubpath.length);
+
+  // Resample both sides to the same uniform arc-length parameterisation.
   const srcAligned =
     srcSubpath.length < maxCount
       ? resamplePointList3D(srcSubpath, maxCount)
-      : srcSubpath.map((p) => [...p]);
-  const tgtAlignedRaw =
+      : resamplePointList3D(srcSubpath, srcSubpath.length);
+  const tgtUniform =
     tgtSubpath.length < maxCount
       ? resamplePointList3D(tgtSubpath, maxCount)
-      : tgtSubpath.map((p) => [...p]);
+      : resamplePointList3D(tgtSubpath, tgtSubpath.length);
 
-  const tgtAligned = rotateClosedTargetForBestAlignment(srcAligned, tgtAlignedRaw);
+  // Only meaningful for stride-3 closed cubic chains. For anything else
+  // fall back to rotation-only alignment.
+  const stride = 3;
+  if (
+    !isStrideClosedCubicSubpath(srcAligned, stride) ||
+    !isStrideClosedCubicSubpath(tgtUniform, stride) ||
+    srcAligned.length !== tgtUniform.length
+  ) {
+    return {
+      srcAligned,
+      tgtAligned: rotateClosedTargetForBestAlignment(srcAligned, tgtUniform),
+    };
+  }
 
-  return { srcAligned, tgtAligned };
+  const openLen = srcAligned.length - 1;
+  const anchorCount = openLen / stride;
+  if (anchorCount < 4) {
+    return {
+      srcAligned,
+      tgtAligned: rotateClosedTargetForBestAlignment(srcAligned, tgtUniform),
+    };
+  }
+
+  // Extract just the anchors (every stride-th point) from both sides.
+  const srcAnchors: number[][] = [];
+  const tgtAnchors: number[][] = [];
+  for (let i = 0; i < openLen; i += stride) {
+    srcAnchors.push(srcAligned[i]);
+    tgtAnchors.push(tgtUniform[i]);
+  }
+
+  // DTW correspondence: for each src anchor i, the warped tgt anchor.
+  const srcToTgt = dtwCyclicCorrespondence(srcAnchors, tgtAnchors);
+
+  // Compute total target perimeter so we can express the warped tgt
+  // anchors as arc-length positions on the original target chain. The
+  // threshold is `1e-9`, not exactly zero, because evaluating a chain of
+  // degenerate (zero-length) cubics through floating-point math
+  // accumulates noise that comes out as ~1e-14 instead of 0; treating
+  // that noise as a non-degenerate perimeter would re-sample a synthetic
+  // null subpath into points that drift off the centroid by a few ulps,
+  // breaking the "synthetic = constant" invariant downstream callers rely
+  // on (placeholder fades, hole-collapse rendering, etc.).
+  const tgtInfo = buildChainArcInfo(tgtSubpath);
+  if (tgtInfo.totalLen < 1e-9) {
+    return {
+      srcAligned,
+      tgtAligned: rotateClosedTargetForBestAlignment(srcAligned, tgtUniform),
+    };
+  }
+
+  // Warped arc positions. Anchor 0 is whatever DTW picked; we walk the
+  // target perimeter monotonically and unwrap cyclic wraparounds (i.e. if
+  // the next chosen index wraps under the previous one, we treat it as
+  // "+M after" instead of "before").
+  const warpedAnchorArcs: number[] = [];
+  let prevIdx = srcToTgt[0];
+  let cumulativeIdx = prevIdx;
+  warpedAnchorArcs.push((prevIdx / anchorCount) * tgtInfo.totalLen);
+  for (let i = 1; i < anchorCount; i++) {
+    const cur = srcToTgt[i];
+    let unwrap = cur;
+    while (unwrap < prevIdx) unwrap += anchorCount;
+    cumulativeIdx += unwrap - prevIdx;
+    warpedAnchorArcs.push((cumulativeIdx / anchorCount) * tgtInfo.totalLen);
+    prevIdx = unwrap % anchorCount;
+  }
+  // Close the loop by returning to anchor 0 + one full perimeter.
+  warpedAnchorArcs.push(warpedAnchorArcs[0] + tgtInfo.totalLen);
+
+  // Each consecutive arc position must remain within [first, first+L]; if
+  // total drift exceeded one full loop we collapse extras (defensive).
+  for (let i = 1; i < warpedAnchorArcs.length; i++) {
+    if (warpedAnchorArcs[i] < warpedAnchorArcs[i - 1]) {
+      warpedAnchorArcs[i] = warpedAnchorArcs[i - 1];
+    }
+  }
+  const span = warpedAnchorArcs[warpedAnchorArcs.length - 1] - warpedAnchorArcs[0];
+  if (span > 1.5 * tgtInfo.totalLen || span < 0.5 * tgtInfo.totalLen) {
+    // DTW produced a degenerate warping (more than one full loop or less
+    // than half a loop). Fall back to rotation-only alignment, which is
+    // always sensible for closed curves.
+    return {
+      srcAligned,
+      tgtAligned: rotateClosedTargetForBestAlignment(srcAligned, tgtUniform),
+    };
+  }
+
+  // Re-resample tgt with anchors placed at the warped arc positions.
+  // We work modulo the target perimeter so wraparound positions land on
+  // the actual chain.
+  const wrappedArcs = warpedAnchorArcs.map((a) => {
+    let v = a % tgtInfo.totalLen;
+    if (v < 0) v += tgtInfo.totalLen;
+    return v;
+  });
+  // For monotonic resample we need positions in non-decreasing order.
+  // Re-cumulate after the wrap so the resampler can interpret them as a
+  // single sweep around the loop, possibly across the seam.
+  const splitArcs = unwrapArcCycle(wrappedArcs, tgtInfo.totalLen);
+  const tgtWarped = resampleCubicChainAtArcs(tgtSubpath, splitArcs);
+
+  if (tgtWarped.length !== srcAligned.length) {
+    return {
+      srcAligned,
+      tgtAligned: rotateClosedTargetForBestAlignment(srcAligned, tgtUniform),
+    };
+  }
+
+  return { srcAligned, tgtAligned: tgtWarped };
+}
+
+/**
+ * Unwrap a cyclic sequence of arc positions into a monotonic non-decreasing
+ * one by adding the perimeter length wherever the next position appears to
+ * have looped back.
+ */
+function unwrapArcCycle(arcs: number[], perimeter: number): number[] {
+  const out = arcs.slice();
+  for (let i = 1; i < out.length; i++) {
+    while (out[i] < out[i - 1]) out[i] += perimeter;
+  }
+  return out;
 }
 
 /** Compute center of all points in array. */

--- a/src/core/VMobjectTransformAlignment.ts
+++ b/src/core/VMobjectTransformAlignment.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { evalCubicBezier, lerpPoint as lerpPoint3D, signedArea2DFromStride } from '../utils/math';
 
 export interface CompoundAlignmentResult {
@@ -285,13 +284,7 @@ function arcLengthResampleCubicChain(points: number[][], newCurveCount: number):
   }
 
   const info = buildChainArcInfo(points);
-  // A degenerate "all points coincide" chain has total perimeter zero in
-  // exact arithmetic; under floating point it picks up ULP noise (~1e-14)
-  // from evaluating the polynomial at non-zero `t`, so we use a small
-  // epsilon to guarantee we return an exact constant chain rather than
-  // walk the noise through arc-length sampling and re-emit slightly
-  // different points at each anchor.
-  if (info.totalLen < 1e-9) return makeDegenerateChain(points[0], newCurveCount);
+  if (info.totalLen <= 0) return makeDegenerateChain(points[0], newCurveCount);
 
   // Anchor positions and unit tangents at each new arc-length-uniform anchor.
   const anchors: number[][] = [];
@@ -429,307 +422,24 @@ function rotateClosedTargetForBestAlignment(
   return rotateClosedSubpath(tgtSubpath, bestShift, openLen);
 }
 
-/**
- * Resample a cubic Bezier chain so its anchor positions land at the
- * specified arc-length values (instead of arc-length-uniform). Used to
- * realise an "OT-warped" target: each new anchor sits where the optimal
- * monotonic correspondence places it relative to the source. Adjacent
- * anchors that map to the same arc position produce a degenerate
- * zero-length sub-cubic, which renders as nothing — that's the natural
- * way DTW expresses "this source anchor doesn't have a corresponding
- * target anchor moving with it".
- */
-function resampleCubicChainAtArcs(points: number[][], arcPositions: number[]): number[][] {
-  if (arcPositions.length < 2) return points.map((p) => [...p]);
-  const newCurveCount = arcPositions.length - 1;
-  const currentCurveCount = (points.length - 1) / 3;
-  if (!Number.isInteger(currentCurveCount) || currentCurveCount <= 0) {
-    return points.map((p) => [...p]);
-  }
-  const info = buildChainArcInfo(points);
-  if (info.totalLen <= 0) return makeDegenerateChain(points[0], newCurveCount);
-
-  const anchors: number[][] = [];
-  const tangents: number[][] = [];
-  const locs: { curveIdx: number; t: number }[] = [];
-  for (const arc of arcPositions) {
-    const loc = locateOnChain(info, Math.max(0, Math.min(info.totalLen, arc)));
-    locs.push(loc);
-    const c = info.curves[loc.curveIdx];
-    anchors.push(evalCubicBezier(c[0], c[1], c[2], c[3], loc.t));
-    tangents.push(unitTangentAt(c, loc.t));
-  }
-
-  const out: number[][] = [[...anchors[0]]];
-  for (let i = 0; i < newCurveCount; i++) {
-    const { h1, h2 } = buildSubCubic(
-      info,
-      anchors[i],
-      anchors[i + 1],
-      tangents[i],
-      tangents[i + 1],
-      locs[i],
-      locs[i + 1],
-    );
-    out.push(h1, h2, [...anchors[i + 1]]);
-  }
-  return out;
-}
-
-/**
- * Run cyclic Dynamic-Time-Warping on two equal-length anchor sequences.
- * For each cyclic shift `s` of the target, finds the monotonic warping
- * path between source and shifted target that minimises total squared
- * distance, then picks the best shift. Returns, for each source anchor
- * index, the (possibly warped) target anchor index it pairs with.
- *
- * Why DTW over plain rotation: rotation is equivalent to choosing a
- * single cyclic offset and then forcing a 1:1 monotonic bijection. DTW
- * keeps the monotonic constraint but lets some source anchors "linger"
- * on the same target index (or vice versa) — i.e. it stretches and
- * compresses regions of one path against the other to align corresponding
- * features. For glyph pairs whose features don't naturally fall at the
- * same arc-length fractions (e.g. MathTex `2` vs `3`), this gives a
- * substantially smoother visual morph than pure rotation.
- */
-// eslint-disable-next-line complexity
-function dtwCyclicCorrespondence(srcAnchors: number[][], tgtAnchors: number[][]): number[] {
-  const N = srcAnchors.length;
-  const M = tgtAnchors.length;
-  if (N === 0 || M === 0) return [];
-  if (N === 1) return [0];
-
-  let bestCost = Infinity;
-  let bestSrcToTgt = new Array<number>(N).fill(0);
-
-  // O(N) per shift × O(N·M) DP per shift × O(N) shifts = O(N²·M).
-  // Acceptable at Transform begin for typical N, M ≤ ~60.
-  // Use Float64Array DP table reused across shifts to limit allocation.
-  const dp = new Float64Array((N + 1) * (M + 1));
-  const back = new Uint8Array((N + 1) * (M + 1));
-  const idx = (i: number, j: number) => i * (M + 1) + j;
-
-  for (let shift = 0; shift < M; shift++) {
-    dp.fill(Infinity);
-    dp[idx(0, 0)] = 0;
-    for (let i = 1; i <= N; i++) {
-      const sp = srcAnchors[i - 1];
-      for (let j = 1; j <= M; j++) {
-        const tp = tgtAnchors[(j - 1 + shift) % M];
-        const dx = sp[0] - tp[0];
-        const dy = sp[1] - tp[1];
-        const dz = (sp[2] ?? 0) - (tp[2] ?? 0);
-        const cost = dx * dx + dy * dy + dz * dz;
-        const a = dp[idx(i - 1, j - 1)];
-        const b = dp[idx(i - 1, j)];
-        const c = dp[idx(i, j - 1)];
-        let mv = a;
-        let mi: 0 | 1 | 2 = 0;
-        if (b < mv) {
-          mv = b;
-          mi = 1;
-        }
-        if (c < mv) {
-          mv = c;
-          mi = 2;
-        }
-        dp[idx(i, j)] = cost + mv;
-        back[idx(i, j)] = mi;
-      }
-    }
-
-    const total = dp[idx(N, M)];
-    if (total >= bestCost) continue;
-
-    // Backtrack: collect (i, j) pairs.
-    const pairs: [number, number][] = [];
-    let i = N;
-    let j = M;
-    while (i > 0 && j > 0) {
-      pairs.push([i - 1, (j - 1 + shift) % M]);
-      const dir = back[idx(i, j)];
-      if (dir === 0) {
-        i--;
-        j--;
-      } else if (dir === 1) {
-        i--;
-      } else {
-        j--;
-      }
-    }
-    pairs.reverse();
-
-    // Collapse pairs to a per-source target index using the median tgt
-    // among all tgts paired with each src — preserves monotonicity since
-    // DTW pairs are monotone, and the median of a monotonic-prefix is
-    // monotone in src.
-    const buckets: number[][] = Array.from({ length: N }, () => []);
-    for (const [si, ti] of pairs) buckets[si].push(ti);
-    const srcToTgt = buckets.map((b, s) => {
-      if (b.length === 0) return s % M;
-      b.sort((p, q) => p - q);
-      return b[(b.length - 1) >> 1];
-    });
-
-    bestCost = total;
-    bestSrcToTgt = srcToTgt;
-  }
-
-  return bestSrcToTgt;
-}
-
-/**
- * Pair two cubic-Bezier subpaths by:
- *   1. Resampling each side to a shared arc-length-uniform anchor count.
- *   2. Running cyclic DTW between the two anchor sequences to find the
- *      monotonic correspondence that minimises total per-anchor displacement.
- *   3. Re-resampling the target chain with anchors placed at the warped
- *      arc-length positions chosen by DTW.
- *
- * Result: equal-length cubic chains whose anchor `i` pairs source feature
- * `i` with the target feature DTW judged most similar — instead of forcing
- * a single uniform cyclic offset across the whole shape.
- */
-// eslint-disable-next-line complexity
+/** Equalize point counts by resampling the shorter subpath only. */
 function alignSubpathPairPoints(
   srcSubpath: number[][],
   tgtSubpath: number[][],
 ): { srcAligned: number[][]; tgtAligned: number[][] } {
   const maxCount = Math.max(srcSubpath.length, tgtSubpath.length);
-
-  // Resample both sides to the same uniform arc-length parameterisation.
   const srcAligned =
     srcSubpath.length < maxCount
       ? resamplePointList3D(srcSubpath, maxCount)
-      : resamplePointList3D(srcSubpath, srcSubpath.length);
-  const tgtUniform =
+      : srcSubpath.map((p) => [...p]);
+  const tgtAlignedRaw =
     tgtSubpath.length < maxCount
       ? resamplePointList3D(tgtSubpath, maxCount)
-      : resamplePointList3D(tgtSubpath, tgtSubpath.length);
+      : tgtSubpath.map((p) => [...p]);
 
-  // Only meaningful for stride-3 closed cubic chains. For anything else
-  // fall back to rotation-only alignment.
-  const stride = 3;
-  if (
-    !isStrideClosedCubicSubpath(srcAligned, stride) ||
-    !isStrideClosedCubicSubpath(tgtUniform, stride) ||
-    srcAligned.length !== tgtUniform.length
-  ) {
-    return {
-      srcAligned,
-      tgtAligned: rotateClosedTargetForBestAlignment(srcAligned, tgtUniform),
-    };
-  }
+  const tgtAligned = rotateClosedTargetForBestAlignment(srcAligned, tgtAlignedRaw);
 
-  const openLen = srcAligned.length - 1;
-  const anchorCount = openLen / stride;
-  if (anchorCount < 4) {
-    return {
-      srcAligned,
-      tgtAligned: rotateClosedTargetForBestAlignment(srcAligned, tgtUniform),
-    };
-  }
-
-  // Extract just the anchors (every stride-th point) from both sides.
-  const srcAnchors: number[][] = [];
-  const tgtAnchors: number[][] = [];
-  for (let i = 0; i < openLen; i += stride) {
-    srcAnchors.push(srcAligned[i]);
-    tgtAnchors.push(tgtUniform[i]);
-  }
-
-  // DTW correspondence: for each src anchor i, the warped tgt anchor.
-  const srcToTgt = dtwCyclicCorrespondence(srcAnchors, tgtAnchors);
-
-  // Compute total target perimeter so we can express the warped tgt
-  // anchors as arc-length positions on the original target chain. The
-  // threshold is `1e-9`, not exactly zero, because evaluating a chain of
-  // degenerate (zero-length) cubics through floating-point math
-  // accumulates noise that comes out as ~1e-14 instead of 0; treating
-  // that noise as a non-degenerate perimeter would re-sample a synthetic
-  // null subpath into points that drift off the centroid by a few ulps,
-  // breaking the "synthetic = constant" invariant downstream callers rely
-  // on (placeholder fades, hole-collapse rendering, etc.).
-  const tgtInfo = buildChainArcInfo(tgtSubpath);
-  if (tgtInfo.totalLen < 1e-9) {
-    return {
-      srcAligned,
-      tgtAligned: rotateClosedTargetForBestAlignment(srcAligned, tgtUniform),
-    };
-  }
-
-  // Warped arc positions. Anchor 0 is whatever DTW picked; we walk the
-  // target perimeter monotonically and unwrap cyclic wraparounds (i.e. if
-  // the next chosen index wraps under the previous one, we treat it as
-  // "+M after" instead of "before").
-  const warpedAnchorArcs: number[] = [];
-  let prevIdx = srcToTgt[0];
-  let cumulativeIdx = prevIdx;
-  warpedAnchorArcs.push((prevIdx / anchorCount) * tgtInfo.totalLen);
-  for (let i = 1; i < anchorCount; i++) {
-    const cur = srcToTgt[i];
-    let unwrap = cur;
-    while (unwrap < prevIdx) unwrap += anchorCount;
-    cumulativeIdx += unwrap - prevIdx;
-    warpedAnchorArcs.push((cumulativeIdx / anchorCount) * tgtInfo.totalLen);
-    prevIdx = unwrap % anchorCount;
-  }
-  // Close the loop by returning to anchor 0 + one full perimeter.
-  warpedAnchorArcs.push(warpedAnchorArcs[0] + tgtInfo.totalLen);
-
-  // Each consecutive arc position must remain within [first, first+L]; if
-  // total drift exceeded one full loop we collapse extras (defensive).
-  for (let i = 1; i < warpedAnchorArcs.length; i++) {
-    if (warpedAnchorArcs[i] < warpedAnchorArcs[i - 1]) {
-      warpedAnchorArcs[i] = warpedAnchorArcs[i - 1];
-    }
-  }
-  const span = warpedAnchorArcs[warpedAnchorArcs.length - 1] - warpedAnchorArcs[0];
-  if (span > 1.5 * tgtInfo.totalLen || span < 0.5 * tgtInfo.totalLen) {
-    // DTW produced a degenerate warping (more than one full loop or less
-    // than half a loop). Fall back to rotation-only alignment, which is
-    // always sensible for closed curves.
-    return {
-      srcAligned,
-      tgtAligned: rotateClosedTargetForBestAlignment(srcAligned, tgtUniform),
-    };
-  }
-
-  // Re-resample tgt with anchors placed at the warped arc positions.
-  // We work modulo the target perimeter so wraparound positions land on
-  // the actual chain.
-  const wrappedArcs = warpedAnchorArcs.map((a) => {
-    let v = a % tgtInfo.totalLen;
-    if (v < 0) v += tgtInfo.totalLen;
-    return v;
-  });
-  // For monotonic resample we need positions in non-decreasing order.
-  // Re-cumulate after the wrap so the resampler can interpret them as a
-  // single sweep around the loop, possibly across the seam.
-  const splitArcs = unwrapArcCycle(wrappedArcs, tgtInfo.totalLen);
-  const tgtWarped = resampleCubicChainAtArcs(tgtSubpath, splitArcs);
-
-  if (tgtWarped.length !== srcAligned.length) {
-    return {
-      srcAligned,
-      tgtAligned: rotateClosedTargetForBestAlignment(srcAligned, tgtUniform),
-    };
-  }
-
-  return { srcAligned, tgtAligned: tgtWarped };
-}
-
-/**
- * Unwrap a cyclic sequence of arc positions into a monotonic non-decreasing
- * one by adding the perimeter length wherever the next position appears to
- * have looped back.
- */
-function unwrapArcCycle(arcs: number[], perimeter: number): number[] {
-  const out = arcs.slice();
-  for (let i = 1; i < out.length; i++) {
-    while (out[i] < out[i - 1]) out[i] += perimeter;
-  }
-  return out;
+  return { srcAligned, tgtAligned };
 }
 
 /** Compute center of all points in array. */

--- a/src/core/vmobject-coverage.test.ts
+++ b/src/core/vmobject-coverage.test.ts
@@ -362,8 +362,11 @@ describe('VMobject._sampleBezierOutline', () => {
     ]);
     const pts = v.getPoints();
     const outline = (v as any)._sampleBezierOutline(pts, 8) as number[][];
-    // Linear segment should use only 2 samples (start + end)
-    expect(outline.length).toBe(2);
+    // Always emits `samplesPerSegment + 1` samples per segment regardless
+    // of linearity; previously the adaptive collapse made this 2, but
+    // adaptive sampling caused stroke flicker mid-Transform as lerped
+    // segments crossed the linearity threshold. Stability over compute.
+    expect(outline.length).toBe(9);
   });
 
   it('handles fallback for non-bezier points', () => {
@@ -453,9 +456,11 @@ describe('VMobject._sampleBezierPath', () => {
     expect(sampled).toEqual(pts);
   });
 
-  it('uses adaptive sampling (linear segments get fewer samples)', () => {
+  it('emits a fixed sample count per segment regardless of linearity', () => {
     const v = new VMobject();
-    // Linear segment + curved segment
+    // Linear segment + curved segment — both get full sampling now so the
+    // stroke polyline length doesn't flicker mid-Transform when the lerped
+    // segment crosses any linearity threshold.
     v.setPoints([
       [0, 0, 0],
       [1 / 3, 0, 0], // linear handles
@@ -467,8 +472,8 @@ describe('VMobject._sampleBezierPath', () => {
     ]);
     const pts = v.getPoints();
     const sampled = (v as any)._sampleBezierPath(pts, 8) as number[][];
-    // Linear part should produce 2 points, curved part should produce ~9 points
-    expect(sampled.length).toBeGreaterThan(3);
+    // 2 segments * 8 samples + 1 shared anchor = 17 samples.
+    expect(sampled.length).toBe(17);
   });
 });
 

--- a/src/core/vmobject-coverage.test.ts
+++ b/src/core/vmobject-coverage.test.ts
@@ -242,6 +242,61 @@ describe('VMobject._isNearlyLinear', () => {
     const p3 = [0, 1, 0];
     expect((VMobject as any)._isNearlyLinear(p0, p1, p2, p3)).toBe(false);
   });
+
+  // Regression for issue #310: classification must be scale-invariant so that
+  // adaptive sampling produces consistent polyline lengths across scaled
+  // versions of the same shape (e.g. small MathTex "0" → big MathTex "0"
+  // during a Transform). A fixed absolute threshold causes small glyphs to
+  // render as polygons while large copies render as curves.
+  it('classification is invariant under uniform scaling (issue #310)', () => {
+    // Curved segment: a quarter-circle-ish bulge (handle ~25% off-chord).
+    const p0 = [0, 0, 0];
+    const p1 = [0.25, 0.25, 0];
+    const p2 = [0.75, 0.25, 0];
+    const p3 = [1, 0, 0];
+
+    const scaleAll = (s: number, p: number[]) => p.map((v) => v * s);
+    const scaled = (s: number) => [
+      scaleAll(s, p0),
+      scaleAll(s, p1),
+      scaleAll(s, p2),
+      scaleAll(s, p3),
+    ];
+
+    const classify = (s: number) => {
+      const [a, b, c, d] = scaled(s);
+      return (VMobject as any)._isNearlyLinear(a, b, c, d) as boolean;
+    };
+
+    // Same shape at different scales must classify the same.
+    expect(classify(1)).toBe(classify(0.05));
+    expect(classify(1)).toBe(classify(0.005));
+    expect(classify(1)).toBe(classify(10));
+  });
+
+  it('a tiny but visibly curved segment is not classified as linear (issue #310)', () => {
+    // ~25% bulge relative to chord, but chord is only 0.02 world units —
+    // representative of MathTex glyph segment at small font size.
+    const p0 = [0, 0, 0];
+    const p1 = [0.005, 0.005, 0];
+    const p2 = [0.015, 0.005, 0];
+    const p3 = [0.02, 0, 0];
+    expect((VMobject as any)._isNearlyLinear(p0, p1, p2, p3)).toBe(false);
+  });
+
+  it('a clearly linear segment at any scale stays linear (issue #310)', () => {
+    // Handle perpendicular deviation = 0.1% of chord length.
+    const tiny = (s: number) => [
+      [0, 0, 0],
+      [s / 3, s * 0.001, 0],
+      [(2 * s) / 3, -s * 0.001, 0],
+      [s, 0, 0],
+    ];
+    for (const s of [0.001, 0.1, 1, 100]) {
+      const [a, b, c, d] = tiny(s);
+      expect((VMobject as any)._isNearlyLinear(a, b, c, d)).toBe(true);
+    }
+  });
 });
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

Fixes #310. `isNearlyLinear` (src/core/VMobjectGeometry.ts) used a fixed absolute threshold (`0.01` world units) to decide if a cubic Bezier segment is straight enough to skip per-sample evaluation. The same logical glyph at different scales — e.g. a small `MathTex("0")` and a big `MathTex("0")` — therefore classified differently. During a `Transform` between them, sample counts flipped mid-animation and the polyline morphed into rectangular artefacts.

Switching the criterion to `max(perpDist) < TOL_REL * chord` (1% of chord length) makes classification scale-invariant: every uniform scaling of the same control polygon gets the same answer. Existing tests still pass since they use unit-length chords.

## Changes

- `src/core/VMobjectGeometry.ts` — `isNearlyLinear` now compares perpendicular handle distance to chord length (relative tolerance). Degenerate-chord branch additionally checks that handles collapse to the endpoint, so curl/loop Beziers (chord ≈ 0 with bulging handles) are still sampled.
- `src/core/vmobject-coverage.test.ts` — three regression tests pinning scale invariance, the small-curve bug, and the small-linear case.
- `examples/mathtex_zero_scale_morph.{html,ts}` — minimal visual repro of the issue (small "0" → big "0" Transform). Glyph stays curved at every scale post-fix.

## Test plan

- [x] `npx vitest run src/core/vmobject-coverage.test.ts` — 80 pass (3 regression cases now pass; failed against the pre-fix code)
- [x] `npx vitest run` (full suite) — 5873 / 5873 pass
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] Manual: load `examples/mathtex_zero_scale_morph.html`, click Play — the "0" smoothly grows from `fontSize=24` to `fontSize=240` with the glyph staying curved throughout (no rectangular frames).