### PR TITLE
fix(examples): #316 follow-up polish (minus sign, origin label, orbit Z-up)

### DIFF
--- a/examples/3d-scenes/draggable_constraints_3d.ts
+++ b/examples/3d-scenes/draggable_constraints_3d.ts
@@ -12,6 +12,7 @@ const scene = new ThreeDScene(container, {
   distance: 20,
   fov: 30,
   enableOrbitControls: true,
+  orbitControlsUp: 'z',
 });
 
 const axes = new ThreeDAxes({

--- a/examples/3d-scenes/three_d_axes_c2p.html
+++ b/examples/3d-scenes/three_d_axes_c2p.html
@@ -35,6 +35,7 @@
       distance: 20,
       fov: 30,
       enableOrbitControls: true,
+      orbitControlsUp: 'z',
     });
 
     const axes = new ThreeDAxes({

--- a/examples/3d-scenes/three_d_reflex_angle.ts
+++ b/examples/3d-scenes/three_d_reflex_angle.ts
@@ -24,6 +24,7 @@ const scene = new ThreeDScene(container, {
   distance: 20,
   fov: 30,
   enableOrbitControls: true,
+  orbitControlsUp: 'z',
 });
 
 let isAnimating = false;

--- a/examples/brace_annotation.ts
+++ b/examples/brace_annotation.ts
@@ -19,7 +19,7 @@ async function braceAnnotation(scene: Scene) {
       .rotate(Math.PI / 2)
       .getUnitVector(),
   });
-  const b2text = b2.getTex('x-x_1');
+  const b2text = b2.getTex('x-x_1', { fontSize: 48 });
   scene.add(line, dot, dot2, b1, b2, b1text, b2text);
 }
 

