### PR TITLE
fix: defer scene.add() auto-render to next microtask (#317)

### DIFF
--- a/src/core/Scene-add-render.test.ts
+++ b/src/core/Scene-add-render.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Scene } from './Scene';
+import { ThreeDScene } from './ThreeDScene';
+import { Circle } from '../mobjects/geometry/Circle';
+import { Square } from '../mobjects/geometry/Rectangle';
+import { Create } from '../animation/creation/Create';
+import { FadeIn } from '../animation/fading/FadeIn';
+
+/**
+ * Regression tests for issue #317:
+ * `scene.add(x); scene.play(Create(x))` must not render `x` at full opacity
+ * for one frame before the animation begins. `add()` is state-only and
+ * defers its auto-render via microtask; `play()` and `wait()` suppress that
+ * deferred render while they set up the animation.
+ */
+
+const flushMicrotasks = () => new Promise<void>((r) => queueMicrotask(r));
+
+type SceneInternals = {
+  _render: () => void;
+  _pendingRender: boolean;
+  _suppressAutoRender: boolean;
+};
+
+describe('Scene.add() defers auto-render (issue #317)', () => {
+  it('add() schedules a render via microtask, does not render synchronously', async () => {
+    const scene = Scene.createHeadless();
+    const renderSpy = vi.spyOn(scene as unknown as SceneInternals, '_render');
+    // Constructor calls _render() once; reset before the test action.
+    renderSpy.mockClear();
+
+    scene.add(new Circle());
+
+    // No synchronous render yet — only a queued microtask.
+    expect(renderSpy).not.toHaveBeenCalled();
+
+    await flushMicrotasks();
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+
+    scene.dispose();
+  });
+
+  it('multiple add() calls within a tick coalesce into a single render', async () => {
+    const scene = Scene.createHeadless();
+    const renderSpy = vi.spyOn(scene as unknown as SceneInternals, '_render');
+    renderSpy.mockClear();
+
+    scene.add(new Circle());
+    scene.add(new Square());
+    scene.add(new Circle());
+
+    expect(renderSpy).not.toHaveBeenCalled();
+    await flushMicrotasks();
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+
+    scene.dispose();
+  });
+
+  it('play() after add() suppresses the pending render (no pre-animation flash)', async () => {
+    const scene = Scene.createHeadless();
+    const circle = new Circle();
+    const renderSpy = vi.spyOn(scene as unknown as SceneInternals, '_render');
+    renderSpy.mockClear();
+
+    scene.add(circle);
+    // Synchronously start play() before the queued add-render microtask runs.
+    const playPromise = scene.play(new Create(circle, { duration: 0.05 }));
+
+    // The pending render flag must be cleared once play() begins its setup.
+    expect((scene as unknown as SceneInternals)._pendingRender).toBe(false);
+
+    await playPromise;
+
+    // We don't pin the exact frame count (varies with timer), but we do
+    // require that begin() ran with `_render()` not yet called from add().
+    // Any render that happened was driven by the render loop, after begin().
+    scene.dispose();
+  });
+
+  it('wait() cancels the add() pending render', async () => {
+    const scene = Scene.createHeadless();
+    scene.add(new Circle());
+    expect((scene as unknown as SceneInternals)._pendingRender).toBe(true);
+
+    const waitPromise = scene.wait(0.01);
+    expect((scene as unknown as SceneInternals)._pendingRender).toBe(false);
+    await waitPromise;
+
+    scene.dispose();
+  });
+
+  it('add() with no follow-up play still renders (backward compatible)', async () => {
+    const scene = Scene.createHeadless();
+    const renderSpy = vi.spyOn(scene as unknown as SceneInternals, '_render');
+    renderSpy.mockClear();
+
+    scene.add(new Circle());
+    await flushMicrotasks();
+
+    expect(renderSpy).toHaveBeenCalled();
+    scene.dispose();
+  });
+
+  it('add() with autoRender=false does not schedule a render', async () => {
+    const scene = Scene.createHeadless({ autoRender: false } as never);
+    const renderSpy = vi.spyOn(scene as unknown as SceneInternals, '_render');
+    renderSpy.mockClear();
+
+    scene.add(new Circle());
+    await flushMicrotasks();
+
+    expect(renderSpy).not.toHaveBeenCalled();
+    scene.dispose();
+  });
+
+  it('ThreeDScene.add() also defers its render (#317)', async () => {
+    const scene = ThreeDScene.createHeadless();
+    const renderSpy = vi.spyOn(scene as unknown as SceneInternals, '_render');
+    renderSpy.mockClear();
+
+    scene.add(new Circle());
+    expect(renderSpy).not.toHaveBeenCalled();
+
+    await flushMicrotasks();
+    expect(renderSpy).toHaveBeenCalled();
+    scene.dispose();
+  });
+
+  it('addForegroundMobject() defers its render and is suppressed by play() (#317)', async () => {
+    const scene = Scene.createHeadless();
+    const circle = new Circle();
+    const renderSpy = vi.spyOn(scene as unknown as SceneInternals, '_render');
+    renderSpy.mockClear();
+
+    scene.addForegroundMobject(circle);
+    expect(renderSpy).not.toHaveBeenCalled();
+
+    const playPromise = scene.play(new Create(circle, { duration: 0.05 }));
+    expect((scene as unknown as SceneInternals)._pendingRender).toBe(false);
+
+    await playPromise;
+    scene.dispose();
+  });
+
+  it('FadeIn after add() does not flash the mobject visible (#317)', async () => {
+    const scene = Scene.createHeadless();
+    const circle = new Circle();
+    const renderSpy = vi.spyOn(scene as unknown as SceneInternals, '_render');
+    renderSpy.mockClear();
+
+    scene.add(circle);
+    const playPromise = scene.play(new FadeIn(circle, { duration: 0.05 }));
+
+    // No render fired between add() and play() entering its setup phase.
+    expect(renderSpy).not.toHaveBeenCalled();
+
+    await playPromise;
+    scene.dispose();
+  });
+});

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -98,6 +98,14 @@ export class Scene {
   // Performance optimization: auto-render control
   protected _autoRender: boolean = true;
 
+  // Deferred auto-render: `add()` schedules a render via microtask instead of
+  // rendering eagerly, so a subsequent `play()` can suppress it and avoid a
+  // visible flash of the pre-animation state. See issue #317.
+  private _pendingRender: boolean = false;
+  // When true, scheduled renders are suppressed and no microtask is queued.
+  // Set by `play()`/`wait()` during their setup phase.
+  private _suppressAutoRender: boolean = false;
+
   // Z-ordering: assign increasing renderOrder to each added mobject
   private _renderOrderCounter: number = 0;
 
@@ -342,9 +350,8 @@ export class Scene {
         child.renderOrder = fgRo;
       });
     }
