### PR TITLE
fix: interpolate scaleVector in VGroup Transform animations

### DIFF
--- a/src/animation/transform/PointMorphStrategy.ts
+++ b/src/animation/transform/PointMorphStrategy.ts
@@ -26,6 +26,8 @@ interface VGroupLeafState {
   targetPoints: number[][];
   startPosition: THREE.Vector3;
   targetPosition: THREE.Vector3;
+  startScale: THREE.Vector3;
+  targetScale: THREE.Vector3;
   finalTargetPoints: number[][];
   finalTargetSubpathLengths?: number[];
   startStyle: ChildStyle;
@@ -151,12 +153,24 @@ export class PointMorphStrategy implements MorphStrategy {
     } else child.setTransformSubpathLengths(undefined);
     const startStyle = sourceIsPlaceholder ? captureStyleFaded(tc) : captureStyle(child);
     const targetStyle = targetIsPlaceholder ? captureStyleFaded(sc) : captureStyle(tc);
+    const startScale = new THREE.Vector3(
+      src.leaf.scaleVector.x,
+      src.leaf.scaleVector.y,
+      src.leaf.scaleVector.z,
+    );
+    const targetScale = new THREE.Vector3(
+      tgt.leaf.scaleVector.x,
+      tgt.leaf.scaleVector.y,
+      tgt.leaf.scaleVector.z,
+    );
     return {
       child,
       startPoints,
       targetPoints,
       startPosition: worldToParentLocalPosition(src.worldPosition, src.parentWorldMatrix),
       targetPosition: worldToParentLocalPosition(tgt.worldPosition, src.parentWorldMatrix),
+      startScale,
+      targetScale,
       finalTargetPoints,
       finalTargetSubpathLengths,
       startStyle,
@@ -181,6 +195,7 @@ export class PointMorphStrategy implements MorphStrategy {
           interpolated.push(lerpPoint(leaf.startPoints[i], leaf.targetPoints[i], alpha));
         leaf.child.setPoints(interpolated);
         leaf.child.position.lerpVectors(leaf.startPosition, leaf.targetPosition, alpha);
+        leaf.child.scaleVector.lerpVectors(leaf.startScale, leaf.targetScale, alpha);
         const ss = leaf.startStyle,
           ts = leaf.targetStyle;
         leaf.child.opacity = ss.opacity + (ts.opacity - ss.opacity) * alpha;
@@ -238,6 +253,7 @@ export class PointMorphStrategy implements MorphStrategy {
       for (const leaf of this._vgroupLeafStates) {
         leaf.child.setPoints(leaf.finalTargetPoints);
         leaf.child.position.copy(leaf.targetPosition);
+        leaf.child.scaleVector.copy(leaf.targetScale);
         const ts = leaf.targetStyle;
         leaf.child.opacity = ts.opacity;
         leaf.child.fillOpacity = ts.fillOpacity;

--- a/src/core/core-extra.test.ts
+++ b/src/core/core-extra.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Mobject, UP, LEFT, RIGHT, UL, UR, DL } from './Mobject';
+import { Mobject, UP, LEFT, RIGHT, UL, UR, DL, registerAnimateProxy } from './Mobject';
+import { Scene } from './Scene';
+import { AnimateProxy } from './AnimateProxy';
+
+// Register animate proxy for tests using animate API
+registerAnimateProxy((mobject) => new AnimateProxy(mobject));
 import { VMobject } from './VMobject';
 import {
   getNumCurves,
@@ -1818,6 +1823,22 @@ describe('VGroup - extended coverage', () => {
     vg.scale([2, 3, 1]);
     expect(a.scaleVector.x).toBe(2);
     expect(a.scaleVector.y).toBe(3);
+  });
+
+  it('animate.scale ends with correct scaleVector', async () => {
+    const scene = Scene.createHeadless({ width: 800, height: 450 });
+
+    const a = new VMobject();
+    a.scaleVector.set(1, 1, 1);
+    const vg = new VGroup(a);
+    scene.add(vg);
+
+    await scene.play(vg.animate.scale(2));
+
+    // After animate.scale, child should have correct scaleVector
+    expect(a.scaleVector.x).toBe(2);
+    expect(a.scaleVector.y).toBe(2);
+    expect(a.scaleVector.z).toBe(2);
   });
 
   it('setColor propagates to children', () => {


### PR DESCRIPTION
## Summary

`Transform` refactor in #319 introduced a bug: `scale` was not interpolated.
This PR fixes it and adds a non-regression test

Brief description of changes.

## Changes
- Add startScale/targetScale to VGroupLeafState interface
- Capture scaleVector in _build() for each child
- Interpolate scaleVector in interpolate() via lerpVectors
- Apply final scaleVector in finish()

- Add test verifying animate.scale ends with correct scaleVector

## Testing
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Types check (`npm run typecheck`)

# Note

I noticed in #347 that in some case when we scale an object we only update its geometry not its scale. maybe it's related.