### PR TITLE
fix(arrow): canonical endpoints + GrowArrow position restore

### DIFF
--- a/examples/arrow-dance.html
+++ b/examples/arrow-dance.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Arrow Dance</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #0b0f14;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+    }
+    #container {
+      border: 2px solid #253041;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .controls {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      gap: 10px;
+    }
+    button {
+      padding: 10px 20px;
+      background: #2563eb;
+      border: none;
+      border-radius: 6px;
+      color: white;
+      cursor: pointer;
+      font-size: 14px;
+    }
+    button:hover { background: #3b82f6; }
+  </style>
+</head>
+<body>
+  <div id="container"></div>
+  <div class="controls">
+    <button id="playBtn">Play Arrow Dance</button>
+    <button id="resetBtn">Reset</button>
+  </div>
+
+  <script type="module" src="./arrow-dance.ts"></script>
+</body>
+</html>

--- a/examples/arrow-dance.ts
+++ b/examples/arrow-dance.ts
@@ -1,0 +1,76 @@
+import { Scene, Arrow, GrowArrow, Transform } from '../src/index.ts';
+
+const container = document.getElementById('container')!;
+const scene = new Scene(container, {
+  width: 800,
+  height: 450,
+  backgroundColor: '#101319',
+});
+
+let isAnimating = false;
+
+function makeArrowTo(radius: number, angle: number): Arrow {
+  return new Arrow({
+    start: [0, 0, 0],
+    end: [radius * Math.cos(angle), radius * Math.sin(angle), 0],
+    color: '#7dd3fc',
+    strokeWidth: 3,
+    tipLength: 0.28,
+    tipWidth: 0.12,
+  });
+}
+
+document.getElementById('playBtn')!.addEventListener('click', async () => {
+  if (isAnimating) return;
+  isAnimating = true;
+
+  scene.clear();
+
+  const n = 12;
+  const radius = 2.6;
+  const arrows: Arrow[] = [];
+
+  for (let i = 0; i < n; i++) {
+    const angle = (2 * Math.PI * i) / n;
+    const arrow = makeArrowTo(radius, angle);
+    arrows.push(arrow);
+  }
+
+  // Grow one-by-one from center out to a 12-gon.
+  // Do not pre-add: GrowArrow/Create pipeline adds to scene.
+  for (const arrow of arrows) {
+    await scene.play(new GrowArrow(arrow, { duration: 0.32 }));
+  }
+
+  await scene.wait(0.25);
+
+  // Shift all arrows outward by +1 unit (together).
+  await scene.play(
+    ...arrows.map((arrow, i) => {
+      const angle = (2 * Math.PI * i) / n;
+      const target = arrow.copy() as Arrow;
+      target.putStartAndEndOn(
+        [Math.cos(angle), Math.sin(angle), 0],
+        [(radius + 1) * Math.cos(angle), (radius + 1) * Math.sin(angle), 0],
+      );
+      return new Transform(arrow, target, { duration: 1.2 });
+    }),
+  );
+
+  // Scale all arrows down to half (together).
+  await scene.play(...arrows.map((arrow) => arrow.animate.scale(0.5).withDuration(0.9)));
+
+  isAnimating = false;
+});
+
+document.getElementById('resetBtn')!.addEventListener('click', () => {
+  scene.clear();
+});
+
+// Embed mode: hide controls and autoplay.
+if (new URLSearchParams(window.location.search).has('embed')) {
+  document
+    .querySelectorAll('.controls')
+    .forEach((el) => ((el as HTMLElement).style.display = 'none'));
+  setTimeout(() => document.getElementById('playBtn')?.click(), 300);
+}

--- a/src/animation/animation-growing.test.ts
+++ b/src/animation/animation-growing.test.ts
@@ -71,72 +71,118 @@ describe('GrowArrow', () => {
   });
 
   describe('begin()', () => {
-    it('sets scale to near-zero', () => {
+    it('sets children scale to near-zero', () => {
       const arrow = makeArrow();
       const anim = new GrowArrow(arrow);
       anim.begin();
-      expect(arrow.scaleVector.x).toBeCloseTo(0.001, 5);
-      expect(arrow.scaleVector.y).toBeCloseTo(0.001, 5);
-      expect(arrow.scaleVector.z).toBeCloseTo(0.001, 5);
+      for (const child of arrow.children) {
+        expect(child.scaleVector.x).toBeCloseTo(0.001, 5);
+        expect(child.scaleVector.y).toBeCloseTo(0.001, 5);
+        expect(child.scaleVector.z).toBeCloseTo(0.001, 5);
+      }
     });
 
-    it('does not change position', () => {
+    it('keeps group position unchanged', () => {
       const arrow = new Arrow({ start: [1, 2, 0], end: [3, 4, 0] });
-      arrow.position.set(9, -3, 0);
+      const before = arrow.position.clone();
       const anim = new GrowArrow(arrow);
       anim.begin();
-      expect(arrow.position.x).toBeCloseTo(9, 5);
-      expect(arrow.position.y).toBeCloseTo(-3, 5);
+      expect(arrow.position.x).toBeCloseTo(before.x, 5);
+      expect(arrow.position.y).toBeCloseTo(before.y, 5);
+      expect(arrow.position.z).toBeCloseTo(before.z, 5);
+    });
+
+    it('aligns shaft start and tip apex at begin for shifted arrow', () => {
+      const arrow = new Arrow({
+        start: [-4, 0, 0],
+        end: [4, 0, 0],
+        tipLength: 0.6,
+        tipWidth: 0.35,
+      });
+      arrow.shift([2, 1, 0]);
+      const anim = new GrowArrow(arrow);
+      anim.begin();
+
+      const shaft = arrow.children[0];
+      const tip = arrow.children[1];
+      const sp = (shaft as VMobject).getPoints()[0];
+      const tp = (tip as VMobject).getPoints()[3];
+
+      const shaftStartWorld: [number, number, number] = [
+        sp[0] * shaft.scaleVector.x + shaft.position.x,
+        sp[1] * shaft.scaleVector.y + shaft.position.y,
+        sp[2] * shaft.scaleVector.z + shaft.position.z,
+      ];
+      const tipApexWorld: [number, number, number] = [
+        tp[0] * tip.scaleVector.x + tip.position.x,
+        tp[1] * tip.scaleVector.y + tip.position.y,
+        tp[2] * tip.scaleVector.z + tip.position.z,
+      ];
+
+      expect(tipApexWorld[0]).toBeCloseTo(shaftStartWorld[0], 5);
+      expect(tipApexWorld[1]).toBeCloseTo(shaftStartWorld[1], 5);
+      expect(tipApexWorld[2]).toBeCloseTo(shaftStartWorld[2], 5);
     });
   });
 
   describe('interpolate()', () => {
-    it('at alpha=0.5 scales to roughly half', () => {
+    it('at alpha=0.5 scales children to roughly half', () => {
       const arrow = makeArrow();
+      const orig = arrow.children.map((c) => c.scaleVector.clone());
       const anim = new GrowArrow(arrow);
       anim.begin();
       anim.interpolate(0.5);
-      expect(arrow.scaleVector.x).toBeCloseTo(0.5, 2);
-      expect(arrow.scaleVector.y).toBeCloseTo(0.5, 2);
+      for (let i = 0; i < arrow.children.length; i++) {
+        expect(arrow.children[i].scaleVector.x).toBeCloseTo(orig[i].x * 0.5, 2);
+        expect(arrow.children[i].scaleVector.y).toBeCloseTo(orig[i].y * 0.5, 2);
+      }
     });
 
-    it('at alpha=1 restores full scale', () => {
+    it('at alpha=1 restores full child scales', () => {
       const arrow = makeArrow();
-      const origScaleX = arrow.scaleVector.x;
+      const orig = arrow.children.map((c) => c.scaleVector.clone());
       const anim = new GrowArrow(arrow);
       anim.begin();
       anim.interpolate(1);
-      expect(arrow.scaleVector.x).toBeCloseTo(origScaleX, 5);
+      for (let i = 0; i < arrow.children.length; i++) {
+        expect(arrow.children[i].scaleVector.x).toBeCloseTo(orig[i].x, 5);
+      }
     });
 
-    it('does not change position during interpolation', () => {
+    it('moves arrow center from start toward target center', () => {
       const arrow = new Arrow({ start: [0, 0, 0], end: [4, 0, 0] });
-      arrow.position.set(10, 1, 0);
+      arrow.shift([10, 1, 0]);
+      const targetCenter = arrow.getCenter();
       const anim = new GrowArrow(arrow);
       anim.begin();
-      anim.interpolate(0.5);
-      expect(arrow.position.x).toBeCloseTo(10, 5);
-      expect(arrow.position.y).toBeCloseTo(1, 5);
+
+      const c0 = arrow.getCenter();
+      expect(c0[0]).toBeLessThan(targetCenter[0]);
+      expect(c0[1]).toBeCloseTo(targetCenter[1], 5);
+
       anim.interpolate(1);
-      expect(arrow.position.x).toBeCloseTo(10, 5);
-      expect(arrow.position.y).toBeCloseTo(1, 5);
+      const c1 = arrow.getCenter();
+      expect(c1[0]).toBeCloseTo(targetCenter[0], 2);
+      expect(c1[1]).toBeCloseTo(targetCenter[1], 2);
     });
   });
 
   describe('finish()', () => {
-    it('restores original scale and keeps position unchanged', () => {
+    it('restores child scales and translated geometry exactly', () => {
       const arrow = new Arrow({ start: [0, 0, 0], end: [4, 0, 0] });
-      arrow.position.set(-3, 2, 0);
-      const origScale = arrow.scaleVector.clone();
-      const origPos = arrow.position.clone();
+      arrow.shift([-3, 2, 0]);
+      const origCenter = arrow.getCenter();
+      const origChildScales = arrow.children.map((c) => c.scaleVector.clone());
       const anim = new GrowArrow(arrow);
       anim.begin();
       anim.interpolate(0.3);
       anim.finish();
-      expect(arrow.scaleVector.x).toBeCloseTo(origScale.x, 5);
-      expect(arrow.scaleVector.y).toBeCloseTo(origScale.y, 5);
-      expect(arrow.position.x).toBeCloseTo(origPos.x, 5);
-      expect(arrow.position.y).toBeCloseTo(origPos.y, 5);
+      const finalCenter = arrow.getCenter();
+      expect(finalCenter[0]).toBeCloseTo(origCenter[0], 5);
+      expect(finalCenter[1]).toBeCloseTo(origCenter[1], 5);
+      for (let i = 0; i < arrow.children.length; i++) {
+        expect(arrow.children[i].scaleVector.x).toBeCloseTo(origChildScales[i].x, 5);
+      }
     });
   });
 

--- a/src/animation/animation-growing.test.ts
+++ b/src/animation/animation-growing.test.ts
@@ -138,6 +138,24 @@ describe('GrowArrow', () => {
       }
     });
 
+    it('keeps shaft position exactly fixed through interpolation', () => {
+      const arrow = new Arrow({ start: [1, 2, 0], end: [6, 2, 0] });
+      const shaft = arrow.children[0];
+      const p0 = shaft.position.clone();
+
+      const anim = new GrowArrow(arrow);
+      anim.begin();
+      anim.interpolate(0.25);
+      expect(shaft.position.x).toBe(p0.x);
+      expect(shaft.position.y).toBe(p0.y);
+      expect(shaft.position.z).toBe(p0.z);
+
+      anim.interpolate(0.75);
+      expect(shaft.position.x).toBe(p0.x);
+      expect(shaft.position.y).toBe(p0.y);
+      expect(shaft.position.z).toBe(p0.z);
+    });
+
     it('at alpha=1 restores full child scales', () => {
       const arrow = makeArrow();
       const orig = arrow.children.map((c) => c.scaleVector.clone());
@@ -168,21 +186,35 @@ describe('GrowArrow', () => {
   });
 
   describe('finish()', () => {
-    it('restores child scales and translated geometry exactly', () => {
+    it('forces canonical alpha=1 end state', () => {
       const arrow = new Arrow({ start: [0, 0, 0], end: [4, 0, 0] });
       arrow.shift([-3, 2, 0]);
-      const origCenter = arrow.getCenter();
-      const origChildScales = arrow.children.map((c) => c.scaleVector.clone());
+
+      const shaft = arrow.children[0];
+      const tip = arrow.children[1];
+      const shaftPos = shaft.position.clone();
+      const shaftScale = shaft.scaleVector.clone();
+      const tipPos = tip.position.clone();
+      const tipScale = tip.scaleVector.clone();
+
       const anim = new GrowArrow(arrow);
       anim.begin();
       anim.interpolate(0.3);
       anim.finish();
-      const finalCenter = arrow.getCenter();
-      expect(finalCenter[0]).toBeCloseTo(origCenter[0], 5);
-      expect(finalCenter[1]).toBeCloseTo(origCenter[1], 5);
-      for (let i = 0; i < arrow.children.length; i++) {
-        expect(arrow.children[i].scaleVector.x).toBeCloseTo(origChildScales[i].x, 5);
-      }
+
+      expect(shaft.position.x).toBe(shaftPos.x);
+      expect(shaft.position.y).toBe(shaftPos.y);
+      expect(shaft.position.z).toBe(shaftPos.z);
+      expect(shaft.scaleVector.x).toBe(shaftScale.x);
+      expect(shaft.scaleVector.y).toBe(shaftScale.y);
+      expect(shaft.scaleVector.z).toBe(shaftScale.z);
+
+      expect(tip.position.x).toBe(tipPos.x);
+      expect(tip.position.y).toBe(tipPos.y);
+      expect(tip.position.z).toBe(tipPos.z);
+      expect(tip.scaleVector.x).toBe(tipScale.x);
+      expect(tip.scaleVector.y).toBe(tipScale.y);
+      expect(tip.scaleVector.z).toBe(tipScale.z);
     });
   });
 

--- a/src/animation/animation-growing.test.ts
+++ b/src/animation/animation-growing.test.ts
@@ -80,12 +80,13 @@ describe('GrowArrow', () => {
       expect(arrow.scaleVector.z).toBeCloseTo(0.001, 5);
     });
 
-    it('moves position to start point', () => {
+    it('does not change position', () => {
       const arrow = new Arrow({ start: [1, 2, 0], end: [3, 4, 0] });
+      arrow.position.set(9, -3, 0);
       const anim = new GrowArrow(arrow);
       anim.begin();
-      expect(arrow.position.x).toBeCloseTo(1, 5);
-      expect(arrow.position.y).toBeCloseTo(2, 5);
+      expect(arrow.position.x).toBeCloseTo(9, 5);
+      expect(arrow.position.y).toBeCloseTo(-3, 5);
     });
   });
 
@@ -108,11 +109,14 @@ describe('GrowArrow', () => {
       expect(arrow.scaleVector.x).toBeCloseTo(origScaleX, 5);
     });
 
-    it('position interpolates from start toward original position', () => {
+    it('does not change position during interpolation', () => {
       const arrow = new Arrow({ start: [0, 0, 0], end: [4, 0, 0] });
       arrow.position.set(10, 1, 0);
       const anim = new GrowArrow(arrow);
       anim.begin();
+      anim.interpolate(0.5);
+      expect(arrow.position.x).toBeCloseTo(10, 5);
+      expect(arrow.position.y).toBeCloseTo(1, 5);
       anim.interpolate(1);
       expect(arrow.position.x).toBeCloseTo(10, 5);
       expect(arrow.position.y).toBeCloseTo(1, 5);
@@ -120,7 +124,7 @@ describe('GrowArrow', () => {
   });
 
   describe('finish()', () => {
-    it('restores original scale and exact original position', () => {
+    it('restores original scale and keeps position unchanged', () => {
       const arrow = new Arrow({ start: [0, 0, 0], end: [4, 0, 0] });
       arrow.position.set(-3, 2, 0);
       const origScale = arrow.scaleVector.clone();

--- a/src/animation/animation-growing.test.ts
+++ b/src/animation/animation-growing.test.ts
@@ -92,7 +92,7 @@ describe('GrowArrow', () => {
       expect(arrow.position.z).toBeCloseTo(before.z, 5);
     });
 
-    it('aligns shaft start and tip apex at begin for shifted arrow', () => {
+    it('places shaft/tip centers at arrow start at begin', () => {
       const arrow = new Arrow({
         start: [-4, 0, 0],
         end: [4, 0, 0],
@@ -100,28 +100,20 @@ describe('GrowArrow', () => {
         tipWidth: 0.35,
       });
       arrow.shift([2, 1, 0]);
+      const start = arrow.getStart();
+
       const anim = new GrowArrow(arrow);
       anim.begin();
 
-      const shaft = arrow.children[0];
-      const tip = arrow.children[1];
-      const sp = (shaft as VMobject).getPoints()[0];
-      const tp = (tip as VMobject).getPoints()[3];
+      const shaftCenter = arrow.children[0].getCenter();
+      const tipCenter = arrow.children[1].getCenter();
 
-      const shaftStartWorld: [number, number, number] = [
-        sp[0] * shaft.scaleVector.x + shaft.position.x,
-        sp[1] * shaft.scaleVector.y + shaft.position.y,
-        sp[2] * shaft.scaleVector.z + shaft.position.z,
-      ];
-      const tipApexWorld: [number, number, number] = [
-        tp[0] * tip.scaleVector.x + tip.position.x,
-        tp[1] * tip.scaleVector.y + tip.position.y,
-        tp[2] * tip.scaleVector.z + tip.position.z,
-      ];
-
-      expect(tipApexWorld[0]).toBeCloseTo(shaftStartWorld[0], 5);
-      expect(tipApexWorld[1]).toBeCloseTo(shaftStartWorld[1], 5);
-      expect(tipApexWorld[2]).toBeCloseTo(shaftStartWorld[2], 5);
+      expect(shaftCenter[0]).toBeCloseTo(start[0], 5);
+      expect(shaftCenter[1]).toBeCloseTo(start[1], 5);
+      expect(shaftCenter[2]).toBeCloseTo(start[2], 5);
+      expect(tipCenter[0]).toBeCloseTo(start[0], 5);
+      expect(tipCenter[1]).toBeCloseTo(start[1], 5);
+      expect(tipCenter[2]).toBeCloseTo(start[2], 5);
     });
   });
 
@@ -138,22 +130,48 @@ describe('GrowArrow', () => {
       }
     });
 
-    it('keeps shaft position exactly fixed through interpolation', () => {
+    it('moves shaft center from start to its end center', () => {
       const arrow = new Arrow({ start: [1, 2, 0], end: [6, 2, 0] });
       const shaft = arrow.children[0];
-      const p0 = shaft.position.clone();
+      const endCenter = shaft.getCenter();
+      const start = arrow.getStart();
 
       const anim = new GrowArrow(arrow);
       anim.begin();
+
+      const c0 = shaft.getCenter();
+      expect(c0[0]).toBeCloseTo(start[0], 6);
+
       anim.interpolate(0.25);
-      expect(shaft.position.x).toBe(p0.x);
-      expect(shaft.position.y).toBe(p0.y);
-      expect(shaft.position.z).toBe(p0.z);
+      const c25 = shaft.getCenter();
+      expect(c25[0]).toBeCloseTo(start[0] + (endCenter[0] - start[0]) * 0.25, 6);
 
       anim.interpolate(0.75);
-      expect(shaft.position.x).toBe(p0.x);
-      expect(shaft.position.y).toBe(p0.y);
-      expect(shaft.position.z).toBe(p0.z);
+      const c75 = shaft.getCenter();
+      expect(c75[0]).toBeCloseTo(start[0] + (endCenter[0] - start[0]) * 0.75, 6);
+    });
+
+    it('interpolates tip center toward its offset end-center (not midpoint)', () => {
+      const arrow = new Arrow({ start: [-1, 0, 0], end: [5, 0, 0], tipLength: 1 });
+      const tip = arrow.children[1];
+      const endTipCenter = tip.getCenter();
+      const start = arrow.getStart();
+
+      const anim = new GrowArrow(arrow);
+      anim.begin();
+
+      const c0 = tip.getCenter();
+      expect(c0[0]).toBeCloseTo(start[0], 6);
+
+      anim.interpolate(0.5);
+      const c5 = tip.getCenter();
+      expect(c5[0]).toBeCloseTo(start[0] + (endTipCenter[0] - start[0]) * 0.5, 6);
+
+      anim.interpolate(1);
+      const c1 = tip.getCenter();
+      expect(c1[0]).toBeCloseTo(endTipCenter[0], 6);
+      expect(c1[1]).toBeCloseTo(endTipCenter[1], 6);
+      expect(c1[2]).toBeCloseTo(endTipCenter[2], 6);
     });
 
     it('at alpha=1 restores full child scales', () => {
@@ -167,7 +185,7 @@ describe('GrowArrow', () => {
       }
     });
 
-    it('moves arrow center from start toward target center', () => {
+    it('moves arrow center from start region to target center during interpolation', () => {
       const arrow = new Arrow({ start: [0, 0, 0], end: [4, 0, 0] });
       arrow.shift([10, 1, 0]);
       const targetCenter = arrow.getCenter();
@@ -176,12 +194,11 @@ describe('GrowArrow', () => {
 
       const c0 = arrow.getCenter();
       expect(c0[0]).toBeLessThan(targetCenter[0]);
-      expect(c0[1]).toBeCloseTo(targetCenter[1], 5);
 
       anim.interpolate(1);
       const c1 = arrow.getCenter();
-      expect(c1[0]).toBeCloseTo(targetCenter[0], 2);
-      expect(c1[1]).toBeCloseTo(targetCenter[1], 2);
+      expect(c1[0]).toBeCloseTo(targetCenter[0], 6);
+      expect(c1[1]).toBeCloseTo(targetCenter[1], 6);
     });
   });
 

--- a/src/animation/animation-growing.test.ts
+++ b/src/animation/animation-growing.test.ts
@@ -108,27 +108,31 @@ describe('GrowArrow', () => {
       expect(arrow.scaleVector.x).toBeCloseTo(origScaleX, 5);
     });
 
-    it('position interpolates from start toward center', () => {
+    it('position interpolates from start toward original position', () => {
       const arrow = new Arrow({ start: [0, 0, 0], end: [4, 0, 0] });
+      arrow.position.set(10, 1, 0);
       const anim = new GrowArrow(arrow);
       anim.begin();
       anim.interpolate(1);
-      // At alpha=1 position should be at midpoint (0+4)/2 = 2
-      expect(arrow.position.x).toBeCloseTo(2, 2);
+      expect(arrow.position.x).toBeCloseTo(10, 5);
+      expect(arrow.position.y).toBeCloseTo(1, 5);
     });
   });
 
   describe('finish()', () => {
-    it('restores original scale and sets position to midpoint', () => {
+    it('restores original scale and exact original position', () => {
       const arrow = new Arrow({ start: [0, 0, 0], end: [4, 0, 0] });
+      arrow.position.set(-3, 2, 0);
       const origScale = arrow.scaleVector.clone();
+      const origPos = arrow.position.clone();
       const anim = new GrowArrow(arrow);
       anim.begin();
       anim.interpolate(0.3);
       anim.finish();
       expect(arrow.scaleVector.x).toBeCloseTo(origScale.x, 5);
       expect(arrow.scaleVector.y).toBeCloseTo(origScale.y, 5);
-      expect(arrow.position.x).toBeCloseTo(2, 2);
+      expect(arrow.position.x).toBeCloseTo(origPos.x, 5);
+      expect(arrow.position.y).toBeCloseTo(origPos.y, 5);
     });
   });
 

--- a/src/animation/growing/growing-extra.test.ts
+++ b/src/animation/growing/growing-extra.test.ts
@@ -86,23 +86,23 @@ describe('GrowArrow (extra)', () => {
       expect(arrow.scaleVector.z).toBeCloseTo(0.001, 5);
     });
 
-    it('position moves continuously from start to original position', () => {
+    it('position remains unchanged through interpolation', () => {
       const arrow = makeArrow([0, 0, 0], [6, 0, 0]);
       arrow.position.set(3, 0, 0);
       const anim = new GrowArrow(arrow);
       anim.begin();
 
       anim.interpolate(0);
-      expect(arrow.position.x).toBeCloseTo(0, 2);
+      expect(arrow.position.x).toBeCloseTo(3, 2);
 
       anim.interpolate(0.25);
-      expect(arrow.position.x).toBeCloseTo(0.75, 2);
+      expect(arrow.position.x).toBeCloseTo(3, 2);
 
       anim.interpolate(0.5);
-      expect(arrow.position.x).toBeCloseTo(1.5, 2);
+      expect(arrow.position.x).toBeCloseTo(3, 2);
 
       anim.interpolate(0.75);
-      expect(arrow.position.x).toBeCloseTo(2.25, 2);
+      expect(arrow.position.x).toBeCloseTo(3, 2);
 
       anim.interpolate(1);
       expect(arrow.position.x).toBeCloseTo(3, 2);
@@ -114,13 +114,11 @@ describe('GrowArrow (extra)', () => {
       const anim = new GrowArrow(arrow);
       anim.begin();
 
-      // Position should start at the start point
-      expect(arrow.position.x).toBeCloseTo(1, 2);
-      expect(arrow.position.y).toBeCloseTo(2, 2);
-      expect(arrow.position.z).toBeCloseTo(3, 2);
+      expect(arrow.position.x).toBeCloseTo(3, 2);
+      expect(arrow.position.y).toBeCloseTo(4, 2);
+      expect(arrow.position.z).toBeCloseTo(5, 2);
 
       anim.interpolate(1);
-      // At alpha=1, position should be restored to original
       expect(arrow.position.x).toBeCloseTo(3, 2);
       expect(arrow.position.y).toBeCloseTo(4, 2);
       expect(arrow.position.z).toBeCloseTo(5, 2);
@@ -145,14 +143,14 @@ describe('GrowArrow (extra)', () => {
   });
 
   describe('finish() after partial interpolation', () => {
-    it('restores exact state regardless of last interpolation step', () => {
+    it('restores exact scale and keeps position unchanged', () => {
       const arrow = makeArrow([0, 0, 0], [4, 4, 0]);
       arrow.position.set(7, -2, 0);
       const origScale = arrow.scaleVector.clone();
       const origPos = arrow.position.clone();
       const anim = new GrowArrow(arrow);
       anim.begin();
-      anim.interpolate(0.1); // barely started
+      anim.interpolate(0.1);
       anim.finish();
       expect(arrow.scaleVector.x).toBeCloseTo(origScale.x, 5);
       expect(arrow.scaleVector.y).toBeCloseTo(origScale.y, 5);

--- a/src/animation/growing/growing-extra.test.ts
+++ b/src/animation/growing/growing-extra.test.ts
@@ -59,7 +59,7 @@ function trianglePoints(): number[][] {
 
 describe('GrowArrow (extra)', () => {
   describe('interpolate() progression', () => {
-    it('scale increases monotonically from 0 to 1', () => {
+    it('child scale increases monotonically from 0 to 1', () => {
       const arrow = makeArrow();
       const anim = new GrowArrow(arrow);
       anim.begin();
@@ -67,26 +67,25 @@ describe('GrowArrow (extra)', () => {
       const scales: number[] = [];
       for (let a = 0; a <= 1; a += 0.1) {
         anim.interpolate(a);
-        scales.push(arrow.scaleVector.x);
+        scales.push(arrow.children[0].scaleVector.x);
       }
 
-      // Each scale should be >= previous
       for (let i = 1; i < scales.length; i++) {
         expect(scales[i]).toBeGreaterThanOrEqual(scales[i - 1] - 0.001);
       }
     });
 
-    it('at alpha=0, scale is clamped to 0.001 (not 0)', () => {
+    it('at alpha=0, child scale is clamped to 0.001 (not 0)', () => {
       const arrow = makeArrow();
       const anim = new GrowArrow(arrow);
       anim.begin();
       anim.interpolate(0);
-      expect(arrow.scaleVector.x).toBeCloseTo(0.001, 5);
-      expect(arrow.scaleVector.y).toBeCloseTo(0.001, 5);
-      expect(arrow.scaleVector.z).toBeCloseTo(0.001, 5);
+      expect(arrow.children[0].scaleVector.x).toBeCloseTo(0.001, 5);
+      expect(arrow.children[0].scaleVector.y).toBeCloseTo(0.001, 5);
+      expect(arrow.children[0].scaleVector.z).toBeCloseTo(0.001, 5);
     });
 
-    it('position remains unchanged through interpolation', () => {
+    it('group position remains unchanged through interpolation', () => {
       const arrow = makeArrow([0, 0, 0], [6, 0, 0]);
       arrow.position.set(3, 0, 0);
       const anim = new GrowArrow(arrow);
@@ -95,69 +94,66 @@ describe('GrowArrow (extra)', () => {
       anim.interpolate(0);
       expect(arrow.position.x).toBeCloseTo(3, 2);
 
-      anim.interpolate(0.25);
-      expect(arrow.position.x).toBeCloseTo(3, 2);
-
       anim.interpolate(0.5);
-      expect(arrow.position.x).toBeCloseTo(3, 2);
-
-      anim.interpolate(0.75);
       expect(arrow.position.x).toBeCloseTo(3, 2);
 
       anim.interpolate(1);
       expect(arrow.position.x).toBeCloseTo(3, 2);
     });
 
-    it('handles arrow with 3D coordinates', () => {
+    it('handles shifted arrow with 3D coordinates', () => {
       const arrow = makeArrow([1, 2, 3], [5, 6, 7]);
-      arrow.position.set(3, 4, 5);
+      arrow.shift([3, 4, 5]);
+      const targetCenter = arrow.getCenter();
       const anim = new GrowArrow(arrow);
       anim.begin();
 
-      expect(arrow.position.x).toBeCloseTo(3, 2);
-      expect(arrow.position.y).toBeCloseTo(4, 2);
-      expect(arrow.position.z).toBeCloseTo(5, 2);
+      const beginCenter = arrow.getCenter();
+      expect(beginCenter[0]).not.toBeCloseTo(targetCenter[0], 2);
 
       anim.interpolate(1);
-      expect(arrow.position.x).toBeCloseTo(3, 2);
-      expect(arrow.position.y).toBeCloseTo(4, 2);
-      expect(arrow.position.z).toBeCloseTo(5, 2);
+      expect(arrow.getCenter()[0]).toBeCloseTo(targetCenter[0], 2);
+      expect(arrow.getCenter()[1]).toBeCloseTo(targetCenter[1], 2);
+      expect(arrow.getCenter()[2]).toBeCloseTo(targetCenter[2], 2);
     });
   });
 
   describe('begin() stores target correctly', () => {
-    it('preserves target scale for non-unit scaled arrow', () => {
+    it('preserves target scale for non-unit scaled child geometry', () => {
       const arrow = makeArrow();
-      arrow.scaleVector.set(2, 3, 4);
+      for (const child of arrow.children) child.scale(2);
+      const orig = arrow.children.map((c) => c.scaleVector.clone());
       const anim = new GrowArrow(arrow);
       anim.begin();
 
-      // Scale should be near-zero after begin
-      expect(arrow.scaleVector.x).toBeCloseTo(0.001, 5);
+      expect(arrow.children[0].scaleVector.x).toBeCloseTo(orig[0].x * 0.001, 5);
 
       anim.interpolate(1);
-      expect(arrow.scaleVector.x).toBeCloseTo(2, 2);
-      expect(arrow.scaleVector.y).toBeCloseTo(3, 2);
-      expect(arrow.scaleVector.z).toBeCloseTo(4, 2);
+      for (let i = 0; i < arrow.children.length; i++) {
+        expect(arrow.children[i].scaleVector.x).toBeCloseTo(orig[i].x, 2);
+        expect(arrow.children[i].scaleVector.y).toBeCloseTo(orig[i].y, 2);
+        expect(arrow.children[i].scaleVector.z).toBeCloseTo(orig[i].z, 2);
+      }
     });
   });
 
   describe('finish() after partial interpolation', () => {
-    it('restores exact scale and keeps position unchanged', () => {
+    it('restores exact child scales and geometry', () => {
       const arrow = makeArrow([0, 0, 0], [4, 4, 0]);
-      arrow.position.set(7, -2, 0);
-      const origScale = arrow.scaleVector.clone();
-      const origPos = arrow.position.clone();
+      arrow.shift([7, -2, 0]);
+      const origCenter = arrow.getCenter();
+      const origScales = arrow.children.map((c) => c.scaleVector.clone());
       const anim = new GrowArrow(arrow);
       anim.begin();
       anim.interpolate(0.1);
       anim.finish();
-      expect(arrow.scaleVector.x).toBeCloseTo(origScale.x, 5);
-      expect(arrow.scaleVector.y).toBeCloseTo(origScale.y, 5);
-      expect(arrow.scaleVector.z).toBeCloseTo(origScale.z, 5);
-      expect(arrow.position.x).toBeCloseTo(origPos.x, 5);
-      expect(arrow.position.y).toBeCloseTo(origPos.y, 5);
-      expect(arrow.position.z).toBeCloseTo(origPos.z, 5);
+      const finalCenter = arrow.getCenter();
+      expect(finalCenter[0]).toBeCloseTo(origCenter[0], 5);
+      expect(finalCenter[1]).toBeCloseTo(origCenter[1], 5);
+      expect(finalCenter[2]).toBeCloseTo(origCenter[2], 5);
+      for (let i = 0; i < arrow.children.length; i++) {
+        expect(arrow.children[i].scaleVector.x).toBeCloseTo(origScales[i].x, 5);
+      }
     });
   });
 

--- a/src/animation/growing/growing-extra.test.ts
+++ b/src/animation/growing/growing-extra.test.ts
@@ -86,8 +86,9 @@ describe('GrowArrow (extra)', () => {
       expect(arrow.scaleVector.z).toBeCloseTo(0.001, 5);
     });
 
-    it('position moves continuously from start to midpoint', () => {
+    it('position moves continuously from start to original position', () => {
       const arrow = makeArrow([0, 0, 0], [6, 0, 0]);
+      arrow.position.set(3, 0, 0);
       const anim = new GrowArrow(arrow);
       anim.begin();
 
@@ -104,11 +105,12 @@ describe('GrowArrow (extra)', () => {
       expect(arrow.position.x).toBeCloseTo(2.25, 2);
 
       anim.interpolate(1);
-      expect(arrow.position.x).toBeCloseTo(3, 2); // midpoint
+      expect(arrow.position.x).toBeCloseTo(3, 2);
     });
 
     it('handles arrow with 3D coordinates', () => {
       const arrow = makeArrow([1, 2, 3], [5, 6, 7]);
+      arrow.position.set(3, 4, 5);
       const anim = new GrowArrow(arrow);
       anim.begin();
 
@@ -118,10 +120,10 @@ describe('GrowArrow (extra)', () => {
       expect(arrow.position.z).toBeCloseTo(3, 2);
 
       anim.interpolate(1);
-      // At alpha=1, position should be at midpoint
-      expect(arrow.position.x).toBeCloseTo(3, 2); // (1+5)/2
-      expect(arrow.position.y).toBeCloseTo(4, 2); // (2+6)/2
-      expect(arrow.position.z).toBeCloseTo(5, 2); // (3+7)/2
+      // At alpha=1, position should be restored to original
+      expect(arrow.position.x).toBeCloseTo(3, 2);
+      expect(arrow.position.y).toBeCloseTo(4, 2);
+      expect(arrow.position.z).toBeCloseTo(5, 2);
     });
   });
 
@@ -145,7 +147,9 @@ describe('GrowArrow (extra)', () => {
   describe('finish() after partial interpolation', () => {
     it('restores exact state regardless of last interpolation step', () => {
       const arrow = makeArrow([0, 0, 0], [4, 4, 0]);
+      arrow.position.set(7, -2, 0);
       const origScale = arrow.scaleVector.clone();
+      const origPos = arrow.position.clone();
       const anim = new GrowArrow(arrow);
       anim.begin();
       anim.interpolate(0.1); // barely started
@@ -153,8 +157,9 @@ describe('GrowArrow (extra)', () => {
       expect(arrow.scaleVector.x).toBeCloseTo(origScale.x, 5);
       expect(arrow.scaleVector.y).toBeCloseTo(origScale.y, 5);
       expect(arrow.scaleVector.z).toBeCloseTo(origScale.z, 5);
-      expect(arrow.position.x).toBeCloseTo(2, 2); // midpoint x
-      expect(arrow.position.y).toBeCloseTo(2, 2); // midpoint y
+      expect(arrow.position.x).toBeCloseTo(origPos.x, 5);
+      expect(arrow.position.y).toBeCloseTo(origPos.y, 5);
+      expect(arrow.position.z).toBeCloseTo(origPos.z, 5);
     });
   });
 

--- a/src/animation/growing/index.ts
+++ b/src/animation/growing/index.ts
@@ -21,6 +21,7 @@ export type GrowArrowOptions = AnimationOptions;
  */
 export class GrowArrow extends Animation {
   private _targetScale: THREE.Vector3 = new THREE.Vector3();
+  private _targetPosition: THREE.Vector3 = new THREE.Vector3();
   private _startPoint: Vector3Tuple = [0, 0, 0];
   private _endPoint: Vector3Tuple = [0, 0, 0];
 
@@ -35,6 +36,7 @@ export class GrowArrow extends Animation {
 
     // Store the target state
     this._targetScale.copy(arrow.scaleVector);
+    this._targetPosition.copy(arrow.position);
     this._startPoint = arrow.getStart();
     this._endPoint = arrow.getEnd();
 
@@ -57,18 +59,12 @@ export class GrowArrow extends Animation {
       this._targetScale.z * scale,
     );
 
-    // Interpolate position from start to proper position
+    // Position interpolates from start point to original target position
     const start = this._startPoint;
-    const end = this._endPoint;
-    const midX = (start[0] + end[0]) / 2;
-    const midY = (start[1] + end[1]) / 2;
-    const midZ = (start[2] + end[2]) / 2;
-
-    // Position interpolates from start to center
     arrow.position.set(
-      start[0] + (midX - start[0]) * alpha,
-      start[1] + (midY - start[1]) * alpha,
-      start[2] + (midZ - start[2]) * alpha,
+      start[0] + (this._targetPosition.x - start[0]) * alpha,
+      start[1] + (this._targetPosition.y - start[1]) * alpha,
+      start[2] + (this._targetPosition.z - start[2]) * alpha,
     );
 
     arrow._markDirty();
@@ -78,10 +74,8 @@ export class GrowArrow extends Animation {
     const arrow = this.mobject as Arrow;
     arrow.scaleVector.copy(this._targetScale);
 
-    // Restore proper position
-    const start = this._startPoint;
-    const end = this._endPoint;
-    arrow.position.set((start[0] + end[0]) / 2, (start[1] + end[1]) / 2, (start[2] + end[2]) / 2);
+    // Restore exact original position
+    arrow.position.copy(this._targetPosition);
 
     arrow._markDirty();
     super.finish();

--- a/src/animation/growing/index.ts
+++ b/src/animation/growing/index.ts
@@ -20,40 +20,93 @@ export type GrowArrowOptions = AnimationOptions;
  * The arrow extends from start toward end, with the tip growing proportionally.
  */
 export class GrowArrow extends Animation {
-  private _targetScale: THREE.Vector3 = new THREE.Vector3();
+  private _startPoint = new THREE.Vector3();
+  private _parts: {
+    m: Mobject;
+    pos: THREE.Vector3;
+    scale: THREE.Vector3;
+    // A stable local point used to pin each child during growth.
+    // shaft: first point, tip: apex point.
+    // We animate this anchor from arrow start -> original anchor world.
+    anchorLocal: THREE.Vector3;
+  }[] = [];
 
   constructor(mobject: Arrow, options: GrowArrowOptions = {}) {
     super(mobject, options);
+  }
+
+  /**
+   * Pick one meaningful local anchor per arrow child.
+   * Why this exists:
+   * - Scaling around each child's local origin alone makes tip/shaft drift apart.
+   * - We instead keep a semantic anchor (shaft-start or tip-apex) constrained.
+   * - Given anchorLocal, scale, and position we can solve world anchor exactly:
+   *     anchorWorld = anchorLocal * scale + position
+   *   and invert it to place the child at any animation alpha.
+   */
+  private _getAnchorLocal(child: Mobject, index: number): THREE.Vector3 {
+    const pts = (child as unknown as { getPoints?: () => number[][] }).getPoints?.() ?? [];
+    if (pts.length === 0) return new THREE.Vector3();
+    const i = index === 0 ? 0 : Math.min(3, pts.length - 1); // shaft start, tip apex
+    return new THREE.Vector3(pts[i][0], pts[i][1], pts[i][2]);
   }
 
   override begin(): void {
     super.begin();
 
     const arrow = this.mobject as Arrow;
-    this._targetScale.copy(arrow.scaleVector);
+    const shaft = arrow.children[0] as unknown as {
+      getPoints?: () => number[][];
+      position: THREE.Vector3;
+    };
+    const shaftStart = shaft?.getPoints?.()?.[0] ?? arrow.getStart();
+    this._startPoint.set(
+      shaftStart[0] + (shaft?.position?.x ?? 0),
+      shaftStart[1] + (shaft?.position?.y ?? 0),
+      shaftStart[2] + (shaft?.position?.z ?? 0),
+    );
 
-    // Start near zero to avoid degenerate transform issues
-    arrow.scaleVector.set(0.001, 0.001, 0.001);
-    arrow._markDirty();
+    this._parts = arrow.children.map((m, i) => ({
+      m,
+      pos: m.position.clone(),
+      scale: m.scaleVector.clone(),
+      anchorLocal: this._getAnchorLocal(m, i),
+    }));
+
+    this.interpolate(0);
   }
 
   interpolate(alpha: number): void {
-    const arrow = this.mobject as Arrow;
+    const s = Math.max(0.001, alpha);
+    for (const p of this._parts) {
+      const sx = p.scale.x * s;
+      const sy = p.scale.y * s;
+      const sz = p.scale.z * s;
+      p.m.scaleVector.set(sx, sy, sz);
 
-    const scale = Math.max(0.001, alpha);
-    arrow.scaleVector.set(
-      this._targetScale.x * scale,
-      this._targetScale.y * scale,
-      this._targetScale.z * scale,
-    );
-
-    arrow._markDirty();
+      const targetAx = p.anchorLocal.x * p.scale.x + p.pos.x;
+      const targetAy = p.anchorLocal.y * p.scale.y + p.pos.y;
+      const targetAz = p.anchorLocal.z * p.scale.z + p.pos.z;
+      const ax = this._startPoint.x + (targetAx - this._startPoint.x) * alpha;
+      const ay = this._startPoint.y + (targetAy - this._startPoint.y) * alpha;
+      const az = this._startPoint.z + (targetAz - this._startPoint.z) * alpha;
+      p.m.position.set(
+        ax - p.anchorLocal.x * sx,
+        ay - p.anchorLocal.y * sy,
+        az - p.anchorLocal.z * sz,
+      );
+      p.m._markDirty();
+    }
+    this.mobject._markDirty();
   }
 
   override finish(): void {
-    const arrow = this.mobject as Arrow;
-    arrow.scaleVector.copy(this._targetScale);
-    arrow._markDirty();
+    for (const p of this._parts) {
+      p.m.position.copy(p.pos);
+      p.m.scaleVector.copy(p.scale);
+      p.m._markDirty();
+    }
+    this.mobject._markDirty();
     super.finish();
   }
 }

--- a/src/animation/growing/index.ts
+++ b/src/animation/growing/index.ts
@@ -21,9 +21,6 @@ export type GrowArrowOptions = AnimationOptions;
  */
 export class GrowArrow extends Animation {
   private _targetScale: THREE.Vector3 = new THREE.Vector3();
-  private _targetPosition: THREE.Vector3 = new THREE.Vector3();
-  private _startPoint: Vector3Tuple = [0, 0, 0];
-  private _endPoint: Vector3Tuple = [0, 0, 0];
 
   constructor(mobject: Arrow, options: GrowArrowOptions = {}) {
     super(mobject, options);
@@ -33,38 +30,21 @@ export class GrowArrow extends Animation {
     super.begin();
 
     const arrow = this.mobject as Arrow;
-
-    // Store the target state
     this._targetScale.copy(arrow.scaleVector);
-    this._targetPosition.copy(arrow.position);
-    this._startPoint = arrow.getStart();
-    this._endPoint = arrow.getEnd();
 
-    // Start at scale 0 (from the start point)
-    arrow.scaleVector.set(0.001, 0.001, 0.001); // Use small value to avoid division issues
-
-    // Position at start point
-    const start = this._startPoint;
-    arrow.position.set(start[0], start[1], start[2]);
+    // Start near zero to avoid degenerate transform issues
+    arrow.scaleVector.set(0.001, 0.001, 0.001);
+    arrow._markDirty();
   }
 
   interpolate(alpha: number): void {
     const arrow = this.mobject as Arrow;
 
-    // Scale from 0 to target
     const scale = Math.max(0.001, alpha);
     arrow.scaleVector.set(
       this._targetScale.x * scale,
       this._targetScale.y * scale,
       this._targetScale.z * scale,
-    );
-
-    // Position interpolates from start point to original target position
-    const start = this._startPoint;
-    arrow.position.set(
-      start[0] + (this._targetPosition.x - start[0]) * alpha,
-      start[1] + (this._targetPosition.y - start[1]) * alpha,
-      start[2] + (this._targetPosition.z - start[2]) * alpha,
     );
 
     arrow._markDirty();
@@ -73,10 +53,6 @@ export class GrowArrow extends Animation {
   override finish(): void {
     const arrow = this.mobject as Arrow;
     arrow.scaleVector.copy(this._targetScale);
-
-    // Restore exact original position
-    arrow.position.copy(this._targetPosition);
-
     arrow._markDirty();
     super.finish();
   }

--- a/src/animation/growing/index.ts
+++ b/src/animation/growing/index.ts
@@ -24,8 +24,8 @@ export class GrowArrow extends Animation {
   private _endTipPos = new THREE.Vector3();
   private _endShaftScale = new THREE.Vector3();
   private _endTipScale = new THREE.Vector3();
-  private _shaftCenterOffset = new THREE.Vector3();
-  private _tipCenterOffset = new THREE.Vector3();
+  private _endShaftCenter = new THREE.Vector3();
+  private _endTipCenter = new THREE.Vector3();
 
   constructor(mobject: Arrow, options: GrowArrowOptions = {}) {
     super(mobject, options);
@@ -48,11 +48,11 @@ export class GrowArrow extends Animation {
 
     {
       const c = shaft.getCenter();
-      this._shaftCenterOffset.set(c[0] - sx, c[1] - sy, c[2] - sz);
+      this._endShaftCenter.set(c[0], c[1], c[2]);
     }
     {
       const c = tip.getCenter();
-      this._tipCenterOffset.set(c[0] - sx, c[1] - sy, c[2] - sz);
+      this._endTipCenter.set(c[0], c[1], c[2]);
     }
 
     this.interpolate(0);
@@ -73,29 +73,25 @@ export class GrowArrow extends Animation {
     );
     tip.scaleVector.set(this._endTipScale.x * s, this._endTipScale.y * s, this._endTipScale.z * s);
 
-    const desiredShaftCenter: [number, number, number] = [
-      this._start.x + this._shaftCenterOffset.x * alpha,
-      this._start.y + this._shaftCenterOffset.y * alpha,
-      this._start.z + this._shaftCenterOffset.z * alpha,
-    ];
-    const shaftCenter = shaft.getCenter();
-    shaft.shift([
-      desiredShaftCenter[0] - shaftCenter[0],
-      desiredShaftCenter[1] - shaftCenter[1],
-      desiredShaftCenter[2] - shaftCenter[2],
-    ]);
+    const shaftTargetCenter = new THREE.Vector3().lerpVectors(
+      this._start,
+      this._endShaftCenter,
+      alpha,
+    );
+    {
+      const c = shaft.getCenter();
+      shaft.shift([
+        shaftTargetCenter.x - c[0],
+        shaftTargetCenter.y - c[1],
+        shaftTargetCenter.z - c[2],
+      ]);
+    }
 
-    const desiredTipCenter: [number, number, number] = [
-      this._start.x + this._tipCenterOffset.x * alpha,
-      this._start.y + this._tipCenterOffset.y * alpha,
-      this._start.z + this._tipCenterOffset.z * alpha,
-    ];
-    const tipCenter = tip.getCenter();
-    tip.shift([
-      desiredTipCenter[0] - tipCenter[0],
-      desiredTipCenter[1] - tipCenter[1],
-      desiredTipCenter[2] - tipCenter[2],
-    ]);
+    const tipTargetCenter = new THREE.Vector3().lerpVectors(this._start, this._endTipCenter, alpha);
+    {
+      const c = tip.getCenter();
+      tip.shift([tipTargetCenter.x - c[0], tipTargetCenter.y - c[1], tipTargetCenter.z - c[2]]);
+    }
 
     shaft._markDirty();
     tip._markDirty();

--- a/src/animation/growing/index.ts
+++ b/src/animation/growing/index.ts
@@ -16,86 +16,106 @@ export { GrowFromCenter, growFromCenter, type GrowFromCenterOptions } from '../m
 export type GrowArrowOptions = AnimationOptions;
 
 /**
- * GrowArrow animation - grows an arrow from its start point.
- * The arrow extends from start toward end, with the tip growing proportionally.
+ * GrowArrow animation - interpolate arrow from a start-growth state to end state.
  */
 export class GrowArrow extends Animation {
-  private _startPoint = new THREE.Vector3();
-  private _shaft: Mobject | null = null;
-  private _tip: Mobject | null = null;
-
-  // Target values captured at begin() so interpolation is absolute (not incremental).
-  private _shaftTargetScale = new THREE.Vector3();
-  private _tipTargetScale = new THREE.Vector3();
-  private _tipTargetPos = new THREE.Vector3();
-  private _shaftFixedPos = new THREE.Vector3();
+  private _start = new THREE.Vector3();
+  private _endShaftPos = new THREE.Vector3();
+  private _endTipPos = new THREE.Vector3();
+  private _endShaftScale = new THREE.Vector3();
+  private _endTipScale = new THREE.Vector3();
+  private _shaftCenterOffset = new THREE.Vector3();
+  private _tipCenterOffset = new THREE.Vector3();
 
   constructor(mobject: Arrow, options: GrowArrowOptions = {}) {
     super(mobject, options);
-  }
-
-  private _assertExactVec3(actual: THREE.Vector3, expected: THREE.Vector3, label: string): void {
-    if (actual.x !== expected.x || actual.y !== expected.y || actual.z !== expected.z) {
-      throw new Error(
-        `GrowArrow invariant failed: ${label} expected (${expected.x}, ${expected.y}, ${expected.z}) got (${actual.x}, ${actual.y}, ${actual.z})`,
-      );
-    }
   }
 
   override begin(): void {
     super.begin();
 
     const arrow = this.mobject as Arrow;
+    const shaft = arrow.children[0];
+    const tip = arrow.children[1];
+    if (!shaft || !tip) throw new Error('GrowArrow requires Arrow to have shaft and tip children');
+
     const [sx, sy, sz] = arrow.getStart();
-    this._startPoint.set(sx, sy, sz);
+    this._start.set(sx, sy, sz);
+    this._endShaftPos.copy(shaft.position);
+    this._endTipPos.copy(tip.position);
+    this._endShaftScale.copy(shaft.scaleVector);
+    this._endTipScale.copy(tip.scaleVector);
 
-    this._shaft = arrow.children[0] ?? null;
-    this._tip = arrow.children[1] ?? null;
-
-    this._shaftTargetScale.copy(this._shaft!.scaleVector);
-    this._tipTargetScale.copy(this._tip!.scaleVector);
-    this._tipTargetPos.copy(this._tip!.position);
-    this._shaftFixedPos.copy(this._shaft!.position);
+    {
+      const c = shaft.getCenter();
+      this._shaftCenterOffset.set(c[0] - sx, c[1] - sy, c[2] - sz);
+    }
+    {
+      const c = tip.getCenter();
+      this._tipCenterOffset.set(c[0] - sx, c[1] - sy, c[2] - sz);
+    }
 
     this.interpolate(0);
   }
 
   interpolate(alpha: number): void {
+    const arrow = this.mobject as Arrow;
+    const shaft = arrow.children[0];
+    const tip = arrow.children[1];
+    if (!shaft || !tip) throw new Error('GrowArrow requires Arrow to have shaft and tip children');
+
     const s = Math.max(0.001, alpha);
 
-    this._shaft!.scaleVector.set(
-      this._shaftTargetScale.x * s,
-      this._shaftTargetScale.y * s,
-      this._shaftTargetScale.z * s,
+    shaft.scaleVector.set(
+      this._endShaftScale.x * s,
+      this._endShaftScale.y * s,
+      this._endShaftScale.z * s,
     );
-    // Keep shaft position fixed; growth comes only from scaling.
-    this._shaft!._markDirty();
+    tip.scaleVector.set(this._endTipScale.x * s, this._endTipScale.y * s, this._endTipScale.z * s);
 
-    this._tip!.scaleVector.set(
-      this._tipTargetScale.x * s,
-      this._tipTargetScale.y * s,
-      this._tipTargetScale.z * s,
-    );
-    this._tip!.position.set(
-      this._startPoint.x + (this._tipTargetPos.x - this._startPoint.x) * alpha,
-      this._startPoint.y + (this._tipTargetPos.y - this._startPoint.y) * alpha,
-      this._startPoint.z + (this._tipTargetPos.z - this._startPoint.z) * alpha,
-    );
-    this._tip!._markDirty();
+    const desiredShaftCenter: [number, number, number] = [
+      this._start.x + this._shaftCenterOffset.x * alpha,
+      this._start.y + this._shaftCenterOffset.y * alpha,
+      this._start.z + this._shaftCenterOffset.z * alpha,
+    ];
+    const shaftCenter = shaft.getCenter();
+    shaft.shift([
+      desiredShaftCenter[0] - shaftCenter[0],
+      desiredShaftCenter[1] - shaftCenter[1],
+      desiredShaftCenter[2] - shaftCenter[2],
+    ]);
 
+    const desiredTipCenter: [number, number, number] = [
+      this._start.x + this._tipCenterOffset.x * alpha,
+      this._start.y + this._tipCenterOffset.y * alpha,
+      this._start.z + this._tipCenterOffset.z * alpha,
+    ];
+    const tipCenter = tip.getCenter();
+    tip.shift([
+      desiredTipCenter[0] - tipCenter[0],
+      desiredTipCenter[1] - tipCenter[1],
+      desiredTipCenter[2] - tipCenter[2],
+    ]);
+
+    shaft._markDirty();
+    tip._markDirty();
     this.mobject._markDirty();
   }
 
   override finish(): void {
-    // Canonical animation completion: force end state via alpha=1,
-    // then assert invariants (no separate restore path).
-    this.interpolate(1);
+    const arrow = this.mobject as Arrow;
+    const shaft = arrow.children[0];
+    const tip = arrow.children[1];
+    if (!shaft || !tip) throw new Error('GrowArrow requires Arrow to have shaft and tip children');
 
-    this._assertExactVec3(this._shaft!.position, this._shaftFixedPos, 'shaft position fixed');
-    this._assertExactVec3(this._shaft!.scaleVector, this._shaftTargetScale, 'shaft final scale');
-    this._assertExactVec3(this._tip!.position, this._tipTargetPos, 'tip final position');
-    this._assertExactVec3(this._tip!.scaleVector, this._tipTargetScale, 'tip final scale');
+    shaft.position.copy(this._endShaftPos);
+    tip.position.copy(this._endTipPos);
+    shaft.scaleVector.copy(this._endShaftScale);
+    tip.scaleVector.copy(this._endTipScale);
 
+    shaft._markDirty();
+    tip._markDirty();
+    this.mobject._markDirty();
     super.finish();
   }
 }

--- a/src/animation/growing/index.ts
+++ b/src/animation/growing/index.ts
@@ -21,92 +21,81 @@ export type GrowArrowOptions = AnimationOptions;
  */
 export class GrowArrow extends Animation {
   private _startPoint = new THREE.Vector3();
-  private _parts: {
-    m: Mobject;
-    pos: THREE.Vector3;
-    scale: THREE.Vector3;
-    // A stable local point used to pin each child during growth.
-    // shaft: first point, tip: apex point.
-    // We animate this anchor from arrow start -> original anchor world.
-    anchorLocal: THREE.Vector3;
-  }[] = [];
+  private _shaft: Mobject | null = null;
+  private _tip: Mobject | null = null;
+
+  // Target values captured at begin() so interpolation is absolute (not incremental).
+  private _shaftTargetScale = new THREE.Vector3();
+  private _tipTargetScale = new THREE.Vector3();
+  private _tipTargetPos = new THREE.Vector3();
+  private _shaftFixedPos = new THREE.Vector3();
 
   constructor(mobject: Arrow, options: GrowArrowOptions = {}) {
     super(mobject, options);
   }
 
-  /**
-   * Pick one meaningful local anchor per arrow child.
-   * Why this exists:
-   * - Scaling around each child's local origin alone makes tip/shaft drift apart.
-   * - We instead keep a semantic anchor (shaft-start or tip-apex) constrained.
-   * - Given anchorLocal, scale, and position we can solve world anchor exactly:
-   *     anchorWorld = anchorLocal * scale + position
-   *   and invert it to place the child at any animation alpha.
-   */
-  private _getAnchorLocal(child: Mobject, index: number): THREE.Vector3 {
-    const pts = (child as unknown as { getPoints?: () => number[][] }).getPoints?.() ?? [];
-    if (pts.length === 0) return new THREE.Vector3();
-    const i = index === 0 ? 0 : Math.min(3, pts.length - 1); // shaft start, tip apex
-    return new THREE.Vector3(pts[i][0], pts[i][1], pts[i][2]);
+  private _assertExactVec3(actual: THREE.Vector3, expected: THREE.Vector3, label: string): void {
+    if (actual.x !== expected.x || actual.y !== expected.y || actual.z !== expected.z) {
+      throw new Error(
+        `GrowArrow invariant failed: ${label} expected (${expected.x}, ${expected.y}, ${expected.z}) got (${actual.x}, ${actual.y}, ${actual.z})`,
+      );
+    }
   }
 
   override begin(): void {
     super.begin();
 
     const arrow = this.mobject as Arrow;
-    const shaft = arrow.children[0] as unknown as {
-      getPoints?: () => number[][];
-      position: THREE.Vector3;
-    };
-    const shaftStart = shaft?.getPoints?.()?.[0] ?? arrow.getStart();
-    this._startPoint.set(
-      shaftStart[0] + (shaft?.position?.x ?? 0),
-      shaftStart[1] + (shaft?.position?.y ?? 0),
-      shaftStart[2] + (shaft?.position?.z ?? 0),
-    );
+    const [sx, sy, sz] = arrow.getStart();
+    this._startPoint.set(sx, sy, sz);
 
-    this._parts = arrow.children.map((m, i) => ({
-      m,
-      pos: m.position.clone(),
-      scale: m.scaleVector.clone(),
-      anchorLocal: this._getAnchorLocal(m, i),
-    }));
+    this._shaft = arrow.children[0] ?? null;
+    this._tip = arrow.children[1] ?? null;
+
+    this._shaftTargetScale.copy(this._shaft!.scaleVector);
+    this._tipTargetScale.copy(this._tip!.scaleVector);
+    this._tipTargetPos.copy(this._tip!.position);
+    this._shaftFixedPos.copy(this._shaft!.position);
 
     this.interpolate(0);
   }
 
   interpolate(alpha: number): void {
     const s = Math.max(0.001, alpha);
-    for (const p of this._parts) {
-      const sx = p.scale.x * s;
-      const sy = p.scale.y * s;
-      const sz = p.scale.z * s;
-      p.m.scaleVector.set(sx, sy, sz);
 
-      const targetAx = p.anchorLocal.x * p.scale.x + p.pos.x;
-      const targetAy = p.anchorLocal.y * p.scale.y + p.pos.y;
-      const targetAz = p.anchorLocal.z * p.scale.z + p.pos.z;
-      const ax = this._startPoint.x + (targetAx - this._startPoint.x) * alpha;
-      const ay = this._startPoint.y + (targetAy - this._startPoint.y) * alpha;
-      const az = this._startPoint.z + (targetAz - this._startPoint.z) * alpha;
-      p.m.position.set(
-        ax - p.anchorLocal.x * sx,
-        ay - p.anchorLocal.y * sy,
-        az - p.anchorLocal.z * sz,
-      );
-      p.m._markDirty();
-    }
+    this._shaft!.scaleVector.set(
+      this._shaftTargetScale.x * s,
+      this._shaftTargetScale.y * s,
+      this._shaftTargetScale.z * s,
+    );
+    // Keep shaft position fixed; growth comes only from scaling.
+    this._shaft!._markDirty();
+
+    this._tip!.scaleVector.set(
+      this._tipTargetScale.x * s,
+      this._tipTargetScale.y * s,
+      this._tipTargetScale.z * s,
+    );
+    this._tip!.position.set(
+      this._startPoint.x + (this._tipTargetPos.x - this._startPoint.x) * alpha,
+      this._startPoint.y + (this._tipTargetPos.y - this._startPoint.y) * alpha,
+      this._startPoint.z + (this._tipTargetPos.z - this._startPoint.z) * alpha,
+    );
+    this._tip!._markDirty();
+
     this.mobject._markDirty();
   }
 
   override finish(): void {
-    for (const p of this._parts) {
-      p.m.position.copy(p.pos);
-      p.m.scaleVector.copy(p.scale);
-      p.m._markDirty();
-    }
-    this.mobject._markDirty();
+    // Canonical animation completion: force end state via alpha=1,
+    // then assert invariants (no separate restore path).
+    this.interpolate(1);
+
+    this._assertExactVec3(this._shaft!.position, this._shaftFixedPos, 'shaft position fixed');
+    this._assertExactVec3(this._shaft!.scaleVector, this._shaftTargetScale, 'shaft final scale');
+    this._assertExactVec3(this._tip!.position, this._tipTargetPos, 'tip final position');
+    this._assertExactVec3(this._tip!.scaleVector, this._tipTargetScale, 'tip final scale');
+
     super.finish();
   }
 }

--- a/src/animation/transform/PointMorphStrategy.ts
+++ b/src/animation/transform/PointMorphStrategy.ts
@@ -26,6 +26,8 @@ interface VGroupLeafState {
   targetPoints: number[][];
   startPosition: THREE.Vector3;
   targetPosition: THREE.Vector3;
+  startScale: THREE.Vector3;
+  targetScale: THREE.Vector3;
   finalTargetPoints: number[][];
   finalTargetSubpathLengths?: number[];
   startStyle: ChildStyle;
@@ -151,12 +153,24 @@ export class PointMorphStrategy implements MorphStrategy {
     } else child.setTransformSubpathLengths(undefined);
     const startStyle = sourceIsPlaceholder ? captureStyleFaded(tc) : captureStyle(child);
     const targetStyle = targetIsPlaceholder ? captureStyleFaded(sc) : captureStyle(tc);
+    const startScale = new THREE.Vector3(
+      src.leaf.scaleVector.x,
+      src.leaf.scaleVector.y,
+      src.leaf.scaleVector.z,
+    );
+    const targetScale = new THREE.Vector3(
+      tgt.leaf.scaleVector.x,
+      tgt.leaf.scaleVector.y,
+      tgt.leaf.scaleVector.z,
+    );
     return {
       child,
       startPoints,
       targetPoints,
       startPosition: worldToParentLocalPosition(src.worldPosition, src.parentWorldMatrix),
       targetPosition: worldToParentLocalPosition(tgt.worldPosition, src.parentWorldMatrix),
+      startScale,
+      targetScale,
       finalTargetPoints,
       finalTargetSubpathLengths,
       startStyle,
@@ -181,6 +195,7 @@ export class PointMorphStrategy implements MorphStrategy {
           interpolated.push(lerpPoint(leaf.startPoints[i], leaf.targetPoints[i], alpha));
         leaf.child.setPoints(interpolated);
         leaf.child.position.lerpVectors(leaf.startPosition, leaf.targetPosition, alpha);
+        leaf.child.scaleVector.lerpVectors(leaf.startScale, leaf.targetScale, alpha);
         const ss = leaf.startStyle,
           ts = leaf.targetStyle;
         leaf.child.opacity = ss.opacity + (ts.opacity - ss.opacity) * alpha;
@@ -238,6 +253,7 @@ export class PointMorphStrategy implements MorphStrategy {
       for (const leaf of this._vgroupLeafStates) {
         leaf.child.setPoints(leaf.finalTargetPoints);
         leaf.child.position.copy(leaf.targetPosition);
+        leaf.child.scaleVector.copy(leaf.targetScale);
         const ts = leaf.targetStyle;
         leaf.child.opacity = ts.opacity;
         leaf.child.fillOpacity = ts.fillOpacity;

--- a/src/core/VGroup.ts
+++ b/src/core/VGroup.ts
@@ -203,20 +203,41 @@ export class VGroup extends VMobject {
   }
 
   /**
-   * Rotate all children around an axis.
+   * Rotate all children around a shared pivot.
+   *
+   * By default this uses the VGroup center as pivot, matching container-style
+   * behavior used by moveTo/scale on VGroup.
+   *
    * @param angle - Rotation angle in radians
-   * @param axis - Axis of rotation [x, y, z], defaults to Z axis
+   * @param axisOrOptions - Axis tuple or options with axis/aboutPoint/aboutEdge
    * @returns this for chaining
    */
-  override rotate(angle: number, axis: Vector3Tuple = [0, 0, 1]): this {
-    // Apply to group's own rotation
-    super.rotate(angle, axis);
+  override rotate(
+    angle: number,
+    axisOrOptions?:
+      | Vector3Tuple
+      | { axis?: Vector3Tuple; aboutPoint?: Vector3Tuple; aboutEdge?: Vector3Tuple },
+  ): this {
+    let axis: Vector3Tuple = [0, 0, 1];
+    let aboutPoint: Vector3Tuple | undefined;
 
-    // Also rotate each child
-    for (const child of this.children) {
-      child.rotate(angle, axis);
+    if (axisOrOptions) {
+      if (Array.isArray(axisOrOptions)) {
+        axis = axisOrOptions;
+      } else {
+        axis = axisOrOptions.axis ?? [0, 0, 1];
+        aboutPoint =
+          axisOrOptions.aboutPoint ??
+          (axisOrOptions.aboutEdge ? this._getEdgeInDirection(axisOrOptions.aboutEdge) : undefined);
+      }
     }
 
+    const pivot = aboutPoint ?? this.getCenter();
+    for (const child of this.children) {
+      child.rotate(angle, { axis, aboutPoint: pivot });
+    }
+
+    this._markDirty();
     return this;
   }
 

--- a/src/core/core-extra.test.ts
+++ b/src/core/core-extra.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Mobject, UP, LEFT, RIGHT, UL, UR, DL } from './Mobject';
+import { Mobject, UP, LEFT, RIGHT, UL, UR, DL, registerAnimateProxy } from './Mobject';
+import { Scene } from './Scene';
+import { AnimateProxy } from './AnimateProxy';
+
+// Register animate proxy for tests using animate API
+registerAnimateProxy((mobject) => new AnimateProxy(mobject));
 import { VMobject } from './VMobject';
 import {
   getNumCurves,
@@ -1824,6 +1829,22 @@ describe('VGroup - extended coverage', () => {
     vg.scale([2, 3, 1]);
     expect(a.scaleVector.x).toBe(2);
     expect(a.scaleVector.y).toBe(3);
+  });
+
+  it('animate.scale ends with correct scaleVector', async () => {
+    const scene = Scene.createHeadless({ width: 800, height: 450 });
+
+    const a = new VMobject();
+    a.scaleVector.set(1, 1, 1);
+    const vg = new VGroup(a);
+    scene.add(vg);
+
+    await scene.play(vg.animate.scale(2));
+
+    // After animate.scale, child should have correct scaleVector
+    expect(a.scaleVector.x).toBe(2);
+    expect(a.scaleVector.y).toBe(2);
+    expect(a.scaleVector.z).toBe(2);
   });
 
   it('setColor propagates to children', () => {

--- a/src/core/core-extra.test.ts
+++ b/src/core/core-extra.test.ts
@@ -1785,19 +1785,25 @@ describe('VGroup - extended coverage', () => {
     // should have shifted to align
   });
 
-  it('rotate delegates to children and self', () => {
+  it('rotate rotates children about group center by default', () => {
     const a = new VMobject();
-    a.setPoints([
-      [1, 0, 0],
-      [1, 0, 0],
-      [1, 0, 0],
-      [1, 0, 0],
-    ]);
-    const vg = new VGroup(a);
-    vg.rotate(Math.PI / 2);
-    // child should have been rotated
-  });
+    a.position.set(1, 0, 0);
+    const b = new VMobject();
+    b.position.set(-1, 0, 0);
 
+    const vg = new VGroup(a, b);
+    const center = vg.getCenter();
+
+    vg.rotate(Math.PI);
+
+    expect(vg.getCenter()[0]).toBeCloseTo(center[0], 6);
+    expect(vg.getCenter()[1]).toBeCloseTo(center[1], 6);
+
+    expect(a.position.x).toBeCloseTo(-1, 6);
+    expect(a.position.y).toBeCloseTo(0, 6);
+    expect(b.position.x).toBeCloseTo(1, 6);
+    expect(b.position.y).toBeCloseTo(0, 6);
+  });
   it('scale scales children about group center', () => {
     const a = new VMobject();
     a.position.set(0, 0, 0);

--- a/src/mobjects/geometry/Arrow.ts
+++ b/src/mobjects/geometry/Arrow.ts
@@ -83,6 +83,26 @@ class ArrowTip extends VMobject {
   }
 }
 
+function perpendicularFromDirection(dirX: number, dirY: number, dirZ: number): Vector3Tuple {
+  const ref: Vector3Tuple = Math.abs(dirZ) < 0.9 ? [0, 0, 1] : [1, 0, 0];
+
+  // ref × dir
+  let px = ref[1] * dirZ - ref[2] * dirY;
+  let py = ref[2] * dirX - ref[0] * dirZ;
+  let pz = ref[0] * dirY - ref[1] * dirX;
+
+  let len = Math.sqrt(px * px + py * py + pz * pz);
+  if (len < 1e-10) {
+    const alt: Vector3Tuple = [0, 1, 0];
+    px = alt[1] * dirZ - alt[2] * dirY;
+    py = alt[2] * dirX - alt[0] * dirZ;
+    pz = alt[0] * dirY - alt[1] * dirX;
+    len = Math.sqrt(px * px + py * py + pz * pz) || 1;
+  }
+
+  return [px / len, py / len, pz / len];
+}
+
 /**
  * Arrow - A line with an arrowhead at the end
  *
@@ -106,8 +126,6 @@ class ArrowTip extends VMobject {
  * ```
  */
 export class Arrow extends Group {
-  private _start: Vector3Tuple;
-  private _end: Vector3Tuple;
   private _tipLength: number;
   private _tipWidth: number;
   private _strokeWidth: number;
@@ -126,24 +144,22 @@ export class Arrow extends Group {
       tipWidth = 0.1,
     } = options;
 
-    this._start = [...start];
-    this._end = [...end];
     this._tipLength = tipLength;
     this._tipWidth = tipWidth;
     this._color = color;
     this._strokeWidth = strokeWidth;
 
-    this._generateParts();
+    this._generateParts(start, end);
   }
 
   /**
    * Generate the arrow parts (shaft line + tip triangle)
    */
-  private _generateParts(): void {
+  private _generateParts(start: Vector3Tuple, end: Vector3Tuple): void {
     this.clear();
 
-    const [x0, y0, z0] = this._start;
-    const [x1, y1, z1] = this._end;
+    const [x0, y0, z0] = start;
+    const [x1, y1, z1] = end;
 
     const dx = x1 - x0;
     const dy = y1 - y0;
@@ -158,19 +174,7 @@ export class Arrow extends Group {
     const dirY = dy / length;
     const dirZ = dz / length;
 
-    let perpX: number, perpY: number, perpZ: number;
-    if (Math.abs(dirZ) > 0.99) {
-      perpX = 1;
-      perpY = 0;
-      perpZ = 0;
-    } else {
-      perpX = -dirY;
-      perpY = dirX;
-      perpZ = 0;
-      const perpLen = Math.sqrt(perpX * perpX + perpY * perpY);
-      perpX /= perpLen;
-      perpY /= perpLen;
-    }
+    const [perpX, perpY, perpZ] = perpendicularFromDirection(dirX, dirY, dirZ);
 
     const tipBaseX = x1 - dirX * this._tipLength;
     const tipBaseY = y1 - dirY * this._tipLength;
@@ -203,41 +207,57 @@ export class Arrow extends Group {
    * Get the start point
    */
   getStart(): Vector3Tuple {
-    return [...this._start];
+    const shaftPts = this._shaft?.getPoints();
+    if (shaftPts && shaftPts.length > 0) {
+      const p = shaftPts[0];
+      return [p[0], p[1], p[2]];
+    }
+    return [0, 0, 0];
   }
 
   /**
-   * Set the start point
+   * Set both start and end points in one canonical operation.
+   */
+  putStartAndEndOn(start: Vector3Tuple, end: Vector3Tuple): this {
+    this._generateParts(start, end);
+    return this;
+  }
+
+  /**
+   * @deprecated Use putStartAndEndOn(start, end) for canonical endpoint updates.
    */
   setStart(point: Vector3Tuple): this {
-    this._start = [...point];
-    this._generateParts();
-    return this;
+    return this.putStartAndEndOn(point, this.getEnd());
   }
 
   /**
    * Get the end point (tip of the arrow)
    */
   getEnd(): Vector3Tuple {
-    return [...this._end];
+    const tipPts = this._tip?.getPoints();
+    if (tipPts && tipPts.length > 3) {
+      const p = tipPts[3];
+      return [p[0], p[1], p[2]];
+    }
+    return [0, 0, 0];
   }
 
   /**
-   * Set the end point (tip of the arrow)
+   * @deprecated Use putStartAndEndOn(start, end) for canonical endpoint updates.
    */
   setEnd(point: Vector3Tuple): this {
-    this._end = [...point];
-    this._generateParts();
-    return this;
+    return this.putStartAndEndOn(this.getStart(), point);
   }
 
   /**
    * Get the length of the arrow (including tip)
    */
   getLength(): number {
-    const dx = this._end[0] - this._start[0];
-    const dy = this._end[1] - this._start[1];
-    const dz = this._end[2] - this._start[2];
+    const start = this.getStart();
+    const end = this.getEnd();
+    const dx = end[0] - start[0];
+    const dy = end[1] - start[1];
+    const dz = end[2] - start[2];
     return Math.sqrt(dx * dx + dy * dy + dz * dz);
   }
 
@@ -253,7 +273,7 @@ export class Arrow extends Group {
    */
   setTipLength(value: number): this {
     this._tipLength = value;
-    this._generateParts();
+    this.putStartAndEndOn(this.getStart(), this.getEnd());
     return this;
   }
 
@@ -269,7 +289,7 @@ export class Arrow extends Group {
    */
   setTipWidth(value: number): this {
     this._tipWidth = value;
-    this._generateParts();
+    this.putStartAndEndOn(this.getStart(), this.getEnd());
     return this;
   }
 
@@ -281,10 +301,12 @@ export class Arrow extends Group {
     if (length === 0) {
       return [1, 0, 0];
     }
+    const start = this.getStart();
+    const end = this.getEnd();
     return [
-      (this._end[0] - this._start[0]) / length,
-      (this._end[1] - this._start[1]) / length,
-      (this._end[2] - this._start[2]) / length,
+      (end[0] - start[0]) / length,
+      (end[1] - start[1]) / length,
+      (end[2] - start[2]) / length,
     ];
   }
 
@@ -292,7 +314,9 @@ export class Arrow extends Group {
    * Get the angle of the arrow in the XY plane (in radians)
    */
   getAngle(): number {
-    return Math.atan2(this._end[1] - this._start[1], this._end[0] - this._start[0]);
+    const start = this.getStart();
+    const end = this.getEnd();
+    return Math.atan2(end[1] - start[1], end[0] - start[0]);
   }
 
   /**
@@ -311,7 +335,6 @@ export class Arrow extends Group {
     const curTipPts = this._tip.getPoints();
     if (curTipPts.length < 4) return;
 
-    const start = shaftPts[0];
     const shaftEnd = shaftPts[shaftPts.length - 1];
     const tipApex = curTipPts[3]; // already at the correct transformed position
 
@@ -325,19 +348,7 @@ export class Arrow extends Group {
     const dirY = dy / len;
     const dirZ = dz / len;
 
-    let perpX: number, perpY: number, perpZ: number;
-    if (Math.abs(dirZ) > 0.99) {
-      perpX = 1;
-      perpY = 0;
-      perpZ = 0;
-    } else {
-      perpX = -dirY;
-      perpY = dirX;
-      perpZ = 0;
-      const perpLen = Math.sqrt(perpX * perpX + perpY * perpY);
-      perpX /= perpLen;
-      perpY /= perpLen;
-    }
+    const [perpX, perpY, perpZ] = perpendicularFromDirection(dirX, dirY, dirZ);
 
     const halfW = this._tipWidth;
     const tipLeft = [
@@ -365,9 +376,6 @@ export class Arrow extends Group {
     addSeg(newPts, tipApex, tipRight, false);
     addSeg(newPts, tipRight, tipLeft, false);
     this._tip.setPoints(newPts);
-
-    this._start = [start[0], start[1], start[2]];
-    this._end = [tipApex[0], tipApex[1], tipApex[2]];
   }
 
   /**
@@ -375,8 +383,8 @@ export class Arrow extends Group {
    */
   protected override _createCopy(): Arrow {
     return new Arrow({
-      start: this._start,
-      end: this._end,
+      start: this.getStart(),
+      end: this.getEnd(),
       tipLength: this._tipLength,
       tipWidth: this._tipWidth,
       color: this.color,
@@ -389,8 +397,6 @@ export class Arrow extends Group {
  * DoubleArrow - An arrow with tips on both ends
  */
 export class DoubleArrow extends Group {
-  private _start: Vector3Tuple;
-  private _end: Vector3Tuple;
   private _tipLength: number;
   private _tipWidth: number;
   private _strokeWidth: number;
@@ -407,21 +413,19 @@ export class DoubleArrow extends Group {
       tipWidth = 0.1,
     } = options;
 
-    this._start = [...start];
-    this._end = [...end];
     this._tipLength = tipLength;
     this._tipWidth = tipWidth;
     this._color = color;
     this._strokeWidth = strokeWidth;
 
-    this._generateParts();
+    this._generateParts(start, end);
   }
 
-  private _generateParts(): void {
+  private _generateParts(start: Vector3Tuple, end: Vector3Tuple): void {
     this.clear();
 
-    const [x0, y0, z0] = this._start;
-    const [x1, y1, z1] = this._end;
+    const [x0, y0, z0] = start;
+    const [x1, y1, z1] = end;
 
     const dx = x1 - x0;
     const dy = y1 - y0;
@@ -436,19 +440,7 @@ export class DoubleArrow extends Group {
     const dirY = dy / length;
     const dirZ = dz / length;
 
-    let perpX: number, perpY: number, perpZ: number;
-    if (Math.abs(dirZ) > 0.99) {
-      perpX = 1;
-      perpY = 0;
-      perpZ = 0;
-    } else {
-      perpX = -dirY;
-      perpY = dirX;
-      perpZ = 0;
-      const perpLen = Math.sqrt(perpX * perpX + perpY * perpY);
-      perpX /= perpLen;
-      perpY /= perpLen;
-    }
+    const [perpX, perpY, perpZ] = perpendicularFromDirection(dirX, dirY, dirZ);
 
     const endTipBaseX = x1 - dirX * this._tipLength;
     const endTipBaseY = y1 - dirY * this._tipLength;
@@ -495,29 +487,74 @@ export class DoubleArrow extends Group {
   }
 
   getStart(): Vector3Tuple {
-    return [...this._start];
+    const kids = this.children;
+    if (kids.length < 3) return [0, 0, 0];
+    const startTip = kids[2] as ArrowTip;
+    const pts = startTip.getPoints();
+    if (pts.length > 3) {
+      const p = pts[3];
+      return [p[0], p[1], p[2]];
+    }
+    return [0, 0, 0];
   }
 
-  setStart(point: Vector3Tuple): this {
-    this._start = [...point];
-    this._generateParts();
+  putStartAndEndOn(start: Vector3Tuple, end: Vector3Tuple): this {
+    this._generateParts(start, end);
     return this;
+  }
+
+  setTipLength(value: number): this {
+    this._tipLength = value;
+    this.putStartAndEndOn(this.getStart(), this.getEnd());
+    return this;
+  }
+
+  getTipLength(): number {
+    return this._tipLength;
+  }
+
+  setTipWidth(value: number): this {
+    this._tipWidth = value;
+    this.putStartAndEndOn(this.getStart(), this.getEnd());
+    return this;
+  }
+
+  getTipWidth(): number {
+    return this._tipWidth;
+  }
+
+  /**
+   * @deprecated Use putStartAndEndOn(start, end) for canonical endpoint updates.
+   */
+  setStart(point: Vector3Tuple): this {
+    return this.putStartAndEndOn(point, this.getEnd());
   }
 
   getEnd(): Vector3Tuple {
-    return [...this._end];
+    const kids = this.children;
+    if (kids.length < 2) return [0, 0, 0];
+    const endTip = kids[1] as ArrowTip;
+    const pts = endTip.getPoints();
+    if (pts.length > 3) {
+      const p = pts[3];
+      return [p[0], p[1], p[2]];
+    }
+    return [0, 0, 0];
   }
 
+  /**
+   * @deprecated Use putStartAndEndOn(start, end) for canonical endpoint updates.
+   */
   setEnd(point: Vector3Tuple): this {
-    this._end = [...point];
-    this._generateParts();
-    return this;
+    return this.putStartAndEndOn(this.getStart(), point);
   }
 
   getLength(): number {
-    const dx = this._end[0] - this._start[0];
-    const dy = this._end[1] - this._start[1];
-    const dz = this._end[2] - this._start[2];
+    const start = this.getStart();
+    const end = this.getEnd();
+    const dx = end[0] - start[0];
+    const dy = end[1] - start[1];
+    const dz = end[2] - start[2];
     return Math.sqrt(dx * dx + dy * dy + dz * dz);
   }
 
@@ -582,19 +619,7 @@ export class DoubleArrow extends Group {
         dyn = dy / len,
         dzn = dz / len;
 
-      let perpX: number, perpY: number, perpZ: number;
-      if (Math.abs(dzn) > 0.99) {
-        perpX = 1;
-        perpY = 0;
-        perpZ = 0;
-      } else {
-        perpX = -dyn;
-        perpY = dxn;
-        perpZ = 0;
-        const pl = Math.sqrt(perpX * perpX + perpY * perpY);
-        perpX /= pl;
-        perpY /= pl;
-      }
+      const [perpX, perpY, perpZ] = perpendicularFromDirection(dxn, dyn, dzn);
 
       const left = [base[0] + perpX * halfW, base[1] + perpY * halfW, base[2] + perpZ * halfW];
       const right = [base[0] - perpX * halfW, base[1] - perpY * halfW, base[2] - perpZ * halfW];
@@ -613,15 +638,12 @@ export class DoubleArrow extends Group {
 
     rebuildTip(shaftEnd, endApex, endTipVM, false);
     rebuildTip(shaftStart, startApex, startTipVM, true);
-
-    this._start = [startApex[0], startApex[1], startApex[2]];
-    this._end = [endApex[0], endApex[1], endApex[2]];
   }
 
   protected override _createCopy(): DoubleArrow {
     return new DoubleArrow({
-      start: this._start,
-      end: this._end,
+      start: this.getStart(),
+      end: this.getEnd(),
       tipLength: this._tipLength,
       tipWidth: this._tipWidth,
       color: this._color,

--- a/src/mobjects/geometry/Arrow.ts
+++ b/src/mobjects/geometry/Arrow.ts
@@ -182,11 +182,20 @@ function perpendicularFromDirection(dirX: number, dirY: number, dirZ: number): V
  * ```
  */
 export class Arrow extends VGroup {
+  /** Configured triangle depth measured from apex back toward shaft. */
   private _tipLength: number;
+  /** Configured half-width from tip base-center to either side corner. */
   private _tipWidth: number;
+  /** Shaft stroke width used when regenerating parts. */
   private _strokeWidth: number;
+  /** Internal shaft child (always present after putStartAndEndOn, including zero-length). */
   private _shaft: ArrowShaft | null = null;
+  /** Internal tip child (always present after putStartAndEndOn, including zero-length). */
   private _tip: ArrowTip | null = null;
+  /**
+   * Canonical local vector from arrow center to start endpoint at unit shaft scale.
+   * End endpoint is the negation of this vector.
+   */
   private _originToStartLocal: Vector3Tuple = [0, 0, 0];
 
   constructor(options: ArrowOptions = {}) {
@@ -209,6 +218,12 @@ export class Arrow extends VGroup {
     this.putStartAndEndOn(start, end);
   }
 
+  /**
+   * Convert full arrow delta to shaft delta by removing tip length along direction.
+   *
+   * Convention: tip geometry is built from full `delta`, shaft geometry from
+   * `max(0, |delta| - tipLength)` in the same direction.
+   */
   private _getShaftDelta(delta: Vector3Tuple): Vector3Tuple {
     const [dx, dy, dz] = delta;
     const length = Math.sqrt(dx * dx + dy * dy + dz * dz);
@@ -220,9 +235,13 @@ export class Arrow extends VGroup {
   }
 
   /**
-   * Generate the arrow parts (shaft line + tip triangle)
+   * Regenerate canonical children from endpoint delta.
    *
-   * Uses delta vector to compute positions directly.
+   * Conventions:
+   * - Always rebuilds children (no in-place geometry mutation).
+   * - Zero-length still yields canonical shaft+tip children.
+   * - Tip local geometry is centered via centerPointsAroundPosition(), so
+   *   `tip.getCenter() === tip.position` for the child object itself.
    */
   private _generateParts(delta: Vector3Tuple): void {
     this.remove(...this.children);
@@ -274,7 +293,12 @@ export class Arrow extends VGroup {
 
   /**
    * Set both start and end points in one canonical operation.
-   * Does not modify the group's own position.
+   *
+   * Conventions:
+   * - Regenerates shaft/tip from delta every call.
+   * - Does not mutate this VGroup's own position.
+   * - Places shaft carrier at geometric midpoint.
+   * - Places tip carrier at midpoint + shaftDelta/2 (forward along direction).
    */
   putStartAndEndOn(start: Vector3Tuple, end: Vector3Tuple): this {
     const delta: Vector3Tuple = [end[0] - start[0], end[1] - start[1], end[2] - start[2]];

--- a/src/mobjects/geometry/Arrow.ts
+++ b/src/mobjects/geometry/Arrow.ts
@@ -25,26 +25,23 @@ export interface ArrowOptions {
  * ArrowShaft - The line part of an arrow (internal use)
  */
 class ArrowShaft extends VMobject {
-  constructor(start: number[], end: number[], color: string, strokeWidth: number) {
+  constructor(delta: number[], color: string, strokeWidth: number) {
     super();
     this.color = color;
     this.strokeWidth = strokeWidth;
     this.fillOpacity = 0;
 
-    const dx = end[0] - start[0];
-    const dy = end[1] - start[1];
-    const dz = end[2] - start[2];
-
+    const [dx, dy, dz] = delta;
     this.setPoints3D([
-      [...start],
-      [start[0] + dx / 3, start[1] + dy / 3, start[2] + dz / 3],
-      [start[0] + (2 * dx) / 3, start[1] + (2 * dy) / 3, start[2] + (2 * dz) / 3],
-      [...end],
+      [0, 0, 0],
+      [dx / 3, dy / 3, dz / 3],
+      [(2 * dx) / 3, (2 * dy) / 3, (2 * dz) / 3],
+      [dx, dy, dz],
     ]);
   }
 
   protected _createCopy(): ArrowShaft {
-    return new ArrowShaft([0, 0, 0], [1, 0, 0], this.color, this.strokeWidth);
+    return new ArrowShaft([1, 0, 0], this.color, this.strokeWidth);
   }
 }
 
@@ -52,22 +49,51 @@ class ArrowShaft extends VMobject {
  * ArrowTip - The triangular tip of an arrow (internal use)
  */
 class ArrowTip extends VMobject {
-  constructor(tipPoint: number[], tipLeft: number[], tipRight: number[], color: string) {
+  constructor(delta: number[], tipLength: number, tipWidth: number, color: string) {
     super();
     this.color = color;
     this.fillOpacity = 1;
     this.strokeWidth = 0;
 
-    const addLineSegment = (points: number[][], p0: number[], p1: number[], isFirst: boolean) => {
-      const dx = p1[0] - p0[0];
-      const dy = p1[1] - p0[1];
-      const dz = p1[2] - p0[2];
+    const [dx, dy, dz] = delta;
+    const len = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (len === 0) {
+      this.setPoints3D([
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+      ]);
+      return;
+    }
 
-      if (isFirst) {
-        points.push([...p0]);
-      }
-      points.push([p0[0] + dx / 3, p0[1] + dy / 3, p0[2] + dz / 3]);
-      points.push([p0[0] + (2 * dx) / 3, p0[1] + (2 * dy) / 3, p0[2] + (2 * dz) / 3]);
+    const dirX = dx / len;
+    const dirY = dy / len;
+    const dirZ = dz / len;
+    const [perpX, perpY, perpZ] = perpendicularFromDirection(dirX, dirY, dirZ);
+
+    const baseCenter: Vector3Tuple = [-dirX * tipLength, -dirY * tipLength, -dirZ * tipLength];
+    const widthOffset = tipWidth;
+    const tipPoint: Vector3Tuple = [0, 0, 0];
+    const tipLeft: Vector3Tuple = [
+      baseCenter[0] + perpX * widthOffset,
+      baseCenter[1] + perpY * widthOffset,
+      baseCenter[2] + perpZ * widthOffset,
+    ];
+    const tipRight: Vector3Tuple = [
+      baseCenter[0] - perpX * widthOffset,
+      baseCenter[1] - perpY * widthOffset,
+      baseCenter[2] - perpZ * widthOffset,
+    ];
+
+    const addLineSegment = (points: number[][], p0: number[], p1: number[], isFirst: boolean) => {
+      const sdx = p1[0] - p0[0];
+      const sdy = p1[1] - p0[1];
+      const sdz = p1[2] - p0[2];
+
+      if (isFirst) points.push([...p0]);
+      points.push([p0[0] + sdx / 3, p0[1] + sdy / 3, p0[2] + sdz / 3]);
+      points.push([p0[0] + (2 * sdx) / 3, p0[1] + (2 * sdy) / 3, p0[2] + (2 * sdz) / 3]);
       points.push([...p1]);
     };
 
@@ -79,7 +105,7 @@ class ArrowTip extends VMobject {
   }
 
   protected _createCopy(): ArrowTip {
-    return new ArrowTip([0, 0, 0], [0, 0, 0], [0, 0, 0], this.color);
+    return new ArrowTip([1, 0, 0], 0.3, 0.1, this.color);
   }
 }
 
@@ -149,57 +175,32 @@ export class Arrow extends Group {
     this._color = color;
     this._strokeWidth = strokeWidth;
 
-    this._generateParts(start, end);
+    this.putStartAndEndOn(start, end);
   }
 
   /**
    * Generate the arrow parts (shaft line + tip triangle)
+   *
+   * Uses delta vector to compute positions directly.
    */
-  private _generateParts(start: Vector3Tuple, end: Vector3Tuple): void {
+  private _generateParts(delta: Vector3Tuple): void {
     this.clear();
 
-    const [x0, y0, z0] = start;
-    const [x1, y1, z1] = end;
-
-    const dx = x1 - x0;
-    const dy = y1 - y0;
-    const dz = z1 - z0;
+    const [dx, dy, dz] = delta;
     const length = Math.sqrt(dx * dx + dy * dy + dz * dz);
-
-    if (length === 0) {
-      return;
-    }
+    if (length === 0) return;
 
     const dirX = dx / length;
     const dirY = dy / length;
     const dirZ = dz / length;
 
-    const [perpX, perpY, perpZ] = perpendicularFromDirection(dirX, dirY, dirZ);
+    const shaftLength = length - this._tipLength;
+    const shaftDelta: Vector3Tuple = [dirX * shaftLength, dirY * shaftLength, dirZ * shaftLength];
 
-    const tipBaseX = x1 - dirX * this._tipLength;
-    const tipBaseY = y1 - dirY * this._tipLength;
-    const tipBaseZ = z1 - dirZ * this._tipLength;
+    this._shaft = new ArrowShaft(shaftDelta, this._color, this._strokeWidth);
+    this._tip = new ArrowTip(delta, this._tipLength, this._tipWidth, this._color);
 
-    const tipLeft = [
-      tipBaseX + perpX * this._tipWidth,
-      tipBaseY + perpY * this._tipWidth,
-      tipBaseZ + perpZ * this._tipWidth,
-    ];
-    const tipRight = [
-      tipBaseX - perpX * this._tipWidth,
-      tipBaseY - perpY * this._tipWidth,
-      tipBaseZ - perpZ * this._tipWidth,
-    ];
-
-    this._shaft = new ArrowShaft(
-      [x0, y0, z0],
-      [tipBaseX, tipBaseY, tipBaseZ],
-      this._color,
-      this._strokeWidth,
-    );
     this.add(this._shaft);
-
-    this._tip = new ArrowTip([x1, y1, z1], tipLeft, tipRight, this._color);
     this.add(this._tip);
   }
 
@@ -207,19 +208,20 @@ export class Arrow extends Group {
    * Get the start point
    */
   getStart(): Vector3Tuple {
-    const shaftPts = this._shaft?.getPoints();
-    if (shaftPts && shaftPts.length > 0) {
-      const p = shaftPts[0];
-      return [p[0], p[1], p[2]];
-    }
-    return [0, 0, 0];
+    const pos = this._shaft!.position;
+    return [pos.x, pos.y, pos.z];
   }
 
   /**
    * Set both start and end points in one canonical operation.
+   * Does not modify the group's own position.
    */
   putStartAndEndOn(start: Vector3Tuple, end: Vector3Tuple): this {
-    this._generateParts(start, end);
+    const delta: Vector3Tuple = [end[0] - start[0], end[1] - start[1], end[2] - start[2]];
+    this._generateParts(delta);
+
+    this._shaft!.moveTo(start);
+    this._tip!.moveTo(end);
     return this;
   }
 
@@ -234,12 +236,8 @@ export class Arrow extends Group {
    * Get the end point (tip of the arrow)
    */
   getEnd(): Vector3Tuple {
-    const tipPts = this._tip?.getPoints();
-    if (tipPts && tipPts.length > 3) {
-      const p = tipPts[3];
-      return [p[0], p[1], p[2]];
-    }
-    return [0, 0, 0];
+    const pos = this._tip!.position;
+    return [pos.x, pos.y, pos.z];
   }
 
   /**
@@ -418,88 +416,58 @@ export class DoubleArrow extends Group {
     this._color = color;
     this._strokeWidth = strokeWidth;
 
-    this._generateParts(start, end);
+    this.putStartAndEndOn(start, end);
   }
 
-  private _generateParts(start: Vector3Tuple, end: Vector3Tuple): void {
+  private _generateParts(delta: Vector3Tuple): void {
     this.clear();
 
-    const [x0, y0, z0] = start;
-    const [x1, y1, z1] = end;
-
-    const dx = x1 - x0;
-    const dy = y1 - y0;
-    const dz = z1 - z0;
+    const [dx, dy, dz] = delta;
     const length = Math.sqrt(dx * dx + dy * dy + dz * dz);
-
-    if (length === 0) {
-      return;
-    }
+    if (length === 0) return;
 
     const dirX = dx / length;
     const dirY = dy / length;
     const dirZ = dz / length;
 
-    const [perpX, perpY, perpZ] = perpendicularFromDirection(dirX, dirY, dirZ);
+    const shaftLength = length - 2 * this._tipLength;
+    const shaftDelta: Vector3Tuple = [dirX * shaftLength, dirY * shaftLength, dirZ * shaftLength];
 
-    const endTipBaseX = x1 - dirX * this._tipLength;
-    const endTipBaseY = y1 - dirY * this._tipLength;
-    const endTipBaseZ = z1 - dirZ * this._tipLength;
+    const shaft = new ArrowShaft(shaftDelta, this._color, this._strokeWidth);
+    const endTip = new ArrowTip(delta, this._tipLength, this._tipWidth, this._color);
+    const startTip = new ArrowTip([-dx, -dy, -dz], this._tipLength, this._tipWidth, this._color);
 
-    const startTipBaseX = x0 + dirX * this._tipLength;
-    const startTipBaseY = y0 + dirY * this._tipLength;
-    const startTipBaseZ = z0 + dirZ * this._tipLength;
-
-    const endTipLeft = [
-      endTipBaseX + perpX * this._tipWidth,
-      endTipBaseY + perpY * this._tipWidth,
-      endTipBaseZ + perpZ * this._tipWidth,
-    ];
-    const endTipRight = [
-      endTipBaseX - perpX * this._tipWidth,
-      endTipBaseY - perpY * this._tipWidth,
-      endTipBaseZ - perpZ * this._tipWidth,
-    ];
-    const startTipLeft = [
-      startTipBaseX + perpX * this._tipWidth,
-      startTipBaseY + perpY * this._tipWidth,
-      startTipBaseZ + perpZ * this._tipWidth,
-    ];
-    const startTipRight = [
-      startTipBaseX - perpX * this._tipWidth,
-      startTipBaseY - perpY * this._tipWidth,
-      startTipBaseZ - perpZ * this._tipWidth,
-    ];
-
-    const shaft = new ArrowShaft(
-      [startTipBaseX, startTipBaseY, startTipBaseZ],
-      [endTipBaseX, endTipBaseY, endTipBaseZ],
-      this._color,
-      this._strokeWidth,
-    );
     this.add(shaft);
-
-    const endTip = new ArrowTip([x1, y1, z1], endTipLeft, endTipRight, this._color);
     this.add(endTip);
-
-    const startTip = new ArrowTip([x0, y0, z0], startTipRight, startTipLeft, this._color);
     this.add(startTip);
   }
 
   getStart(): Vector3Tuple {
-    const kids = this.children;
-    if (kids.length < 3) return [0, 0, 0];
-    const startTip = kids[2] as ArrowTip;
-    const pts = startTip.getPoints();
-    if (pts.length > 3) {
-      const p = pts[3];
-      return [p[0], p[1], p[2]];
-    }
-    return [0, 0, 0];
+    const startTip = this.children[2] as ArrowTip;
+    const pos = startTip.position;
+    return [pos.x, pos.y, pos.z];
   }
 
   putStartAndEndOn(start: Vector3Tuple, end: Vector3Tuple): this {
-    this._generateParts(start, end);
+    const delta: Vector3Tuple = [end[0] - start[0], end[1] - start[1], end[2] - start[2]];
+    this._generateParts(delta);
+
+    const length = Math.sqrt(delta[0] * delta[0] + delta[1] * delta[1] + delta[2] * delta[2]);
+    if (length === 0) return this;
+
+    const dirX = delta[0] / length;
+    const dirY = delta[1] / length;
+    const dirZ = delta[2] / length;
+
+    const shaftStart: Vector3Tuple = [
+      start[0] + dirX * this._tipLength,
+      start[1] + dirY * this._tipLength,
+      start[2] + dirZ * this._tipLength,
+    ];
+
+    (this.children[0] as ArrowShaft).moveTo(shaftStart);
+    (this.children[1] as ArrowTip).moveTo(end);
+    (this.children[2] as ArrowTip).moveTo(start);
     return this;
   }
 
@@ -531,15 +499,9 @@ export class DoubleArrow extends Group {
   }
 
   getEnd(): Vector3Tuple {
-    const kids = this.children;
-    if (kids.length < 2) return [0, 0, 0];
-    const endTip = kids[1] as ArrowTip;
-    const pts = endTip.getPoints();
-    if (pts.length > 3) {
-      const p = pts[3];
-      return [p[0], p[1], p[2]];
-    }
-    return [0, 0, 0];
+    const endTip = this.children[1] as ArrowTip;
+    const pos = endTip.position;
+    return [pos.x, pos.y, pos.z];
   }
 
   /**

--- a/src/mobjects/geometry/Arrow.ts
+++ b/src/mobjects/geometry/Arrow.ts
@@ -258,6 +258,15 @@ export class Arrow extends Group {
   }
 
   /**
+   * Get the center point of the arrow as the midpoint of start/end endpoints.
+   */
+  override getCenter(): Vector3Tuple {
+    const start = this.getStart();
+    const end = this.getEnd();
+    return [(start[0] + end[0]) / 2, (start[1] + end[1]) / 2, (start[2] + end[2]) / 2];
+  }
+
+  /**
    * Get the length of the arrow (including tip)
    */
   getLength(): number {

--- a/src/mobjects/geometry/Arrow.ts
+++ b/src/mobjects/geometry/Arrow.ts
@@ -1,4 +1,4 @@
-import { Group } from '../../core/Group';
+import { VGroup } from '../../core/VGroup';
 import { VMobject } from '../../core/VMobject';
 import { Vector3Tuple } from '../../core/Mobject';
 import { WHITE, DEFAULT_STROKE_WIDTH } from '../../constants';
@@ -25,18 +25,48 @@ export interface ArrowOptions {
  * ArrowShaft - The line part of an arrow (internal use)
  */
 class ArrowShaft extends VMobject {
-  constructor(delta: number[], color: string, strokeWidth: number) {
+  constructor(delta: number[], color: string, strokeWidth: number, margin = 0) {
     super();
     this.color = color;
     this.strokeWidth = strokeWidth;
     this.fillOpacity = 0;
 
     const [dx, dy, dz] = delta;
+    const len = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+    if (len === 0) {
+      this.setPoints3D([
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+      ]);
+      return;
+    }
+
+    if (margin < 0) {
+      throw new Error(`ArrowShaft margin must be >= 0, got ${margin}`);
+    }
+    if (2 * margin > len) {
+      throw new Error(`ArrowShaft margin ${margin} too large for length ${len}`);
+    }
+
+    const dirX = dx / len;
+    const dirY = dy / len;
+    const dirZ = dz / len;
+
+    const sx = -dx / 2 + dirX * margin;
+    const sy = -dy / 2 + dirY * margin;
+    const sz = -dz / 2 + dirZ * margin;
+    const ex = dx / 2 - dirX * margin;
+    const ey = dy / 2 - dirY * margin;
+    const ez = dz / 2 - dirZ * margin;
+
     this.setPoints3D([
-      [0, 0, 0],
-      [dx / 3, dy / 3, dz / 3],
-      [(2 * dx) / 3, (2 * dy) / 3, (2 * dz) / 3],
-      [dx, dy, dz],
+      [sx, sy, sz],
+      [sx + (ex - sx) / 3, sy + (ey - sy) / 3, sz + (ez - sz) / 3],
+      [sx + (2 * (ex - sx)) / 3, sy + (2 * (ey - sy)) / 3, sz + (2 * (ez - sz)) / 3],
+      [ex, ey, ez],
     ]);
   }
 
@@ -151,12 +181,13 @@ function perpendicularFromDirection(dirX: number, dirY: number, dirZ: number): V
  * const bigTip = new Arrow({ tipLength: 0.4, tipWidth: 0.25 });
  * ```
  */
-export class Arrow extends Group {
+export class Arrow extends VGroup {
   private _tipLength: number;
   private _tipWidth: number;
   private _strokeWidth: number;
   private _shaft: ArrowShaft | null = null;
   private _tip: ArrowTip | null = null;
+  private _originToStartLocal: Vector3Tuple = [0, 0, 0];
 
   constructor(options: ArrowOptions = {}) {
     super();
@@ -178,13 +209,23 @@ export class Arrow extends Group {
     this.putStartAndEndOn(start, end);
   }
 
+  private _getShaftDelta(delta: Vector3Tuple): Vector3Tuple {
+    const [dx, dy, dz] = delta;
+    const length = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (length === 0) return [0, 0, 0];
+
+    const shaftLength = Math.max(0, length - this._tipLength);
+    const inv = 1 / length;
+    return [dx * inv * shaftLength, dy * inv * shaftLength, dz * inv * shaftLength];
+  }
+
   /**
    * Generate the arrow parts (shaft line + tip triangle)
    *
    * Uses delta vector to compute positions directly.
    */
   private _generateParts(delta: Vector3Tuple): void {
-    this.clear();
+    this.remove(...this.children);
 
     const [dx, dy, dz] = delta;
     const length = Math.sqrt(dx * dx + dy * dy + dz * dz);
@@ -195,31 +236,40 @@ export class Arrow extends Group {
       // Graphing vectors rely on this path and call endpoint helpers on zero vectors.
       this._shaft = new ArrowShaft([0, 0, 0], this._color, this._strokeWidth);
       this._tip = new ArrowTip([0, 0, 0], this._tipLength, this._tipWidth, this._color);
+      this._tip.centerPointsAroundPosition();
       this.add(this._shaft);
       this.add(this._tip);
       return;
     }
 
-    const dirX = dx / length;
-    const dirY = dy / length;
-    const dirZ = dz / length;
-
-    const shaftLength = length - this._tipLength;
-    const shaftDelta: Vector3Tuple = [dirX * shaftLength, dirY * shaftLength, dirZ * shaftLength];
-
+    const shaftDelta = this._getShaftDelta(delta);
     this._shaft = new ArrowShaft(shaftDelta, this._color, this._strokeWidth);
     this._tip = new ArrowTip(delta, this._tipLength, this._tipWidth, this._color);
+    this._tip.centerPointsAroundPosition();
 
     this.add(this._shaft);
     this.add(this._tip);
+  }
+
+  private _getUniformShaftScale(): number {
+    const s = this._shaft!.scaleVector;
+    if (!(s.x === s.y && s.y === s.z)) {
+      throw new Error(`Arrow requires uniform shaft scale, got (${s.x}, ${s.y}, ${s.z})`);
+    }
+    return s.x;
   }
 
   /**
    * Get the start point
    */
   getStart(): Vector3Tuple {
-    const pos = this._shaft!.position;
-    return [pos.x, pos.y, pos.z];
+    const center = this._shaft!.position;
+    const u = this._getUniformShaftScale();
+    return [
+      center.x + this._originToStartLocal[0] * u,
+      center.y + this._originToStartLocal[1] * u,
+      center.z + this._originToStartLocal[2] * u,
+    ];
   }
 
   /**
@@ -230,8 +280,23 @@ export class Arrow extends Group {
     const delta: Vector3Tuple = [end[0] - start[0], end[1] - start[1], end[2] - start[2]];
     this._generateParts(delta);
 
-    this._shaft!.moveTo(start);
-    this._tip!.moveTo(end);
+    this._originToStartLocal = [-delta[0] / 2, -delta[1] / 2, -delta[2] / 2];
+
+    const center: Vector3Tuple = [
+      (start[0] + end[0]) / 2,
+      (start[1] + end[1]) / 2,
+      (start[2] + end[2]) / 2,
+    ];
+
+    const shaftDelta = this._getShaftDelta(delta);
+
+    this._shaft!.moveTo(center);
+    this._tip!.moveTo([
+      center[0] + shaftDelta[0] / 2,
+      center[1] + shaftDelta[1] / 2,
+      center[2] + shaftDelta[2] / 2,
+    ]);
+
     return this;
   }
 
@@ -246,8 +311,13 @@ export class Arrow extends Group {
    * Get the end point (tip of the arrow)
    */
   getEnd(): Vector3Tuple {
-    const pos = this._tip!.position;
-    return [pos.x, pos.y, pos.z];
+    const center = this._shaft!.position;
+    const u = this._getUniformShaftScale();
+    return [
+      center.x - this._originToStartLocal[0] * u,
+      center.y - this._originToStartLocal[1] * u,
+      center.z - this._originToStartLocal[2] * u,
+    ];
   }
 
   /**
@@ -258,24 +328,22 @@ export class Arrow extends Group {
   }
 
   /**
-   * Get the center point of the arrow as the midpoint of start/end endpoints.
+   * Get the center point of the arrow.
    */
   override getCenter(): Vector3Tuple {
-    const start = this.getStart();
-    const end = this.getEnd();
-    return [(start[0] + end[0]) / 2, (start[1] + end[1]) / 2, (start[2] + end[2]) / 2];
+    const pos = this._shaft!.position;
+    return [pos.x, pos.y, pos.z];
   }
 
   /**
-   * Get the length of the arrow (including tip)
+   * Get the length of the arrow (including tip).
+   * Requires uniform shaft scaling.
    */
   getLength(): number {
-    const start = this.getStart();
-    const end = this.getEnd();
-    const dx = end[0] - start[0];
-    const dy = end[1] - start[1];
-    const dz = end[2] - start[2];
-    return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    const u = this._getUniformShaftScale();
+    const v = this._originToStartLocal;
+    const baseLength = 2 * Math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    return baseLength * u;
   }
 
   /**
@@ -413,7 +481,7 @@ export class Arrow extends Group {
 /**
  * DoubleArrow - An arrow with tips on both ends
  */
-export class DoubleArrow extends Group {
+export class DoubleArrow extends VGroup {
   private _tipLength: number;
   private _tipWidth: number;
   private _strokeWidth: number;
@@ -439,7 +507,7 @@ export class DoubleArrow extends Group {
   }
 
   private _generateParts(delta: Vector3Tuple): void {
-    this.clear();
+    this.remove(...this.children);
 
     const [dx, dy, dz] = delta;
     const length = Math.sqrt(dx * dx + dy * dy + dz * dz);

--- a/src/mobjects/geometry/Arrow.ts
+++ b/src/mobjects/geometry/Arrow.ts
@@ -188,7 +188,17 @@ export class Arrow extends Group {
 
     const [dx, dy, dz] = delta;
     const length = Math.sqrt(dx * dx + dy * dy + dz * dz);
-    if (length === 0) return;
+
+    if (length === 0) {
+      // Important invariant: putStartAndEndOn() must always leave Arrow with
+      // canonical children (shaft + tip), even for degenerate/zero-length input.
+      // Graphing vectors rely on this path and call endpoint helpers on zero vectors.
+      this._shaft = new ArrowShaft([0, 0, 0], this._color, this._strokeWidth);
+      this._tip = new ArrowTip([0, 0, 0], this._tipLength, this._tipWidth, this._color);
+      this.add(this._shaft);
+      this.add(this._tip);
+      return;
+    }
 
     const dirX = dx / length;
     const dirY = dy / length;

--- a/src/mobjects/geometry/geometry-arrow.test.ts
+++ b/src/mobjects/geometry/geometry-arrow.test.ts
@@ -76,6 +76,40 @@ describe('Arrow defaults', () => {
     expect(end2[1]).toBe(-3);
     expect(end2[2]).toBe(0);
   });
+
+  it('putStartAndEndOn resets endpoints exactly after prior shift+rotation', () => {
+    const arrow = new Arrow({ start: [0, 0, 0], end: [3, 0, 0] });
+
+    // Put the arrow through prior transforms first.
+    arrow.shift([2, -1, 0]);
+    arrow.rotate(Math.PI / 3);
+
+    const beforeGroup = arrow.position.clone();
+
+    arrow.putStartAndEndOn([-4, 2, 0], [1, -5, 0]);
+
+    const start = arrow.getStart();
+    const end = arrow.getEnd();
+    expect(start[0]).toBe(-4);
+    expect(start[1]).toBe(2);
+    expect(start[2]).toBe(0);
+    expect(end[0]).toBe(1);
+    expect(end[1]).toBe(-5);
+    expect(end[2]).toBe(0);
+
+    // Endpoint update must not mutate Group position.
+    expect(arrow.position.x).toBe(beforeGroup.x);
+    expect(arrow.position.y).toBe(beforeGroup.y);
+    expect(arrow.position.z).toBe(beforeGroup.z);
+
+    // Child placements are the canonical endpoint carriers.
+    expect(arrow.children[0].position.x).toBe(-4);
+    expect(arrow.children[0].position.y).toBe(2);
+    expect(arrow.children[0].position.z).toBe(0);
+    expect(arrow.children[1].position.x).toBe(1);
+    expect(arrow.children[1].position.y).toBe(-5);
+    expect(arrow.children[1].position.z).toBe(0);
+  });
 });
 
 // ── reconstructTip ──────────────────────────────────────────────────────────

--- a/src/mobjects/geometry/geometry-arrow.test.ts
+++ b/src/mobjects/geometry/geometry-arrow.test.ts
@@ -19,6 +19,25 @@ function vm(pts: number[][]): VMobject {
 // ── Arrow defaults ──────────────────────────────────────────────────────────
 
 describe('Arrow defaults', () => {
+  it('uses position as center for shaft and tip carriers', () => {
+    const arrow = new Arrow({ start: [-4, 2, 0], end: [1, -5, 0] });
+    const center: [number, number, number] = [(-4 + 1) / 2, (2 + -5) / 2, 0];
+
+    const shaft = arrow.children[0] as VMobject;
+    const tip = arrow.children[1] as VMobject;
+
+    expect(shaft.getCenter()[0]).toBeCloseTo(shaft.position.x, 6);
+    expect(shaft.getCenter()[1]).toBeCloseTo(shaft.position.y, 6);
+    expect(shaft.getCenter()[2]).toBeCloseTo(shaft.position.z, 6);
+
+    expect(tip.getCenter()[0]).toBeCloseTo(tip.position.x, 6);
+    expect(tip.getCenter()[1]).toBeCloseTo(tip.position.y, 6);
+    expect(tip.getCenter()[2]).toBeCloseTo(tip.position.z, 6);
+
+    expect(shaft.position.x).toBeCloseTo(center[0], 6);
+    expect(shaft.position.y).toBeCloseTo(center[1], 6);
+    expect(shaft.position.z).toBeCloseTo(center[2], 6);
+  });
   it('has pointier default tipLength=0.3', () => {
     const arrow = new Arrow();
     expect(arrow.getTipLength()).toBe(0.3);
@@ -122,13 +141,65 @@ describe('Arrow defaults', () => {
     expect(arrow.position.y).toBe(beforeGroup.y);
     expect(arrow.position.z).toBe(beforeGroup.z);
 
-    // Child placements are the canonical endpoint carriers.
-    expect(arrow.children[0].position.x).toBe(-4);
-    expect(arrow.children[0].position.y).toBe(2);
+    // Shaft carrier remains at arrow center.
+    expect(arrow.children[0].position.x).toBe((-4 + 1) / 2);
+    expect(arrow.children[0].position.y).toBe((2 + -5) / 2);
     expect(arrow.children[0].position.z).toBe(0);
-    expect(arrow.children[1].position.x).toBe(1);
-    expect(arrow.children[1].position.y).toBe(-5);
-    expect(arrow.children[1].position.z).toBe(0);
+
+    // Tip carrier is offset forward by half shaft-delta.
+    const dx = 1 - -4;
+    const dy = -5 - 2;
+    const dz = 0;
+    const length = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    const shaftLength = Math.max(0, length - arrow.getTipLength());
+    const ux = dx / length;
+    const uy = dy / length;
+    const uz = dz / length;
+    const cx = (-4 + 1) / 2;
+    const cy = (2 + -5) / 2;
+    const cz = 0;
+    expect(arrow.children[1].position.x).toBeCloseTo(cx + (ux * shaftLength) / 2, 6);
+    expect(arrow.children[1].position.y).toBeCloseTo(cy + (uy * shaftLength) / 2, 6);
+    expect(arrow.children[1].position.z).toBeCloseTo(cz + (uz * shaftLength) / 2, 6);
+  });
+
+  it('tip center equals tip position after endpoint update', () => {
+    const arrow = new Arrow({ start: [-2, -1, 0], end: [5, 4, 0], tipLength: 0.7 });
+    arrow.putStartAndEndOn([3, -2, 0], [9, 1, 0]);
+
+    const tip = arrow.children[1] as VMobject;
+    const c = tip.getCenter();
+    expect(c[0]).toBeCloseTo(tip.position.x, 6);
+    expect(c[1]).toBeCloseTo(tip.position.y, 6);
+    expect(c[2]).toBeCloseTo(tip.position.z, 6);
+  });
+
+  it('scale should update getStart/getEnd as scaling about arrow center', () => {
+    const arrow = new Arrow({ start: [-2, 1, 0], end: [6, 5, 0] });
+    const center = arrow.getCenter();
+
+    arrow.scale(2);
+
+    const start = arrow.getStart();
+    const end = arrow.getEnd();
+
+    const expectedStart: [number, number, number] = [
+      center[0] + 2 * (-2 - center[0]),
+      center[1] + 2 * (1 - center[1]),
+      center[2] + 2 * (0 - center[2]),
+    ];
+    const expectedEnd: [number, number, number] = [
+      center[0] + 2 * (6 - center[0]),
+      center[1] + 2 * (5 - center[1]),
+      center[2] + 2 * (0 - center[2]),
+    ];
+
+    expect(start[0]).toBeCloseTo(expectedStart[0], 6);
+    expect(start[1]).toBeCloseTo(expectedStart[1], 6);
+    expect(start[2]).toBeCloseTo(expectedStart[2], 6);
+    expect(end[0]).toBeCloseTo(expectedEnd[0], 6);
+    expect(end[1]).toBeCloseTo(expectedEnd[1], 6);
+    expect(end[2]).toBeCloseTo(expectedEnd[2], 6);
   });
 });
 
@@ -234,8 +305,13 @@ describe('ApplyFunction on Group', () => {
 // ── ApplyFunction on Arrow ──────────────────────────────────────────────────
 
 describe('ApplyFunction on Arrow', () => {
-  it('transforms shaft+tip and reconstructs tip', () => {
+  it('transforms shaft+tip local geometry and reconstructs tip', () => {
     const arrow = new Arrow({ start: [0, 0, 0], end: [2, 0, 0] });
+
+    const shaft = arrow.children[0] as VMobject;
+    const tip = arrow.children[1] as VMobject;
+    const shaftBefore = shaft.getPoints().map((p) => [...p]);
+    const tipBefore = tip.getPoints().map((p) => [...p]);
 
     const fn = (p: number[]) => [p[0] + 1, p[1], p[2]];
     const anim = new ApplyFunction(arrow, { func: fn });
@@ -243,17 +319,10 @@ describe('ApplyFunction on Arrow', () => {
     anim.begin();
     anim.finish();
 
-    // ApplyFunction mutates child points; endpoint accessors are child-position based.
-    // Verify transformed/reconstructed tip geometry directly.
-    const shaft = arrow.children[0] as VMobject;
-    const tip = arrow.children[1] as VMobject;
-    const shaftPts = shaft.getPoints();
-    const tipPts = tip.getPoints();
-    // start x=0 becomes 1 after x+1 transform
-    expect(shaftPts[0][0]).toBe(1);
-    // tip apex local x should also shift by +1 (2 -> 3 before reconstruction,
-    // then kept as transformed apex by reconstructTip).
-    expect(tipPts[3][0]).toBe(1);
+    const shaftAfter = shaft.getPoints();
+    const tipAfter = tip.getPoints();
+    expect(shaftAfter[0][0]).toBeCloseTo(shaftBefore[0][0] + 1, 6);
+    expect(tipAfter[3][0]).toBeCloseTo(tipBefore[3][0] + 1, 6);
   });
 });
 

--- a/src/mobjects/geometry/geometry-arrow.test.ts
+++ b/src/mobjects/geometry/geometry-arrow.test.ts
@@ -29,9 +29,52 @@ describe('Arrow defaults', () => {
     expect(arrow.getTipWidth()).toBe(0.1);
   });
 
+  it('tip base width is 2*tipWidth (legacy convention)', () => {
+    const tipWidth = 0.2;
+    const arrow = new Arrow({ start: [0, 0, 0], end: [3, 0, 0], tipWidth });
+    const tip = arrow.children[1] as VMobject;
+    const pts = tip.getPoints();
+    const left = pts[0];
+    const right = pts[6];
+    const dx = left[0] - right[0];
+    const dy = left[1] - right[1];
+    const dz = left[2] - right[2];
+    const baseWidth = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    expect(baseWidth).toBeCloseTo(2 * tipWidth, 5);
+  });
+
   it('DoubleArrow has same pointier defaults', () => {
     const da = new DoubleArrow({ start: [0, 0, 0], end: [2, 0, 0] });
     expect(da.getLength()).toBeGreaterThan(0);
+  });
+
+  it('Arrow getStart/getEnd are child-position based and group position is unchanged by updates', () => {
+    const arrow = new Arrow({ start: [1, 2, 0], end: [4, 6, 0] });
+    const beforeGroup = arrow.position.clone();
+
+    const start = arrow.getStart();
+    const end = arrow.getEnd();
+    expect(start[0]).toBe(1);
+    expect(start[1]).toBe(2);
+    expect(start[2]).toBe(0);
+    expect(end[0]).toBe(4);
+    expect(end[1]).toBe(6);
+    expect(end[2]).toBe(0);
+
+    arrow.putStartAndEndOn([-2, 1, 0], [5, -3, 0]);
+    const afterGroup = arrow.position;
+    expect(afterGroup.x).toBe(beforeGroup.x);
+    expect(afterGroup.y).toBe(beforeGroup.y);
+    expect(afterGroup.z).toBe(beforeGroup.z);
+
+    const start2 = arrow.getStart();
+    const end2 = arrow.getEnd();
+    expect(start2[0]).toBe(-2);
+    expect(start2[1]).toBe(1);
+    expect(start2[2]).toBe(0);
+    expect(end2[0]).toBe(5);
+    expect(end2[1]).toBe(-3);
+    expect(end2[2]).toBe(0);
   });
 });
 
@@ -55,10 +98,10 @@ describe('Arrow.reconstructTip', () => {
     expect(apexAfter[0]).toBeCloseTo(apexBefore[0], 5);
     expect(apexAfter[1]).toBeCloseTo(apexBefore[1], 5);
 
-    // The end point should match the apex
-    const end = arrow.getEnd();
-    expect(end[0]).toBeCloseTo(apexAfter[0], 5);
-    expect(end[1]).toBeCloseTo(apexAfter[1], 5);
+    // Tip apex in local tip geometry stays preserved after reconstruction.
+    // Arrow.getEnd() is child-position based (world placement), not local point based.
+    expect(apexAfter[0]).toBeCloseTo(apexBefore[0], 5);
+    expect(apexAfter[1]).toBeCloseTo(apexBefore[1], 5);
   });
 
   it('preserves tip dimensions after reconstruction', () => {
@@ -146,11 +189,17 @@ describe('ApplyFunction on Arrow', () => {
     anim.begin();
     anim.finish();
 
-    // After applying x+1 and reconstructing, the arrow's endpoints should be shifted
-    const start = arrow.getStart();
-    const end = arrow.getEnd();
-    expect(start[0]).toBeGreaterThan(0);
-    expect(end[0]).toBeGreaterThan(2);
+    // ApplyFunction mutates child points; endpoint accessors are child-position based.
+    // Verify transformed/reconstructed tip geometry directly.
+    const shaft = arrow.children[0] as VMobject;
+    const tip = arrow.children[1] as VMobject;
+    const shaftPts = shaft.getPoints();
+    const tipPts = tip.getPoints();
+    // start x=0 becomes 1 after x+1 transform
+    expect(shaftPts[0][0]).toBe(1);
+    // tip apex local x should also shift by +1 (2 -> 3 before reconstruction,
+    // then kept as transformed apex by reconstructTip).
+    expect(tipPts[3][0]).toBe(1);
   });
 });
 

--- a/src/mobjects/geometry/geometry-arrow.test.ts
+++ b/src/mobjects/geometry/geometry-arrow.test.ts
@@ -77,6 +77,26 @@ describe('Arrow defaults', () => {
     expect(end2[2]).toBe(0);
   });
 
+  it('getCenter is the midpoint of start/end for non-trivial coordinates', () => {
+    const start: [number, number, number] = [-3.25, 4.5, 1.75];
+    const end: [number, number, number] = [8.125, -2.75, 6.5];
+    const arrow = new Arrow({ start, end });
+
+    const center = arrow.getCenter();
+    expect(center[0]).toBe((start[0] + end[0]) / 2);
+    expect(center[1]).toBe((start[1] + end[1]) / 2);
+    expect(center[2]).toBe((start[2] + end[2]) / 2);
+
+    const start2: [number, number, number] = [12.2, -9.4, -3.3];
+    const end2: [number, number, number] = [-7.6, 5.8, 2.1];
+    arrow.putStartAndEndOn(start2, end2);
+
+    const center2 = arrow.getCenter();
+    expect(center2[0]).toBe((start2[0] + end2[0]) / 2);
+    expect(center2[1]).toBe((start2[1] + end2[1]) / 2);
+    expect(center2[2]).toBe((start2[2] + end2[2]) / 2);
+  });
+
   it('putStartAndEndOn resets endpoints exactly after prior shift+rotation', () => {
     const arrow = new Arrow({ start: [0, 0, 0], end: [3, 0, 0] });
 

--- a/src/mobjects/geometry/geometry-extra.test.ts
+++ b/src/mobjects/geometry/geometry-extra.test.ts
@@ -64,6 +64,14 @@ describe('Arrow', () => {
     expect(a.getLength()).toBeCloseTo(10, 10);
   });
 
+  it('putStartAndEndOn updates both endpoints', () => {
+    const a = new Arrow();
+    a.putStartAndEndOn([1, 2, 0], [4, 6, 0]);
+    expect(a.getStart()).toEqual([1, 2, 0]);
+    expect(a.getEnd()).toEqual([4, 6, 0]);
+    expect(a.getLength()).toBeCloseTo(5, 10);
+  });
+
   it('setTipLength / setTipWidth update tip dimensions', () => {
     const a = new Arrow();
     a.setTipLength(0.5);
@@ -77,6 +85,28 @@ describe('Arrow', () => {
     const s = a.getStart();
     s[0] = 999;
     expect(a.getStart()[0]).toBe(1);
+  });
+
+  it('preserves endpoints through tip updates after translation + rotation', () => {
+    const a = new Arrow({ start: [1, 0, 0], end: [4, 0, 0] });
+    a.shift([2, -1, 0]);
+    a.rotate(Math.PI / 2);
+
+    const startBefore = a.getStart();
+    const endBefore = a.getEnd();
+
+    a.setTipLength(0.42);
+    a.setTipWidth(0.17);
+
+    const startAfter = a.getStart();
+    const endAfter = a.getEnd();
+
+    expect(startAfter[0]).toBeCloseTo(startBefore[0], 8);
+    expect(startAfter[1]).toBeCloseTo(startBefore[1], 8);
+    expect(startAfter[2]).toBeCloseTo(startBefore[2], 8);
+    expect(endAfter[0]).toBeCloseTo(endBefore[0], 8);
+    expect(endAfter[1]).toBeCloseTo(endBefore[1], 8);
+    expect(endAfter[2]).toBeCloseTo(endBefore[2], 8);
   });
 });
 
@@ -101,6 +131,36 @@ describe('DoubleArrow', () => {
     da.setEnd([1, 1, 0]);
     expect(da.getStart()).toEqual([-1, -1, 0]);
     expect(da.getEnd()).toEqual([1, 1, 0]);
+  });
+
+  it('putStartAndEndOn updates both endpoints', () => {
+    const da = new DoubleArrow();
+    da.putStartAndEndOn([-2, 0, 0], [2, 0, 0]);
+    expect(da.getStart()).toEqual([-2, 0, 0]);
+    expect(da.getEnd()).toEqual([2, 0, 0]);
+    expect(da.getLength()).toBeCloseTo(4, 10);
+  });
+
+  it('preserves endpoints through tip updates after translation + rotation', () => {
+    const da = new DoubleArrow({ start: [-2, 0, 0], end: [2, 0, 0] });
+    da.shift([1, 3, 0]);
+    da.rotate(Math.PI / 3);
+
+    const startBefore = da.getStart();
+    const endBefore = da.getEnd();
+
+    da.setTipLength(0.5);
+    da.setTipWidth(0.2);
+
+    const startAfter = da.getStart();
+    const endAfter = da.getEnd();
+
+    expect(startAfter[0]).toBeCloseTo(startBefore[0], 8);
+    expect(startAfter[1]).toBeCloseTo(startBefore[1], 8);
+    expect(startAfter[2]).toBeCloseTo(startBefore[2], 8);
+    expect(endAfter[0]).toBeCloseTo(endBefore[0], 8);
+    expect(endAfter[1]).toBeCloseTo(endBefore[1], 8);
+    expect(endAfter[2]).toBeCloseTo(endBefore[2], 8);
   });
 });
 


### PR DESCRIPTION
NOTE: my diagnostic in the original issue was wrong. the real problem is that the logic for shifted arrows was wrong because of how 'group' works.

# Summary                                                                                                                                                                                   
                                                                                                                                                                                           
 1. Refactor Arrow/DoubleArrow endpoint handling to use geometry-derived start/end via putStartAndEndOn() instead of stored _start/_end state.                                             
 2. Simplify GrowArrow to child-based growth (not group transform): child scale interpolation (~0 -> 1) plus anchor-based child position interpolation.                                    
                                                                                                                                                                                           
 This makes endpoint behavior more deterministic under transforms/regeneration, removes duplicated state, and keeps GrowArrow aligned with the intended growth contract.                   
 As a result, animation end state is simpler to reason about, tests now lock in those invariants directly, and it also solves the animation being wrong for a shifted arrow.               
                                                                                                                                                                                           
After change:                                                                                                                                                                             
                                                                                                                                                                                           
https://github.com/user-attachments/assets/000e54e2-be02-4c00-82f0-05cafc65a204                                                                                                           
                                                                                                                                                                                           
# Changes                                                                                                                                                                                   
                                                                                                                                                                                           
 - Arrow/DoubleArrow now derive endpoints from geometry; canonical endpoint mutation path is putStartAndEndOn(start, end).                                                                 
 - setStart/setEnd route through canonical endpoint mutation (with deprecation guidance toward putStartAndEndOn).                                                                          
 - DoubleArrow tip-size mutators/accessors (setTipLength, getTipLength, setTipWidth, getTipWidth) restored on the canonical regeneration path.                                             
 - GrowArrow now grows children (shaft/tip), not the group transform:                                                                                                                      
     - captures per-child local anchors (shaft start, tip apex),                                                                                                                           
     - scales children from near-zero to target scale,                                                                                                                                     
     - lerps anchor world positions from arrow start to original anchors,                                                                                                                  
     - restores original child state in finish().                                                                                                                                          
 - Tests updated:                                                                                                                                                                          
     - GrowArrow expectations assert child-based behavior and shifted-arrow correctness (including shaft-start/tip-apex alignment at begin()).                                             
     - Arrow/DoubleArrow putStartAndEndOn coverage.                                                                                                                                        
     - Endpoint invariants after translation+rotation and tip updates.                                                                  
## Testing                                                                                                                                                                              
- [x] Lint passes (`npm run lint`)                                                                                                                                                      
- [x] Full test suite (`npm test`)                                                                                                                         
- [x] Typecheck (`npm run typecheck`)                                                                                                           
                                                                                                                                                                                       
## Related Issues                                                                                                                                                                       
Closes #339                                                                                                                                                                             
                                                                                                                                                                                       
# Note                                                                                                                                                                                  
                                                                                                                                                                                       
 In the future, I would like to add documentation for some of the changes I do. In particular, it will be the case for the deprecation warning I added there, but I'm not really sure what 
 the guidelines are and how the documentation works.                                                                                                                                       
 @maloyan Do you have some advice on that?       