-    if (this._autoRender) {
-      this._render();
-    }
+    // Deferred render so a chained `play()` can suppress it (issue #317).
+    this._scheduleRender();
     return this;
   }
 
@@ -387,9 +394,9 @@ export class Scene {
         mobject.createdAtBeginning = true;
       }
     }
-    if (this._autoRender) {
-      this._render();
-    }
+    // Defer the auto-render via microtask so a chained `play()` can suppress
+    // it and avoid a one-frame flash of the pre-animation state (issue #317).
+    this._scheduleRender();
     return this;
   }
 
@@ -500,67 +507,80 @@ export class Scene {
     // AnimationGroup.begin() handles calling begin() on its own children.
     const allAnimations = this._collectAllAnimations(animations);
 
-    // Wait for any async renders (e.g. SVG-based MathTex) to complete before
-    // starting animations. Without this, Create/DrawBorderThenFill would
-    // animate an empty mobject because SVG paths haven't loaded yet.
-    const renderPromises: Promise<void>[] = [];
-    const collectRenders = (mobject: Mobject) => {
-      const asyncMob = mobject as Mobject & { waitForRender?: () => Promise<void> };
-      if (typeof asyncMob.waitForRender === 'function') {
-        renderPromises.push(asyncMob.waitForRender().catch(() => {}));
+    // Suppress any auto-render that `add()` (called by the user before play,
+    // or by us below) might have scheduled. Otherwise the mobject would be
+    // rendered at full opacity for one microtask before begin() hides it
+    // (issue #317). Suppression is released once the render loop is running.
+    this._cancelPendingRender();
+    this._suppressAutoRender = true;
+    try {
+      // Wait for any async renders (e.g. SVG-based MathTex) to complete before
+      // starting animations. Without this, Create/DrawBorderThenFill would
+      // animate an empty mobject because SVG paths haven't loaded yet.
+      const renderPromises: Promise<void>[] = [];
+      const collectRenders = (mobject: Mobject) => {
+        const asyncMob = mobject as Mobject & { waitForRender?: () => Promise<void> };
+        if (typeof asyncMob.waitForRender === 'function') {
+          renderPromises.push(asyncMob.waitForRender().catch(() => {}));
+        }
+        for (const child of mobject.children) {
+          collectRenders(child);
+        }
+      };
+      for (const anim of allAnimations) {
+        collectRenders(anim.mobject);
       }
-      for (const child of mobject.children) {
-        collectRenders(child);
+      if (renderPromises.length > 0) {
+        await Promise.all(renderPromises);
       }
-    };
-    for (const anim of allAnimations) {
-      collectRenders(anim.mobject);
-    }
-    if (renderPromises.length > 0) {
-      await Promise.all(renderPromises);
-    }
 
-    // Force geometry sync so begin() can detect Line2 children for dash-reveal
-    // animations (e.g. MathTex Create). This must happen before begin() but
-    // we must NOT add to the scene yet — otherwise the mobject renders at full
-    // opacity for one frame before begin() hides it.
-    for (const animation of allAnimations) {
-      if (animation.mobject._dirty) {
-        animation.mobject._syncToThree();
-        animation.mobject._dirty = false;
+      // Force geometry sync so begin() can detect Line2 children for dash-reveal
+      // animations (e.g. MathTex Create). This must happen before begin() but
+      // we must NOT add to the scene yet — otherwise the mobject renders at full
+      // opacity for one frame before begin() hides it.
+      for (const animation of allAnimations) {
+        if (animation.mobject._dirty) {
+          animation.mobject._syncToThree();
+          animation.mobject._dirty = false;
+        }
       }
-    }
 
-    // Initialize only top-level animations to avoid double begin() on AnimationGroup children
-    for (const animation of animations) {
-      animation.begin();
-    }
-
-    // Add animated mobjects to scene AFTER begin() so they appear in their
-    // initial animation state (e.g. hidden for Create, zero opacity for FadeIn).
-    for (const animation of allAnimations) {
-      if (!this._mobjects.has(animation.mobject)) {
-        this.add(animation.mobject);
+      // Initialize only top-level animations to avoid double begin() on AnimationGroup children
+      for (const animation of animations) {
+        animation.begin();
       }
+
+      // Add animated mobjects to scene AFTER begin() so they appear in their
+      // initial animation state (e.g. hidden for Create, zero opacity for FadeIn).
+      for (const animation of allAnimations) {
+        if (!this._mobjects.has(animation.mobject)) {
+          this.add(animation.mobject);
+        }
+      }
+
+      // Play all animations in parallel (Manim behavior)
+      this._timeline = new Timeline();
+      this._timeline.addParallel(animations);
+
+      // Start playback
+      this._timeline.play();
+      this._isPlaying = true;
+      this._currentTime = 0;
+
+      // Start audio playback if audio has been loaded
+      if (this._audioManager) {
+        this._audioManager.seek(0);
+        this._audioManager.play();
+      }
+
+      // Start render loop if not already running
+      this._startRenderLoop();
+    } finally {
+      // Render loop owns rendering from here on; release suppression so any
+      // post-play `add()` (or async render resolution) renders normally.
+      this._suppressAutoRender = false;
+      this._cancelPendingRender();
     }
-
-    // Play all animations in parallel (Manim behavior)
-    this._timeline = new Timeline();
-    this._timeline.addParallel(animations);
-
-    // Start playback
-    this._timeline.play();
-    this._isPlaying = true;
-    this._currentTime = 0;
-
-    // Start audio playback if audio has been loaded
-    if (this._audioManager) {
-      this._audioManager.seek(0);
-      this._audioManager.play();
-    }
-
-    // Start render loop if not already running
-    this._startRenderLoop();
 
     // Wait for all animations to finish (or dispose cancels)
     if (this._disposed) return;
@@ -593,6 +613,10 @@ export class Scene {
    */
   async wait(duration: number = 1): Promise<void> {
     if (this._disposed) return;
+    // wait() will render the initial frame itself (either once or via its
+    // own rAF loop); drop any pending add()-scheduled render so we don't
+    // render twice on entry.
+    this._cancelPendingRender();
     return new Promise((resolve) => {
       const startTime = performance.now();
       let lastFrameTime = startTime;
@@ -769,9 +793,9 @@ export class Scene {
         asyncMob
           .waitForRender()
           .then(() => {
-            if (this._autoRender) {
-              this._render();
-            }
+            // Route through the scheduler so a play()/wait() in flight can
+            // suppress this render and avoid a pre-animation flash (#317).
+            this._scheduleRender();
           })
           .catch((err) => {
             console.warn('Scene: async mobject render failed for', asyncMob, err);
@@ -793,6 +817,29 @@ export class Scene {
       if (mob.hasUpdaters()) return true;
     }
     return false;
+  }
+
+  /**
+   * Queue a render to run on the next microtask. Multiple calls within the
+   * same tick coalesce. If `_cancelPendingRender()` is called or
+   * `_suppressAutoRender` is set before the microtask fires, the render is
+   * skipped. Used by `add()` so a chained `play()` can suppress the
+   * pre-animation flash described in issue #317.
+   */
+  protected _scheduleRender(): void {
+    if (!this._autoRender || this._disposed || this._suppressAutoRender) return;
+    if (this._pendingRender) return;
+    this._pendingRender = true;
+    queueMicrotask(() => {
+      if (!this._pendingRender) return;
+      this._pendingRender = false;
+      if (this._suppressAutoRender || this._disposed) return;
+      this._render();
+    });
+  }
+
+  protected _cancelPendingRender(): void {
+    this._pendingRender = false;
   }
 
   /**

--- a/src/core/ThreeDScene.ts
+++ b/src/core/ThreeDScene.ts
@@ -186,8 +186,10 @@ export class ThreeDScene extends Scene {
    *    distance instead of add order (base Scene stamps an incrementing
    *    renderOrder for 2D z-ordering, which defeats 3D depth sort)
    *
-   * Auto-render is suppressed inside super.add() and run once at the end,
+   * Auto-render is suppressed inside super.add() and scheduled once at the end,
    * after settings are applied, so the first visible frame is correct.
+   * Render is deferred via the scheduler (issue #317) so a chained `play()`
+   * can suppress it and avoid a pre-animation flash.
    */
   add(...mobjects: Mobject[]): this {
     const wasAuto = this._autoRender;
@@ -196,10 +198,12 @@ export class ThreeDScene extends Scene {
     try {
       super.add(...mobjects);
       for (const mob of mobjects) ThreeDScene._applyDepthSettings(mob, newMobs.has(mob));
-      if (wasAuto) this._render();
     } finally {
       this._autoRender = wasAuto;
     }
+    // Schedule the post-settings render via the deferred path so it inherits
+    // the same play()/wait() suppression as the base Scene.add().
+    this._scheduleRender();
     return this;
   }
 


### PR DESCRIPTION
Fixes #317.

## Summary
- `scene.add(x)` followed by `scene.play(Create(x))` flashed `x` at full opacity for one frame before `Create.begin()` hid it.
- `add()` now schedules its auto-render via `queueMicrotask` instead of rendering eagerly. A new `_pendingRender` flag dedupes multiple scheduled renders within one tick.
- `play()` and `wait()` cancel the pending render and (in `play()`) set `_suppressAutoRender` for the duration of the synchronous setup phase, so async render resolutions cannot trigger a flash either.
- `ThreeDScene.add()` and `addForegroundMobject()` route through the same scheduler so the fix covers all add-like entry points.

## Why microtask, not eager
- Standalone `scene.add(c)` (no follow-up `play`) — microtask still fires, user sees the object. Backward compatible.
- `scene.add(c); scene.play(Create(c))` (sync) — `play()` cancels before the microtask runs. No flash.
- `scene.add(mathTex); scene.play(...)` (async path inside `play()`) — `_suppressAutoRender` keeps `_awaitAsyncRenders` resolutions suppressed during play setup. No flash.
- Multiple `add()` calls per tick coalesce into a single render.

## Test plan
- [x] New unit tests in `src/core/Scene-add-render.test.ts` covering: deferral, coalescing, `play()` suppression, `wait()` cancellation, `autoRender:false` opt-out, `FadeIn` regression, `ThreeDScene.add()`, `addForegroundMobject()`.
- [x] Full vitest suite: 114 files, 5882 tests passing.
- [x] `npm run lint` clean.
- [x] `npm run typecheck` clean.
- [x] Manual smoke: `examples/basic.html` (the exact pattern from the issue) still animates correctly.
- [x] Probe page instrumented `_render` and confirmed zero renders between `scene.add()` and `play()` returning.
- [x] Codex review: GO after addressing `ThreeDScene.add` and `addForegroundMobject` overrides.

## Files
- `src/core/Scene.ts` — scheduler + suppression, `add()`/`play()`/`wait()`/`addForegroundMobject()`/`_awaitAsyncRenders` updated.
- `src/core/ThreeDScene.ts` — route through scheduler.
- `src/core/Scene-add-render.test.ts` — new regression tests.