### PR TITLE
fix(examples): polish examples after recent camera + font changes (#316)

### DIFF
--- a/examples/apply_matrix_arrows.ts
+++ b/examples/apply_matrix_arrows.ts
@@ -26,7 +26,7 @@ async function applyMatrixArrows(scene: Scene) {
 
   scene.add(arrow1, arrow2, arrow3);
 
-  const label = new Text({ text: 'Before shear', fontSize: 24, color: '#ffffff' });
+  const label = new Text({ text: 'Before shear', fontSize: 48, color: '#ffffff' });
   label.moveTo([0, 3.2, 0]);
   scene.add(label);
 
@@ -51,7 +51,7 @@ async function applyMatrixArrows(scene: Scene) {
   scene.remove(label);
   const label2 = new Text({
     text: 'After shear — tips reconstructed',
-    fontSize: 24,
+    fontSize: 48,
     color: '#ffffff',
   });
   label2.moveTo([0, 3.2, 0]);

--- a/examples/easing_functions_showcase.ts
+++ b/examples/easing_functions_showcase.ts
@@ -6,6 +6,7 @@ import {
   Shift,
   AnimationGroup,
   RIGHT,
+  LEFT,
   BLACK,
   BLUE,
   RED,
@@ -51,10 +52,10 @@ const rateFunctions: Array<{
 ];
 
 const ROW_COUNT = rateFunctions.length;
-const TOP_Y = 2.5;
-const ROW_SPACING = 0.65;
-const START_X = -2.2;
-const SHIFT_DISTANCE = 5.0;
+const TOP_Y = 3.0;
+const ROW_SPACING = 0.75;
+const START_X = -1.2;
+const SHIFT_DISTANCE = 5.5;
 
 document.getElementById('playBtn').addEventListener('click', async () => {
   if (isAnimating) return;
@@ -70,14 +71,6 @@ document.getElementById('playBtn').addEventListener('click', async () => {
     const y = TOP_Y - i * ROW_SPACING;
     const { name, color } = rateFunctions[i];
 
-    // Label on the left
-    const label = new Text({
-      text: name,
-      fontSize: 18,
-      color: WHITE,
-    });
-    label.moveTo([START_X - 2.3, y, 0]);
-
     // Track line (faint guide)
     const trackLine = new Line({
       start: [START_X, y, 0],
@@ -85,6 +78,14 @@ document.getElementById('playBtn').addEventListener('click', async () => {
       color: '#333333',
       strokeWidth: 1,
     });
+
+    // Label on the left, right-edge aligned just before track start
+    const label = new Text({
+      text: name,
+      fontSize: 26,
+      color: WHITE,
+    });
+    label.nextTo(trackLine, LEFT, 0.2);
 
     // Dot at the start position
     const dot = new Dot({

--- a/examples/export_animation.ts
+++ b/examples/export_animation.ts
@@ -5,6 +5,8 @@ import {
   Create,
   Transform,
   FadeOut,
+  Animation,
+  Timeline,
   BLACK,
   BLUE,
   GREEN,
@@ -40,19 +42,45 @@ function setButtonsDisabled(disabled: boolean) {
     .forEach((btn) => (btn.disabled = disabled));
 }
 
+// Build the same three animations Play and Export share.
+// Each call returns a fresh set against a freshly populated scene
+// — animations are stateful (begin() snapshots opacities), so reusing
+// instances across runs would replay against stale state.
+function buildAnimations(): Animation[] {
+  scene.clear();
+  const square = new Square({ sideLength: 2.5, color: BLUE, fillOpacity: 0.5 });
+  const circle = new Circle({ radius: 1.25, color: GREEN, fillOpacity: 0.5 });
+  return [
+    new Create(square, { duration: 1 }),
+    new Transform(square, circle, { duration: 1 }),
+    new FadeOut(square, { duration: 1 }),
+  ];
+}
+
+// Wire animations into the scene's timeline sequentially without
+// starting playback. We avoid Succession here because it would call
+// begin() on every child up front — Transform.begin() would then
+// snapshot the fillOpacity that Create.begin() just zeroed, leaving
+// the square invisible after the morph. Timeline drives each begin()
+// lazily inside _updateAnimationsAtTime as forward-seeking crosses
+// each animation's start time, which is what GifExporter does.
+function installTimeline(anims: Animation[]): number {
+  scene.add(anims[0].mobject);
+  const timeline = new Timeline();
+  for (const anim of anims) timeline.add(anim, '>');
+  scene.setTimeline(timeline);
+  return timeline.getDuration();
+}
+
 // Play animation
 document.getElementById('playBtn')!.addEventListener('click', async () => {
   if (isAnimating) return;
   isAnimating = true;
   setButtonsDisabled(true);
 
-  scene.clear();
-  const square = new Square({ sideLength: 2.5, color: BLUE, fillOpacity: 0.5 });
-  const circle = new Circle({ radius: 1.25, color: GREEN, fillOpacity: 0.5 });
-
-  await scene.play(new Create(square));
-  await scene.play(new Transform(square, circle));
-  await scene.play(new FadeOut(square));
+  for (const anim of buildAnimations()) {
+    await scene.play(anim);
+  }
 
   isAnimating = false;
   setButtonsDisabled(false);
@@ -65,9 +93,11 @@ document.getElementById('exportGifBtn')!.addEventListener('click', async () => {
   setButtonsDisabled(true);
 
   try {
+    const duration = installTimeline(buildAnimations());
     await scene.export('animation.gif', {
       fps: 15,
       quality: 10,
+      duration,
       onProgress: (p) => showProgress(p, 'Exporting GIF'),
     });
   } catch (err) {
@@ -86,8 +116,10 @@ document.getElementById('exportWebmBtn')!.addEventListener('click', async () => 
   setButtonsDisabled(true);
 
   try {
+    const duration = installTimeline(buildAnimations());
     await scene.export('animation.webm', {
       fps: 30,
+      duration,
       onProgress: (p) => showProgress(p, 'Exporting WebM'),
     });
   } catch (err) {

--- a/examples/mathtex_svg.ts
+++ b/examples/mathtex_svg.ts
@@ -14,7 +14,8 @@ import {
   RED,
   BLUE,
   GREEN,
-  YELLOW,
+  TEAL,
+  GOLD,
 } from '../src/index.ts';
 
 const container = document.getElementById('container');
@@ -32,7 +33,7 @@ async function mathtexSvgDemo(scene: Scene) {
   });
   const equation2 = new MathTex({
     latex: 'e^{i\\pi} + 1 = 0',
-    color: YELLOW,
+    color: GOLD,
   });
   const multiPart = new MathTex({
     latex: ['E', '=', 'mc^2'],
@@ -54,7 +55,7 @@ async function mathtexSvgDemo(scene: Scene) {
   });
   const pythagorasExpanded = new MathTex({
     latex: 'c = \\sqrt{a^2 + b^2}',
-    color: YELLOW,
+    color: TEAL,
   });
   const scalingEq = new MathTex({
     latex: '\\nabla \\cdot \\mathbf{E} = \\frac{\\rho}{\\epsilon_0}',
@@ -74,7 +75,7 @@ async function mathtexSvgDemo(scene: Scene) {
   });
   const textAfter = new MathTex({
     latex: 'x = 42',
-    color: YELLOW,
+    color: GOLD,
   });
 
   // Render all SVGs in parallel

--- a/examples/rate_functions_comparison.ts
+++ b/examples/rate_functions_comparison.ts
@@ -6,6 +6,7 @@ import {
   Shift,
   AnimationGroup,
   RIGHT,
+  LEFT,
   BLACK,
   BLUE,
   RED,
@@ -47,10 +48,10 @@ const rateFunctions: Array<{
 ];
 
 const ROW_COUNT = rateFunctions.length;
-const TOP_Y = 2.0;
-const ROW_SPACING = 0.7;
-const START_X = -2.5;
-const SHIFT_DISTANCE = 5.0;
+const TOP_Y = 2.4;
+const ROW_SPACING = 0.85;
+const START_X = -1.5;
+const SHIFT_DISTANCE = 5.5;
 
 document.getElementById('playBtn').addEventListener('click', async () => {
   if (isAnimating) return;
@@ -66,14 +67,6 @@ document.getElementById('playBtn').addEventListener('click', async () => {
     const y = TOP_Y - i * ROW_SPACING;
     const { name, color } = rateFunctions[i];
 
-    // Label on the left
-    const label = new Text({
-      text: name,
-      fontSize: 20,
-      color: WHITE,
-    });
-    label.moveTo([START_X - 2.0, y, 0]);
-
     // Track line (faint guide)
     const trackLine = new Line({
       start: [START_X, y, 0],
@@ -81,6 +74,14 @@ document.getElementById('playBtn').addEventListener('click', async () => {
       color: '#333333',
       strokeWidth: 1,
     });
+
+    // Label on the left, right-edge aligned just before track start
+    const label = new Text({
+      text: name,
+      fontSize: 28,
+      color: WHITE,
+    });
+    label.nextTo(trackLine, LEFT, 0.2);
 
     // Dot at the start position
     const dot = new Dot({

--- a/examples/three_d_camera_illusion_rotation.ts
+++ b/examples/three_d_camera_illusion_rotation.ts
@@ -23,11 +23,6 @@ async function threeDCameraIllusionRotation(scene: ThreeDScene) {
   });
 
   const circle = new Circle({ radius: 1, color: '#FC6255' });
-  // Circle points are in Manim x-y plane but VMobject renders them
-  // directly in THREE.js coords. Rotate -90° around X to lay flat
-  // on the ground plane (THREE.js x-z = Manim x-y).
-  circle.rotation.x = -Math.PI / 2;
-
   scene.add(circle, axes);
 
   // Begin 3D illusion camera rotation (theta rotates at 2 rad/s,

--- a/examples/three_d_camera_rotation.ts
+++ b/examples/three_d_camera_rotation.ts
@@ -23,11 +23,6 @@ async function threeDCameraRotation(scene: ThreeDScene) {
   });
 
   const circle = new Circle({ radius: 1, color: '#FC6255' });
-  // Circle points are in Manim x-y plane but VMobject renders them
-  // directly in THREE.js coords. Rotate -90° around X to lay flat
-  // on the ground plane (THREE.js x-z = Manim x-y).
-  circle.rotation.x = -Math.PI / 2;
-
   scene.add(circle, axes);
 
   // Begin ambient camera rotation (theta rotates at 0.1 rad/s)

--- a/examples/three_d_surface_plot.ts
+++ b/examples/three_d_surface_plot.ts
@@ -15,9 +15,7 @@ async function threeDSurfacePlot(scene: ThreeDScene) {
   const sigma = 0.4;
   const mu = [0.0, 0.0];
 
-  // Gaussian surface: parametric function mapping (u,v) to 3D point
-  // Surface3D func returns [x, y, z] used directly as THREE.js coordinates.
-  // Manim Z-up -> THREE.js Y-up: return [manimX, manimZ, -manimY]
+  // Gaussian surface: Z-up Manim convention — height is along z.
   const gaussSurface = new Surface3D({
     func: (u: number, v: number) => {
       const x = u;
@@ -26,8 +24,7 @@ async function threeDSurfacePlot(scene: ThreeDScene) {
       const dy = y - mu[1];
       const d = Math.sqrt(dx * dx + dy * dy);
       const z = Math.exp(-(d * d) / (2.0 * sigma * sigma));
-      // Manim coords (x, y, z) -> THREE.js coords (x, z, -y)
-      return [x, z, -y];
+      return [x, y, z];
     },
     uRange: [-2, 2],
     vRange: [-2, 2],

--- a/examples/vector_arrow.ts
+++ b/examples/vector_arrow.ts
@@ -1,4 +1,4 @@
-import { Arrow, DOWN, Dot, NumberPlane, ORIGIN, RIGHT, Scene, Text } from '../src/index.ts';
+import { Arrow, DOWN, Dot, NumberPlane, ORIGIN, RIGHT, Scene, Text, YELLOW } from '../src/index.ts';
 
 const container = document.getElementById('container');
 const scene = new Scene(container, {
@@ -8,7 +8,7 @@ const scene = new Scene(container, {
 });
 
 async function vectorArrow(scene: Scene) {
-  const dot = new Dot({ point: ORIGIN });
+  const dot = new Dot({ point: ORIGIN, radius: 0.12, color: YELLOW });
   const arrow = new Arrow({ start: ORIGIN, end: [2, 2, 0] });
   const numberplane = new NumberPlane();
   const originText = new Text({ text: '(0, 0)' }).nextTo(dot, DOWN);


### PR DESCRIPTION
## Summary

Closes #316. Touches only `examples/*.ts` — no library code changed.

- **3D coord convention** (`three_d_surface_plot`, `three_d_camera_rotation`, `three_d_camera_illusion_rotation`): drop the leftover Y-up→Z-up compensations now that `ThreeDScene` is Z-up by default (`Camera.ts` orbit formula uses `z = cos(phi)`). Surface no longer swaps `[x, z, -y]`; the circle in the rotation scenes no longer needs `rotation.x = -π/2`.
- **Font size** (`apply_matrix_arrows`, `rate_functions_comparison`, `easing_functions_showcase`): bump font sizes; for the two row-based comparisons, switch labels to `nextTo(trackLine, LEFT, 0.2)` and retune `TOP_Y` / `ROW_SPACING` / `START_X` so labels right-align against each track and don't clip at 800×450.
- **mathtex_svg yellow**: swap `YELLOW` for `GOLD` (saturated equations) and `TEAL` (transform target) — softer against black.
- **vector_arrow origin**: enlarge the Dot (`radius: 0.12`) and tint it `YELLOW` so it stays visible against the white axes of `NumberPlane`.
- **export_animation**: was producing an empty GIF — each sequential `await scene.play()` overwrites `scene.timeline` with only the last animation (`Scene.ts:548`), and that animation's mobject is removed by `FadeOut`'s `remover=true`, so the seek-based exporter renders a blank scene. Refactor: a shared `buildAnimations()` returns three fresh `Animation` instances; Play awaits them sequentially, Export installs them onto a single `Timeline` via `timeline.add(anim, '>')` so each `begin()` fires lazily as forward seek crosses its start time. Avoided `Succession` deliberately — it begins all children eagerly, which would let `Create.begin()` zero the fillOpacity that `Transform.begin()` then snapshots (caught in codex review).

Minus-sign-not-white from the issue's follow-up comment isn't fixed here — it needs a reproducer in the library code, not the examples.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx vitest run` — 5873/5873 passing
- [x] Visual: all touched examples loaded in `npx vite` and exercised in the browser (origin dot visible, labels readable, 3D Z-up correct, mathtex_svg colors softer, Play shows filled square→circle→fade, Export GIF produces a ~149 KB file, Export WebM begins encoding)