### PR TITLE
feat(slides): per-slide looping via scene.loopPlay (#215)

### DIFF
--- a/examples/slides_mode_loop.html
+++ b/examples/slides_mode_loop.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ManimWeb - Slides Mode with Looping Slide</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #1a1a2e;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+      color: #ccc;
+    }
+    h1 {
+      margin-bottom: 16px;
+      font-size: 20px;
+      font-weight: 400;
+      color: #fff;
+    }
+    #container {
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .info {
+      margin-top: 20px;
+      font-size: 13px;
+      opacity: 0.6;
+      text-align: center;
+      line-height: 1.6;
+    }
+    kbd {
+      background: #333;
+      border: 1px solid #555;
+      border-radius: 3px;
+      padding: 1px 6px;
+      font-size: 12px;
+      font-family: monospace;
+    }
+    .highlight {
+      color: #6cf;
+      opacity: 1;
+      font-weight: 500;
+    }
+  </style>
+</head>
+<body>
+  <h1>Slides Mode with Looping Slide</h1>
+  <div id="container"></div>
+  <div class="info">
+    <p class="highlight">Slide 2 keeps rotating until you press &rarr;</p>
+    <br>
+    <kbd>&rarr;</kbd> Next slide &nbsp;
+    <kbd>&larr;</kbd> Previous slide &nbsp;
+    <kbd>Space</kbd> Play/Pause &nbsp;
+    <kbd>F</kbd> Fullscreen
+  </div>
+
+  <script type="module">
+    import {
+      Player,
+      Circle,
+      Square,
+      Create,
+      Rotate,
+      Transform,
+      FadeOut,
+      BLACK,
+      BLUE,
+      RED,
+    } from '../src/index.ts';
+    import { linear } from '../src/rate-functions/index.ts';
+
+    const container = document.getElementById('container');
+    const player = new Player(container, {
+      width: 800,
+      height: 450,
+      backgroundColor: BLACK,
+      slidesMode: true,
+    });
+    // Expose for manual testing in devtools.
+    window.player = player;
+
+    player.sequence(async (scene) => {
+      // Slide 1: create blue square
+      const square = new Square({ sideLength: 2, color: BLUE });
+      await scene.play(new Create(square));
+
+      // Slide 2: looping rotation — full turn, linear, so each cycle is seamless.
+      // The slide replays until the user presses → to advance.
+      await scene.loopPlay(
+        new Rotate(square, { angle: Math.PI * 2, duration: 2, rateFunc: linear }),
+      );
+
+      // Slide 3: transform to red circle
+      const circle = new Circle({ radius: 1.5, color: RED });
+      await scene.play(new Transform(square, circle));
+
+      // Slide 4: fade out
+      await scene.play(new FadeOut(square));
+    });
+  </script>
+</body>
+</html>

--- a/src/animation/MasterTimeline.test.ts
+++ b/src/animation/MasterTimeline.test.ts
@@ -113,6 +113,29 @@ describe('MasterTimeline', () => {
       expect(tl.getDuration()).toBe(1);
       expect(tl.length).toBe(1); // one scheduled animation on base Timeline
     });
+
+    it('defaults segment.loop to false', () => {
+      const mob = new TestMobject();
+      const anim = new TestAnimation(mob, { duration: 1 });
+      const seg = tl.addSegment([anim]);
+
+      expect(seg.loop).toBe(false);
+    });
+
+    it('stores segment.loop=true when opts.loop is true', () => {
+      const mob = new TestMobject();
+      const anim = new TestAnimation(mob, { duration: 1 });
+      const seg = tl.addSegment([anim], { loop: true });
+
+      expect(seg.loop).toBe(true);
+    });
+
+    it('throws when adding a zero-duration looping segment', () => {
+      const mob = new TestMobject();
+      const anim = new TestAnimation(mob, { duration: 0 });
+
+      expect(() => tl.addSegment([anim], { loop: true })).toThrow(/zero-duration/);
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -143,6 +166,11 @@ describe('MasterTimeline', () => {
       expect(waitSeg.startTime).toBe(1);
       expect(waitSeg.endTime).toBe(1.5);
       expect(tl.getDuration()).toBe(1.5);
+    });
+
+    it('defaults wait segment loop to false', () => {
+      const seg = tl.addWaitSegment(1);
+      expect(seg.loop).toBe(false);
     });
   });
 