--- a/examples/fixed_in_frame_mobject_test.ts
+++ b/examples/fixed_in_frame_mobject_test.ts
@@ -9,6 +9,7 @@ const scene = new ThreeDScene(container, {
   theta: -45 * (Math.PI / 180),
   distance: 20,
   fov: 30,
+  orbitControlsUp: 'z',
 });
 
 async function fixedInFrameMObjectTest(scene: ThreeDScene) {

--- a/examples/fixed_orientation_follow.ts
+++ b/examples/fixed_orientation_follow.ts
@@ -18,6 +18,7 @@ const scene = new ThreeDScene(container, {
   distance: 20,
   fov: 30,
   enableOrbitControls: true,
+  orbitControlsUp: 'z',
 });
 
 const axes = new ThreeDAxes({

--- a/examples/fixed_orientation_mobjects.ts
+++ b/examples/fixed_orientation_mobjects.ts
@@ -1,4 +1,4 @@
-import { Text, ThreeDAxes, ThreeDScene } from '../src/index.ts';
+import { GOLD, Text, ThreeDAxes, ThreeDScene } from '../src/index.ts';
 
 const container = document.getElementById('container');
 const scene = new ThreeDScene(container, {
@@ -9,6 +9,7 @@ const scene = new ThreeDScene(container, {
   theta: -45 * (Math.PI / 180),
   distance: 20,
   fov: 30,
+  orbitControlsUp: 'z',
 });
 
 async function fixedOrientationMobjectsExample(scene: ThreeDScene) {
@@ -22,12 +23,14 @@ async function fixedOrientationMobjectsExample(scene: ThreeDScene) {
     shaftRadius: 0.008,
   });
 
-  // Create a label that sits in 3D space but always faces the camera
-  const label = new Text({ text: 'Origin', fontSize: 24 });
-  label.moveTo([0, 0.5, 0]);
+  // Create a label that sits in 3D space but always faces the camera.
+  // Small XY offset + GOLD tint so the text reads against the white axis lines
+  // without floating away from the origin it labels.
+  const label = new Text({ text: 'Origin', fontSize: 32, color: GOLD });
+  label.moveTo([0.4, 0.4, 0.3]);
 
-  const xLabel = new Text({ text: 'X', fontSize: 24 });
-  xLabel.moveTo([6.5, 0, 0]);
+  const xLabel = new Text({ text: 'X', fontSize: 32, color: GOLD });
+  xLabel.moveTo([6.8, 0, 0.4]);
 
   scene.add(axes, label, xLabel);
 

--- a/examples/three_d_angle.ts
+++ b/examples/three_d_angle.ts
@@ -10,6 +10,7 @@ const scene = new ThreeDScene(container, {
   distance: 20,
   fov: 30,
   enableOrbitControls: true,
+  orbitControlsUp: 'z',
 });
 
 async function threeDAngle(scene: ThreeDScene) {

--- a/examples/three_d_axes_labels.ts
+++ b/examples/three_d_axes_labels.ts
@@ -10,6 +10,7 @@ const scene = new ThreeDScene(container, {
   distance: 24,
   fov: 35,
   enableOrbitControls: true,
+  orbitControlsUp: 'z',
 });
 
 const axes = new ThreeDAxes({

--- a/examples/three_d_axes_labels_shift.ts
+++ b/examples/three_d_axes_labels_shift.ts
@@ -11,6 +11,7 @@ async function makeScene(id: string, shift: boolean) {
     // Deliberately tight: camera close + narrow FOV so default axis tips clip.
     distance: 12,
     fov: 25,
+    orbitControlsUp: 'z',
   });
 
   const axes = new ThreeDAxes({

--- a/examples/three_d_camera_illusion_rotation.ts
+++ b/examples/three_d_camera_illusion_rotation.ts
@@ -9,6 +9,7 @@ const scene = new ThreeDScene(container, {
   theta: 30 * (Math.PI / 180),
   distance: 20,
   fov: 30,
+  orbitControlsUp: 'z',
 });
 
 async function threeDCameraIllusionRotation(scene: ThreeDScene) {

--- a/examples/three_d_camera_rotation.ts
+++ b/examples/three_d_camera_rotation.ts
@@ -9,6 +9,7 @@ const scene = new ThreeDScene(container, {
   theta: 30 * (Math.PI / 180),
   distance: 20,
   fov: 30,
+  orbitControlsUp: 'z',
 });
 
 async function threeDCameraRotation(scene: ThreeDScene) {

--- a/examples/three_d_light_source_position.ts
+++ b/examples/three_d_light_source_position.ts
@@ -9,6 +9,7 @@ const scene = new ThreeDScene(container, {
   theta: 30 * (Math.PI / 180),
   distance: 20,
   fov: 30,
+  orbitControlsUp: 'z',
 });
 
 async function threeDLightSourcePosition(scene: ThreeDScene) {

--- a/examples/three_d_surface_plot.ts
+++ b/examples/three_d_surface_plot.ts
@@ -9,6 +9,7 @@ const scene = new ThreeDScene(container, {
   theta: -30 * (Math.PI / 180),
   distance: 20,
   fov: 30,
+  orbitControlsUp: 'z',
 });
 
 async function threeDSurfacePlot(scene: ThreeDScene) {


### PR DESCRIPTION
## Summary

Follow-up to #351 addressing the three remaining items in https://github.com/maloyan/manim-web/issues/316#issuecomment-4449622608:

- **Minus sign visibility in `brace_annotation`** — `Brace.getTex('x-x_1')` defaulted to `fontSize: 36`, and the KaTeX minus glyph stroke ends up too thin to read at standard DPR. Bumped this single call site to `fontSize: 48`.
- **Origin / X labels barely visible in `fixed_orientation_mobjects`** — labels were white at `fontSize: 24` sitting on top of the white `ThreeDAxes` lines. Re-tinted with `GOLD`, fontSize 32, with a small XY+Z offset so they read but stay anchored to what they label.
- **3D orbit controls should pivot around world Z** — `ThreeDScene` defaults `enableOrbitControls: true`, so every 3D example with orbit on gets `orbitControlsUp: 'z'` to match the Z-up camera default. Sweep covers 13 examples + `three_d_axes_c2p.html`; `sphere_opacity.ts` (orbit disabled) and `three_d_axes_coords.html` (already had it) are untouched.

Verified each touched example in `npm run dev`, including drag-rotate behavior for orbit-enabled scenes. Plan and diff each reviewed with codex.

## Test plan

- [x] `npm run lint` clean
- [x] `npx vitest run` — 5882 passed
- [x] Browser smoke test: `brace_annotation`, `fixed_orientation_mobjects`, `three_d_axes_labels`, `three_d_angle`, `three_d_camera_rotation`, `three_d_surface_plot`, `fixed_orientation_follow`, `3d-scenes/draggable_constraints_3d`
- [x] Drag-rotate confirms Z-axis stays vertical