--- a/src/animation/MasterTimeline.ts
+++ b/src/animation/MasterTimeline.ts
@@ -18,6 +18,18 @@ export interface Segment {
   animations: Animation[];
   /** Whether this is a wait/pause segment */
   isWait: boolean;
+  /**
+   * Whether this segment should loop while paused on it in slides mode.
+   * When true and the player reaches endTime in slidesMode, it seeks
+   * back to startTime and keeps playing until the user advances.
+   * Ignored outside slidesMode.
+   */
+  loop: boolean;
+}
+
+export interface SegmentOptions {
+  /** Loop this segment in slides mode. See Segment.loop. */
+  loop?: boolean;
 }
 
 export class MasterTimeline extends Timeline {
@@ -124,11 +136,17 @@ export class MasterTimeline extends Timeline {
    * Add a segment containing one or more parallel animations.
    * Returns the segment's start time (for the recorder to resolve).
    */
-  addSegment(animations: Animation[]): Segment {
+  addSegment(animations: Animation[], opts: SegmentOptions = {}): Segment {
     const startTime = this.getDuration();
     this.addParallel(animations, startTime);
 
     const maxDuration = Math.max(...animations.map((a) => a.duration));
+    const loop = opts.loop ?? false;
+    if (loop && maxDuration <= 0) {
+      throw new Error(
+        'MasterTimeline.addSegment: cannot loop a zero-duration segment (would rewind every frame).',
+      );
+    }
     const segmentIndex = this._segments.length;
     const segment: Segment = {
       index: segmentIndex,
@@ -136,6 +154,7 @@ export class MasterTimeline extends Timeline {
       endTime: startTime + maxDuration,
       animations,
       isWait: false,
+      loop,
     };
     this._segments.push(segment);
 
@@ -168,6 +187,7 @@ export class MasterTimeline extends Timeline {
       endTime: startTime + duration,
       animations: [],
       isWait: true,
+      loop: false,
     };
     this._segments.push(segment);
     return segment;

--- a/src/player/Player.test.ts
+++ b/src/player/Player.test.ts
@@ -428,6 +428,125 @@ describe('Player', () => {
     expect(player.timeline.getCurrentTime()).toBeCloseTo(1.0);
   });
 
+  // ---- per-slide loop ----
+
+  it('public seek clears _activeLoopSegmentIndex', async () => {
+    player.dispose();
+    container.remove();
+    const { player: p, container: c } = createPlayer({ slidesMode: true });
+    player = p;
+    container = c;
+
+    await player.sequence(async (scene) => {
+      await scene.wait(1);
+      await scene.wait(1);
+    });
+
+    const internal = player as unknown as { _activeLoopSegmentIndex: number | null };
+    internal._activeLoopSegmentIndex = 0;
+    player.seek(0.5);
+    expect(internal._activeLoopSegmentIndex).toBeNull();
+  });
+
+  it('setSlidesMode(false) clears active loop state', async () => {
+    player.dispose();
+    container.remove();
+    const { player: p, container: c } = createPlayer({ slidesMode: true });
+    player = p;
+    container = c;
+
+    await player.sequence(async (scene) => {
+      await scene.wait(1);
+    });
+
+    const internal = player as unknown as {
+      _activeLoopSegmentIndex: number | null;
+      _slidesTargetSegmentIndex: number;
+    };
+    internal._activeLoopSegmentIndex = 0;
+    internal._slidesTargetSegmentIndex = 0;
+    player.setSlidesMode(false);
+    expect(internal._activeLoopSegmentIndex).toBeNull();
+    expect(internal._slidesTargetSegmentIndex).toBe(-1);
+  });
+
+  it('prevSegment from inside an active loop always exits to previous slide', async () => {
+    player.dispose();
+    container.remove();
+    const { player: p, container: c } = createPlayer({ slidesMode: true });
+    player = p;
+    container = c;
+
+    await player.sequence(async (scene) => {
+      await scene.wait(1);
+      await scene.wait(1);
+    });
+
+    const segs = player.timeline.getSegments();
+    (segs[1] as { loop: boolean }).loop = true;
+    // Test the phase-independent behavior: even >0.5s into the loop cycle,
+    // ← should go to the previous slide (not restart the loop).
+    player.seek(1.6);
+    const internal = player as unknown as {
+      _activeLoopSegmentIndex: number | null;
+      _slidesTargetSegmentIndex: number;
+    };
+    internal._activeLoopSegmentIndex = 1;
+
+    player.prevSegment();
+    expect(internal._activeLoopSegmentIndex).toBeNull();
+    expect(internal._slidesTargetSegmentIndex).toBe(-1);
+    // Lands at segment 0's start regardless of where we were in the loop.
+    expect(player.timeline.getCurrentTime()).toBeCloseTo(0);
+  });
+
+  it('public seek out of an active loop clears both loop and target state', async () => {
+    player.dispose();
+    container.remove();
+    const { player: p, container: c } = createPlayer({ slidesMode: true });
+    player = p;
+    container = c;
+
+    await player.sequence(async (scene) => {
+      await scene.wait(1);
+      await scene.wait(1);
+    });
+
+    const internal = player as unknown as {
+      _activeLoopSegmentIndex: number | null;
+      _slidesTargetSegmentIndex: number;
+    };
+    internal._activeLoopSegmentIndex = 0;
+    internal._slidesTargetSegmentIndex = 0;
+    // Seek FAR past the loop segment — if the target stayed at 0, the next
+    // render tick would snap back into the old loop.
+    player.seek(1.5);
+    expect(internal._activeLoopSegmentIndex).toBeNull();
+    expect(internal._slidesTargetSegmentIndex).toBe(-1);
+  });
+
+  it('sequence() resets active loop state', async () => {
+    player.dispose();
+    container.remove();
+    const { player: p, container: c } = createPlayer({ slidesMode: true });
+    player = p;
+    container = c;
+
+    const internal = player as unknown as {
+      _activeLoopSegmentIndex: number | null;
+      _slidesTargetSegmentIndex: number;
+    };
+    internal._activeLoopSegmentIndex = 0;
+    internal._slidesTargetSegmentIndex = 0;
+
+    await player.sequence(async (scene) => {
+      await scene.wait(1);
+    });
+
+    expect(internal._activeLoopSegmentIndex).toBeNull();
+    expect(internal._slidesTargetSegmentIndex).toBe(-1);
+  });
+
   // ---- loop option ----
 
   it('accepts loop option without error', () => {
@@ -664,6 +783,131 @@ describe('Player _startLoop render loop', () => {
     expect(player.timeline.getCurrentTime()).toBeCloseTo(0.5);
   });
 
+  it('_startLoop rewinds and keeps playing on looped segment boundary in slidesMode', async () => {
+    player.dispose();
+    container.remove();
+    const result = createPlayer({ slidesMode: true });
+    player = result.player;
+    container = result.container;
+
+    await player.sequence(async (scene) => {
+      await scene.wait(0.5);
+      await scene.wait(0.5);
+    });
+    // Mark segment 0 as looping
+    (player.timeline.getSegments()[0] as { loop: boolean }).loop = true;
+
+    player.play();
+    flushRaf(600); // past segment 0's endTime
+
+    // Loop should have rewound, NOT paused
+    expect(player.isPlaying).toBe(true);
+    const t = player.timeline.getCurrentTime();
+    expect(t).toBeGreaterThanOrEqual(0);
+    expect(t).toBeLessThan(0.5);
+    const internal = player as unknown as { _activeLoopSegmentIndex: number | null };
+    expect(internal._activeLoopSegmentIndex).toBe(0);
+  });
+
+  it('_startLoop rewinds when loop is the final segment (re-plays the underlying timeline)', async () => {
+    player.dispose();
+    container.remove();
+    const result = createPlayer({ slidesMode: true });
+    player = result.player;
+    container = result.container;
+
+    await player.sequence(async (scene) => {
+      await scene.wait(0.3);
+    });
+    // Mark only segment (the final one) as looping
+    (player.timeline.getSegments()[0] as { loop: boolean }).loop = true;
+
+    player.play();
+    flushRaf(400); // past timeline duration
+
+    expect(player.isPlaying).toBe(true);
+    // The masterTimeline must be playing again after seek-back, otherwise
+    // currentTime would freeze at 0 and the next update would no-op.
+    expect(player.timeline.isPlaying()).toBe(true);
+
+    // Advance another frame: time should keep moving forward from the rewind.
+    const before = player.timeline.getCurrentTime();
+    flushRaf(420);
+    // Strictly greater: a frozen-time bug (timeline left paused) would pass `>=`.
+    expect(player.timeline.getCurrentTime()).toBeGreaterThan(before);
+  });
+
+  it('nextSegment from active loop advances to next segment and keeps playing', async () => {
+    player.dispose();
+    container.remove();
+    const result = createPlayer({ slidesMode: true });
+    player = result.player;
+    container = result.container;
+
+    await player.sequence(async (scene) => {
+      await scene.wait(0.5);
+      await scene.wait(0.5);
+    });
+    (player.timeline.getSegments()[0] as { loop: boolean }).loop = true;
+
+    player.play();
+    flushRaf(600); // triggers rewind: _activeLoopSegmentIndex = 0
+
+    const internal = player as unknown as {
+      _activeLoopSegmentIndex: number | null;
+      _slidesTargetSegmentIndex: number;
+    };
+    expect(internal._activeLoopSegmentIndex).toBe(0);
+
+    player.nextSegment();
+    expect(internal._activeLoopSegmentIndex).toBeNull();
+    expect(internal._slidesTargetSegmentIndex).toBe(1);
+    expect(player.timeline.getCurrentTime()).toBeCloseTo(0.5);
+    expect(player.isPlaying).toBe(true);
+  });
+
+  it('nextSegment on a final loop segment seeks to endTime and pauses', async () => {
+    player.dispose();
+    container.remove();
+    const result = createPlayer({ slidesMode: true });
+    player = result.player;
+    container = result.container;
+
+    await player.sequence(async (scene) => {
+      await scene.wait(0.3);
+    });
+    (player.timeline.getSegments()[0] as { loop: boolean }).loop = true;
+
+    player.play();
+    flushRaf(400);
+
+    const internal = player as unknown as { _activeLoopSegmentIndex: number | null };
+    expect(internal._activeLoopSegmentIndex).toBe(0);
+
+    player.nextSegment();
+    expect(internal._activeLoopSegmentIndex).toBeNull();
+    expect(player.isPlaying).toBe(false);
+    expect(player.timeline.getCurrentTime()).toBeCloseTo(0.3);
+  });
+
+  it('_startLoop ignores loop flag when slidesMode is OFF', async () => {
+    await player.sequence(async (scene) => {
+      await scene.wait(0.3);
+      await scene.wait(0.5);
+    });
+    (player.timeline.getSegments()[0] as { loop: boolean }).loop = true;
+
+    player.play();
+    flushRaf(400);
+
+    // Without slides mode, the loop flag is a no-op: playback advances past
+    // segment 0 normally.
+    expect(player.isPlaying).toBe(true);
+    expect(player.timeline.getCurrentTime()).toBeGreaterThan(0.3);
+    const internal = player as unknown as { _activeLoopSegmentIndex: number | null };
+    expect(internal._activeLoopSegmentIndex).toBeNull();
+  });
+
   it('_startLoop does NOT auto-pause at segment boundary without slidesMode', async () => {
     await player.sequence(async (scene) => {
       await scene.wait(0.5);
@@ -810,6 +1054,38 @@ describe('RecordingScene pass-through methods', () => {
 
     expect(player.timeline.getDuration()).toBeCloseTo(1.0);
     expect(player.timeline.segmentCount).toBe(1);
+  });
+
+  it('loopPlay records a segment with loop=true', async () => {
+    const { mockAnimation } = createMockAnimation();
+    const addSpy = vi.spyOn(player.scene, 'add').mockReturnThis();
+
+    await player.sequence(async (scene) => {
+      await scene.loopPlay(mockAnimation as never);
+    });
+
+    expect(player.timeline.segmentCount).toBe(1);
+    expect(player.timeline.getSegments()[0].loop).toBe(true);
+    addSpy.mockRestore();
+  });
+
+  it('play records a segment with loop=false (default)', async () => {
+    const { mockAnimation } = createMockAnimation();
+    const addSpy = vi.spyOn(player.scene, 'add').mockReturnThis();
+
+    await player.sequence(async (scene) => {
+      await scene.play(mockAnimation as never);
+    });
+
+    expect(player.timeline.getSegments()[0].loop).toBe(false);
+    addSpy.mockRestore();
+  });
+
+  it('loopPlay with no animations is a no-op', async () => {
+    await player.sequence(async (scene) => {
+      await scene.loopPlay();
+    });
+    expect(player.timeline.segmentCount).toBe(0);
   });
 });
 

--- a/src/player/Player.ts
+++ b/src/player/Player.ts
@@ -55,6 +55,18 @@ class RecordingScene {
 
   /** Proxy for scene.play() — records animations into the master timeline. */
   async play(...animations: Animation[]): Promise<void> {
+    await this._record(animations, { loop: false });
+  }
+
+  /**
+   * Like play(), but marks the recorded segment so it loops while paused
+   * on it in slidesMode. Outside slidesMode the loop flag is ignored.
+   */
+  async loopPlay(...animations: Animation[]): Promise<void> {
+    await this._record(animations, { loop: true });
+  }
+
+  private async _record(animations: Animation[], opts: { loop: boolean }): Promise<void> {
     if (animations.length === 0) return;
 
     // Collect all nested animations for scene.add + begin()
@@ -72,7 +84,7 @@ class RecordingScene {
     // pre-animation opacity. begin() may modify mobject opacity (e.g.
     // Create's opacity fallback sets it to 0), which would corrupt the
     // saved value used for visibility restoration during seek/playback.
-    this._masterTimeline.addSegment(animations);
+    this._masterTimeline.addSegment(animations, opts);
 
     // Initialize top-level animations
     for (const anim of animations) {
@@ -142,6 +154,12 @@ export class Player {
   private _autoPlay: boolean;
   private _slidesMode: boolean;
   private _slidesTargetSegmentIndex: number = -1;
+  /**
+   * Index of the segment currently being looped in slidesMode, or null if no
+   * loop is active. When set, the player rewinds to the segment's startTime
+   * on every endTime crossing and keeps playing until the user advances.
+   */
+  private _activeLoopSegmentIndex: number | null = null;
   private _origWidth: number = 0;
   private _origHeight: number = 0;
   private _onFullscreenChange: () => void;
@@ -223,6 +241,8 @@ export class Player {
   async sequence(builder: (scene: RecordingScene) => Promise<void>): Promise<void> {
     // Reset
     this._masterTimeline = new MasterTimeline();
+    this._activeLoopSegmentIndex = null;
+    this._slidesTargetSegmentIndex = -1;
 
     // Record
     const recorder = new RecordingScene(this._scene, this._masterTimeline);
@@ -295,6 +315,10 @@ export class Player {
 
   /** Seek to a specific time in seconds. */
   seek(time: number): void {
+    // User-initiated seek is a strong signal — drop any active slide loop and
+    // its target so the next render tick doesn't snap back to the old segment.
+    this._activeLoopSegmentIndex = null;
+    this._slidesTargetSegmentIndex = -1;
     this._masterTimeline.seek(time);
     this._scene.render();
     this._ui.updateTime(this._masterTimeline.getCurrentTime(), this._masterTimeline.getDuration());
@@ -303,6 +327,36 @@ export class Player {
   /** Jump to the next segment. In slidesMode, plays current segment instead. */
   nextSegment(): void {
     if (this._slidesMode) {
+      // Exiting an active loop is a special case: snap to the start of the
+      // next segment (or end the deck if the loop is the last slide).
+      if (this._activeLoopSegmentIndex !== null) {
+        const loopIdx = this._activeLoopSegmentIndex;
+        const segments = this._masterTimeline.getSegments();
+        const loopSeg = segments[loopIdx];
+        this._activeLoopSegmentIndex = null;
+        const nextIdx = loopIdx + 1;
+        if (nextIdx >= segments.length) {
+          // Final loop: land on its endTime and pause normally.
+          this._masterTimeline.seek(loopSeg.endTime);
+          this._slidesTargetSegmentIndex = -1;
+          this._isPlaying = false;
+          this._masterTimeline.pause();
+          this._ui.setPlaying(false);
+          this._stopLoop();
+          this._scene.render();
+          this._ui.updateTime(
+            this._masterTimeline.getCurrentTime(),
+            this._masterTimeline.getDuration(),
+          );
+          return;
+        }
+        const nextSeg = segments[nextIdx];
+        this._masterTimeline.seek(nextSeg.startTime);
+        this._slidesTargetSegmentIndex = nextIdx;
+        if (!this._isPlaying) this.play();
+        else this._masterTimeline.play();
+        return;
+      }
       const current = this._masterTimeline.getCurrentSegment();
       if (!current) return;
       const nextIdx = current.index + 1;
@@ -327,6 +381,24 @@ export class Player {
   /** Jump to the previous segment. Pauses playback. */
   prevSegment(): void {
     if (this._isPlaying) this.pause();
+    // From an active loop, ← always means "exit to the previous slide" rather
+    // than the >0.5s phase-dependent restart-current behavior, since the user
+    // is conceptually on the looping slide rather than at a specific offset.
+    if (this._activeLoopSegmentIndex !== null) {
+      const loopIdx = this._activeLoopSegmentIndex;
+      this._activeLoopSegmentIndex = null;
+      this._slidesTargetSegmentIndex = -1;
+      const segments = this._masterTimeline.getSegments();
+      const targetIdx = Math.max(0, loopIdx - 1);
+      const targetSeg = segments[targetIdx];
+      this._masterTimeline.seek(targetSeg.startTime);
+      this._scene.render();
+      this._ui.updateTime(
+        this._masterTimeline.getCurrentTime(),
+        this._masterTimeline.getDuration(),
+      );
+      return;
+    }
     this._slidesTargetSegmentIndex = -1;
     const prev = this._masterTimeline.prevSegment();
     if (prev) {
@@ -347,6 +419,10 @@ export class Player {
   setSlidesMode(enabled: boolean): void {
     this._slidesMode = enabled;
     this._ui.setSlidesMode(enabled);
+    if (!enabled) {
+      this._activeLoopSegmentIndex = null;
+      this._slidesTargetSegmentIndex = -1;
+    }
   }
 
   /** Export the animation in the given format (gif, webm, mp4). */
@@ -435,11 +511,26 @@ export class Player {
         this._masterTimeline.getDuration(),
       );
 
-      // In slides mode, auto-pause at the target segment boundary
+      // In slides mode, either rewind a looping segment or auto-pause at
+      // the target segment boundary.
       if (this._slidesMode && this._slidesTargetSegmentIndex >= 0) {
         const segments = this._masterTimeline.getSegments();
         const targetSeg = segments[this._slidesTargetSegmentIndex];
         if (targetSeg && this._masterTimeline.getCurrentTime() >= targetSeg.endTime) {
+          if (targetSeg.loop) {
+            // Rewind and keep playing. play() is required because Timeline.update
+            // self-pauses when currentTime crosses the timeline duration (i.e.
+            // when the looping segment is the final segment).
+            this._masterTimeline.seek(targetSeg.startTime);
+            this._masterTimeline.play();
+            this._activeLoopSegmentIndex = targetSeg.index;
+            this._scene.render();
+            this._ui.updateTime(
+              this._masterTimeline.getCurrentTime(),
+              this._masterTimeline.getDuration(),
+            );
+            return;
+          }
           this._masterTimeline.seek(targetSeg.endTime);
           this._scene.render();
           this._ui.updateTime(


### PR DESCRIPTION
## Summary

Adds per-slide looping in slides mode (closes #215). A slide marked with `scene.loopPlay(...)` keeps replaying until the user presses → to advance — the manim-web equivalent of `manim-slides`' `next_slide(loop=True)`.

```ts
player.sequence(async (scene) => {
  await scene.play(new Create(square));
  // Slide 2 rotates forever until → is pressed.
  await scene.loopPlay(new Rotate(square, { angle: Math.PI * 2, duration: 2, rateFunc: linear }));
  await scene.play(new Transform(square, circle));
});
```

## Changes

- `Segment` gets a required `loop: boolean`; `MasterTimeline.addSegment(animations, opts?)`. Zero-duration loops throw.
- `RecordingScene.loopPlay(...animations)` records a looping segment.
- `Player._startLoop` rewinds to `startTime` and re-`play()`s the master timeline on a looping segment boundary (the re-`play()` is required for a *final-slide* loop because `Timeline.update` self-pauses on duration overrun).
- `nextSegment` exits an active loop to the next segment (or ends the deck on a final-slide loop). `prevSegment` always exits to the previous slide (phase-independent).
- `seek()`, `prevSegment()`, `setSlidesMode(false)`, `sequence()` all clear loop + slide-target state so scrubbing/disabling slides mode never snaps back into the old loop.
- Example: `examples/slides_mode_loop.html`.

Out of scope (follow-ups):
- Multi-`play()` loop groups (one logical slide spanning multiple plays).
- Looping outside slides mode (existing `PlayerOptions.loop` covers full-timeline loop).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 5899 passed (152 in Player.test.ts + MasterTimeline.test.ts after additions)
- [x] Manual browser verification of `examples/slides_mode_loop.html`: loop bounded within `[startTime, endTime]` of the looping slide across 10s+ of fake time, exits cleanly on →, subsequent slides play normally and pause at their endTimes.

Plan and review trail: #215.
