### PR TITLE
feat(slides): rebuild slidesMode on Slide groups, add nextSlide + autoNext (#215)

### DIFF
--- a/examples/slides_mode_loop.html
+++ b/examples/slides_mode_loop.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ManimWeb - Slides Mode with Looping Slide</title>
+  <title>ManimWeb - Slides Mode (loop / autoNext / multi-play)</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
@@ -16,43 +16,23 @@
       font-family: system-ui, sans-serif;
       color: #ccc;
     }
-    h1 {
-      margin-bottom: 16px;
-      font-size: 20px;
-      font-weight: 400;
-      color: #fff;
-    }
-    #container {
-      border-radius: 8px;
-      overflow: hidden;
-    }
-    .info {
-      margin-top: 20px;
-      font-size: 13px;
-      opacity: 0.6;
-      text-align: center;
-      line-height: 1.6;
-    }
-    kbd {
-      background: #333;
-      border: 1px solid #555;
-      border-radius: 3px;
-      padding: 1px 6px;
-      font-size: 12px;
-      font-family: monospace;
-    }
-    .highlight {
-      color: #6cf;
-      opacity: 1;
-      font-weight: 500;
-    }
+    h1 { margin-bottom: 16px; font-size: 20px; font-weight: 400; color: #fff; }
+    #container { border-radius: 8px; overflow: hidden; }
+    .info { margin-top: 20px; font-size: 13px; opacity: 0.6; text-align: center; line-height: 1.7; max-width: 720px; }
+    kbd { background: #333; border: 1px solid #555; border-radius: 3px; padding: 1px 6px; font-size: 12px; font-family: monospace; }
+    .highlight { color: #6cf; opacity: 1; font-weight: 500; }
   </style>
 </head>
 <body>
-  <h1>Slides Mode with Looping Slide</h1>
+  <h1>Slides Mode: <code>nextSlide({ loop, autoNext })</code></h1>
   <div id="container"></div>
   <div class="info">
-    <p class="highlight">Slide 2 keeps rotating until you press &rarr;</p>
+    <p class="highlight">Mirrors manim-slides' <code>next_slide(loop, auto_next)</code>.</p>
+    <br>
+    <p>Slide 1: a normal play. Press <kbd>&rarr;</kbd> to advance.</p>
+    <p>Slide 2 (<code>loop: true</code>): rotation replays until you press <kbd>&rarr;</kbd>.</p>
+    <p>Slide 3 (<code>autoNext: true</code>, multi-play): two plays in one slide, advances automatically when done.</p>
+    <p>Slide 4: final fade out.</p>
     <br>
     <kbd>&rarr;</kbd> Next slide &nbsp;
     <kbd>&larr;</kbd> Previous slide &nbsp;
@@ -68,10 +48,13 @@
       Create,
       Rotate,
       Transform,
+      FadeIn,
+      Indicate,
       FadeOut,
       BLACK,
       BLUE,
       RED,
+      YELLOW,
     } from '../src/index.ts';
     import { linear } from '../src/rate-functions/index.ts';
 
@@ -82,26 +65,31 @@
       backgroundColor: BLACK,
       slidesMode: true,
     });
-    // Expose for manual testing in devtools.
     window.player = player;
 
+    const square = new Square({ sideLength: 2, color: BLUE });
+    const circle = new Circle({ radius: 1.5, color: RED });
+    const label = new Square({ sideLength: 0.6, color: YELLOW });
+
     player.sequence(async (scene) => {
-      // Slide 1: create blue square
-      const square = new Square({ sideLength: 2, color: BLUE });
+      // Slide 1
       await scene.play(new Create(square));
 
-      // Slide 2: looping rotation — full turn, linear, so each cycle is seamless.
-      // The slide replays until the user presses → to advance.
-      await scene.loopPlay(
+      // Slide 2 (loop)
+      await scene.nextSlide({ loop: true });
+      await scene.play(
         new Rotate(square, { angle: Math.PI * 2, duration: 2, rateFunc: linear }),
       );
 
-      // Slide 3: transform to red circle
-      const circle = new Circle({ radius: 1.5, color: RED });
-      await scene.play(new Transform(square, circle));
+      // Slide 3 (multi-play + autoNext)
+      await scene.nextSlide({ autoNext: true });
+      await scene.play(new FadeIn(label));
+      await scene.play(new Indicate(label));
 
-      // Slide 4: fade out
-      await scene.play(new FadeOut(square));
+      // Slide 4 (normal)
+      await scene.nextSlide();
+      await scene.play(new Transform(square, circle));
+      await scene.play(new FadeOut(circle));
     });
   </script>
 </body>

--- a/src/animation/MasterTimeline.test.ts
+++ b/src/animation/MasterTimeline.test.ts
@@ -113,28 +113,137 @@ describe('MasterTimeline', () => {
       expect(tl.getDuration()).toBe(1);
       expect(tl.length).toBe(1); // one scheduled animation on base Timeline
     });
+  });
 
-    it('defaults segment.loop to false', () => {
+  // ---------------------------------------------------------------------------
+  // slides (beginSlide / finalizeSlides / getSlides)
+  // ---------------------------------------------------------------------------
+  describe('slides', () => {
+    it('auto-boundary: one slide per segment when no beginSlide() was called', () => {
       const mob = new TestMobject();
-      const anim = new TestAnimation(mob, { duration: 1 });
-      const seg = tl.addSegment([anim]);
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      tl.addWaitSegment(0.5);
+      tl.finalizeSlides();
 
-      expect(seg.loop).toBe(false);
+      const slides = tl.getSlides();
+      expect(slides).toHaveLength(3);
+      slides.forEach((s, i) => {
+        expect(s.startSegmentIndex).toBe(i);
+        expect(s.endSegmentIndex).toBe(i);
+        expect(s.loop).toBe(false);
+        expect(s.autoNext).toBe(false);
+      });
     });
 
-    it('stores segment.loop=true when opts.loop is true', () => {
+    it('beginSlide before any segment makes slide 0 use those opts', () => {
       const mob = new TestMobject();
-      const anim = new TestAnimation(mob, { duration: 1 });
-      const seg = tl.addSegment([anim], { loop: true });
+      tl.beginSlide({ loop: true });
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      tl.finalizeSlides();
 
-      expect(seg.loop).toBe(true);
+      const slides = tl.getSlides();
+      expect(slides).toHaveLength(1);
+      expect(slides[0].loop).toBe(true);
+      expect(slides[0].autoNext).toBe(false);
     });
 
-    it('throws when adding a zero-duration looping segment', () => {
+    it('beginSlide mid-recording groups subsequent segments into one slide', () => {
       const mob = new TestMobject();
-      const anim = new TestAnimation(mob, { duration: 0 });
+      // slide 0: 1 segment
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      // slide 1 (loop, 2 segments)
+      tl.beginSlide({ loop: true });
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      // slide 2: 1 segment
+      tl.beginSlide({ autoNext: true });
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      tl.finalizeSlides();
 
-      expect(() => tl.addSegment([anim], { loop: true })).toThrow(/zero-duration/);
+      const slides = tl.getSlides();
+      expect(slides).toHaveLength(3);
+      expect(slides[0]).toMatchObject({
+        startSegmentIndex: 0,
+        endSegmentIndex: 0,
+        startTime: 0,
+        endTime: 1,
+        loop: false,
+        autoNext: false,
+      });
+      expect(slides[1]).toMatchObject({
+        startSegmentIndex: 1,
+        endSegmentIndex: 2,
+        startTime: 1,
+        endTime: 3,
+        loop: true,
+        autoNext: false,
+      });
+      expect(slides[2]).toMatchObject({
+        startSegmentIndex: 3,
+        endSegmentIndex: 3,
+        startTime: 3,
+        endTime: 4,
+        loop: false,
+        autoNext: true,
+      });
+    });
+
+    it('back-to-back beginSlide calls without segments are skipped', () => {
+      const mob = new TestMobject();
+      tl.beginSlide({ loop: true });
+      tl.beginSlide({ autoNext: true });
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      tl.finalizeSlides();
+
+      // Only the final boundary owns the segment.
+      const slides = tl.getSlides();
+      expect(slides).toHaveLength(1);
+      expect(slides[0].autoNext).toBe(true);
+      expect(slides[0].loop).toBe(false);
+    });
+
+    it('finalizeSlides with no segments leaves slides empty', () => {
+      tl.beginSlide({ loop: true });
+      tl.finalizeSlides();
+      expect(tl.getSlides()).toHaveLength(0);
+      expect(tl.slideCount).toBe(0);
+    });
+
+    it('throws if a multi-play slide is marked loop with zero total duration', () => {
+      // Synthetic: a beginSlide(loop:true) that wraps a single zero-duration
+      // wait would be a tight-loop trap.
+      tl.beginSlide({ loop: true });
+      tl.addWaitSegment(0); // zero-duration
+      expect(() => tl.finalizeSlides()).toThrow(/zero-duration/);
+    });
+
+    it('finalizeSlides is idempotent: calling twice produces the same slide list', () => {
+      const mob = new TestMobject();
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      tl.beginSlide({ loop: true });
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      tl.finalizeSlides();
+      const first = JSON.parse(JSON.stringify(tl.getSlides()));
+      tl.finalizeSlides();
+      const second = JSON.parse(JSON.stringify(tl.getSlides()));
+      expect(second).toEqual(first);
+    });
+
+    it('getCurrentSlide returns slide containing the current time', () => {
+      const mob = new TestMobject();
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      tl.beginSlide({ loop: true });
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      tl.finalizeSlides();
+
+      tl.seek(0.5);
+      expect(tl.getCurrentSlide()?.index).toBe(0);
+      tl.seek(1.5);
+      expect(tl.getCurrentSlide()?.index).toBe(1);
+      tl.seek(2.5);
+      expect(tl.getCurrentSlide()?.index).toBe(1);
     });
   });
 
@@ -166,11 +275,6 @@ describe('MasterTimeline', () => {
       expect(waitSeg.startTime).toBe(1);
       expect(waitSeg.endTime).toBe(1.5);
       expect(tl.getDuration()).toBe(1.5);
-    });
-
-    it('defaults wait segment loop to false', () => {
-      const seg = tl.addWaitSegment(1);
-      expect(seg.loop).toBe(false);
     });
   });
 

--- a/src/animation/MasterTimeline.ts
+++ b/src/animation/MasterTimeline.ts
@@ -1,7 +1,15 @@
 /**
- * MasterTimeline - Extended Timeline with segment tracking for Player.
- * Each play()/wait() call creates a "segment" that can be navigated
- * via prev/next controls (like slides in a presentation).
+ * MasterTimeline - Extended Timeline with segment + slide tracking for Player.
+ *
+ * Two granularities:
+ * - **Segment**: one play() or wait() call. Pure timing unit.
+ * - **Slide**: one or more contiguous segments that the user navigates as a
+ *   single unit in slidesMode. Mirrors manim-slides' next_slide() concept.
+ *
+ * Slides are built by the recorder calling beginSlide(opts) as a boundary
+ * marker; finalizeSlides() at end of recording builds the _slides array.
+ * If no boundary is ever recorded each segment becomes its own slide, which
+ * preserves the original per-play slidesMode behavior.
  */
 
 import { Animation } from './Animation';
@@ -18,22 +26,41 @@ export interface Segment {
   animations: Animation[];
   /** Whether this is a wait/pause segment */
   isWait: boolean;
-  /**
-   * Whether this segment should loop while paused on it in slides mode.
-   * When true and the player reaches endTime in slidesMode, it seeks
-   * back to startTime and keeps playing until the user advances.
-   * Ignored outside slidesMode.
-   */
-  loop: boolean;
 }
 
-export interface SegmentOptions {
-  /** Loop this segment in slides mode. See Segment.loop. */
+export interface Slide {
+  /** Index in the slides array */
+  index: number;
+  /** First segment in this slide */
+  startSegmentIndex: number;
+  /** Last segment in this slide (inclusive) */
+  endSegmentIndex: number;
+  /** = segments[startSegmentIndex].startTime */
+  startTime: number;
+  /** = segments[endSegmentIndex].endTime */
+  endTime: number;
+  /** Replay this slide until the user presses → in slidesMode. */
+  loop: boolean;
+  /** Advance to the next slide automatically when this slide finishes. */
+  autoNext: boolean;
+}
+
+export interface SlideOptions {
+  /** Replay this slide in slidesMode until the user advances. */
   loop?: boolean;
+  /** Auto-advance to the next slide when this slide finishes (slidesMode only). */
+  autoNext?: boolean;
 }
 
 export class MasterTimeline extends Timeline {
   private _segments: Segment[] = [];
+  private _slides: Slide[] = [];
+  /**
+   * Slide boundaries recorded by beginSlide() during recording. Each entry
+   * means "the segment at this index starts a new slide with these opts."
+   * Consumed by finalizeSlides().
+   */
+  private _slideBoundaries: { atSegmentIndex: number; opts: SlideOptions }[] = [];
   /**
    * Maps mobjects to the segment index where they first appear.
    * Used by seek() to hide mobjects that haven't been introduced yet.
@@ -134,19 +161,12 @@ export class MasterTimeline extends Timeline {
 
   /**
    * Add a segment containing one or more parallel animations.
-   * Returns the segment's start time (for the recorder to resolve).
    */
-  addSegment(animations: Animation[], opts: SegmentOptions = {}): Segment {
+  addSegment(animations: Animation[]): Segment {
     const startTime = this.getDuration();
     this.addParallel(animations, startTime);
 
     const maxDuration = Math.max(...animations.map((a) => a.duration));
-    const loop = opts.loop ?? false;
-    if (loop && maxDuration <= 0) {
-      throw new Error(
-        'MasterTimeline.addSegment: cannot loop a zero-duration segment (would rewind every frame).',
-      );
-    }
     const segmentIndex = this._segments.length;
     const segment: Segment = {
       index: segmentIndex,
@@ -154,7 +174,6 @@ export class MasterTimeline extends Timeline {
       endTime: startTime + maxDuration,
       animations,
       isWait: false,
-      loop,
     };
     this._segments.push(segment);
 
@@ -187,10 +206,88 @@ export class MasterTimeline extends Timeline {
       endTime: startTime + duration,
       animations: [],
       isWait: true,
-      loop: false,
     };
     this._segments.push(segment);
     return segment;
+  }
+
+  /**
+   * Record a slide boundary: the next segment added will start a new slide
+   * with the given options. Mirrors manim-slides' `next_slide(...)` — the
+   * options configure the slide that *follows* this call.
+   *
+   * If no boundary is ever recorded, every segment becomes its own slide
+   * (per-play behavior, used by existing slidesMode callers).
+   */
+  beginSlide(opts: SlideOptions = {}): void {
+    this._slideBoundaries.push({ atSegmentIndex: this._segments.length, opts });
+  }
+
+  /**
+   * Build the _slides array from recorded segments and slide boundaries.
+   * Call once at the end of recording (after the sequence builder finishes).
+   *
+   * - No boundaries recorded: each segment is its own slide.
+   * - Otherwise: segments before the first boundary form an implicit slide 0
+   *   with default opts; each boundary opens a new slide with its opts that
+   *   captures all subsequent segments up to the next boundary (or the end).
+   *
+   * Empty slides (consecutive boundaries with no plays between them) are
+   * skipped — they have no animations and no duration to occupy.
+   */
+  finalizeSlides(): void {
+    this._slides = [];
+    if (this._segments.length === 0) return;
+
+    if (this._slideBoundaries.length === 0) {
+      // Auto-boundary: each segment becomes its own slide with default opts.
+      for (const seg of this._segments) {
+        this._slides.push({
+          index: this._slides.length,
+          startSegmentIndex: seg.index,
+          endSegmentIndex: seg.index,
+          startTime: seg.startTime,
+          endTime: seg.endTime,
+          loop: false,
+          autoNext: false,
+        });
+      }
+      return;
+    }
+
+    // Manual boundary mode. Synthesise a leading boundary at index 0 if the
+    // first user boundary is later, so plays before it form slide 0.
+    const boundaries = [...this._slideBoundaries];
+    if (boundaries[0].atSegmentIndex > 0) {
+      boundaries.unshift({ atSegmentIndex: 0, opts: {} });
+    }
+    // Synthesise a trailing boundary at segments.length so the last slide
+    // has a well-defined end.
+    boundaries.push({ atSegmentIndex: this._segments.length, opts: {} });
+
+    for (let i = 0; i < boundaries.length - 1; i++) {
+      const start = boundaries[i].atSegmentIndex;
+      const end = boundaries[i + 1].atSegmentIndex - 1;
+      if (end < start) continue; // empty slide — skip
+      const opts = boundaries[i].opts;
+      const startSeg = this._segments[start];
+      const endSeg = this._segments[end];
+      const loop = opts.loop ?? false;
+      if (loop && endSeg.endTime <= startSeg.startTime) {
+        throw new Error(
+          'MasterTimeline.finalizeSlides: cannot loop a zero-duration slide (would rewind every frame).',
+        );
+      }
+      this._slides.push({
+        index: this._slides.length,
+        startSegmentIndex: start,
+        endSegmentIndex: end,
+        startTime: startSeg.startTime,
+        endTime: endSeg.endTime,
+        loop,
+        autoNext: opts.autoNext ?? false,
+      });
+    }
   }
 
   /**
@@ -198,6 +295,37 @@ export class MasterTimeline extends Timeline {
    */
   getSegments(): readonly Segment[] {
     return this._segments;
+  }
+
+  /**
+   * Get all slides.
+   */
+  getSlides(): readonly Slide[] {
+    return this._slides;
+  }
+
+  /**
+   * Get the slide active at the given time.
+   */
+  getSlideAtTime(time: number): Slide | null {
+    for (let i = this._slides.length - 1; i >= 0; i--) {
+      if (time >= this._slides[i].startTime) {
+        return this._slides[i];
+      }
+    }
+    return this._slides[0] ?? null;
+  }
+
+  /**
+   * Get the currently-active slide based on _currentTime.
+   */
+  getCurrentSlide(): Slide | null {
+    return this.getSlideAtTime(this.getCurrentTime());
+  }
+
+  /** Number of slides built by finalizeSlides(). */
+  get slideCount(): number {
+    return this._slides.length;
   }
 
   /**

--- a/src/player/Player.test.ts
+++ b/src/player/Player.test.ts
@@ -430,7 +430,7 @@ describe('Player', () => {
 
   // ---- per-slide loop ----
 
-  it('public seek clears _activeLoopSegmentIndex', async () => {
+  it('public seek clears _activeLoopSlideIndex', async () => {
     player.dispose();
     container.remove();
     const { player: p, container: c } = createPlayer({ slidesMode: true });
@@ -442,10 +442,10 @@ describe('Player', () => {
       await scene.wait(1);
     });
 
-    const internal = player as unknown as { _activeLoopSegmentIndex: number | null };
-    internal._activeLoopSegmentIndex = 0;
+    const internal = player as unknown as { _activeLoopSlideIndex: number | null };
+    internal._activeLoopSlideIndex = 0;
     player.seek(0.5);
-    expect(internal._activeLoopSegmentIndex).toBeNull();
+    expect(internal._activeLoopSlideIndex).toBeNull();
   });
 
   it('setSlidesMode(false) clears active loop state', async () => {
@@ -460,14 +460,14 @@ describe('Player', () => {
     });
 
     const internal = player as unknown as {
-      _activeLoopSegmentIndex: number | null;
-      _slidesTargetSegmentIndex: number;
+      _activeLoopSlideIndex: number | null;
+      _slidesTargetSlideIndex: number;
     };
-    internal._activeLoopSegmentIndex = 0;
-    internal._slidesTargetSegmentIndex = 0;
+    internal._activeLoopSlideIndex = 0;
+    internal._slidesTargetSlideIndex = 0;
     player.setSlidesMode(false);
-    expect(internal._activeLoopSegmentIndex).toBeNull();
-    expect(internal._slidesTargetSegmentIndex).toBe(-1);
+    expect(internal._activeLoopSlideIndex).toBeNull();
+    expect(internal._slidesTargetSlideIndex).toBe(-1);
   });
 
   it('prevSegment from inside an active loop always exits to previous slide', async () => {
@@ -479,24 +479,23 @@ describe('Player', () => {
 
     await player.sequence(async (scene) => {
       await scene.wait(1);
+      await scene.nextSlide({ loop: true });
       await scene.wait(1);
     });
 
-    const segs = player.timeline.getSegments();
-    (segs[1] as { loop: boolean }).loop = true;
     // Test the phase-independent behavior: even >0.5s into the loop cycle,
     // ← should go to the previous slide (not restart the loop).
     player.seek(1.6);
     const internal = player as unknown as {
-      _activeLoopSegmentIndex: number | null;
-      _slidesTargetSegmentIndex: number;
+      _activeLoopSlideIndex: number | null;
+      _slidesTargetSlideIndex: number;
     };
-    internal._activeLoopSegmentIndex = 1;
+    internal._activeLoopSlideIndex = 1;
 
     player.prevSegment();
-    expect(internal._activeLoopSegmentIndex).toBeNull();
-    expect(internal._slidesTargetSegmentIndex).toBe(-1);
-    // Lands at segment 0's start regardless of where we were in the loop.
+    expect(internal._activeLoopSlideIndex).toBeNull();
+    expect(internal._slidesTargetSlideIndex).toBe(-1);
+    // Lands at slide 0's start regardless of where we were in the loop.
     expect(player.timeline.getCurrentTime()).toBeCloseTo(0);
   });
 
@@ -513,16 +512,16 @@ describe('Player', () => {
     });
 
     const internal = player as unknown as {
-      _activeLoopSegmentIndex: number | null;
-      _slidesTargetSegmentIndex: number;
+      _activeLoopSlideIndex: number | null;
+      _slidesTargetSlideIndex: number;
     };
-    internal._activeLoopSegmentIndex = 0;
-    internal._slidesTargetSegmentIndex = 0;
+    internal._activeLoopSlideIndex = 0;
+    internal._slidesTargetSlideIndex = 0;
     // Seek FAR past the loop segment — if the target stayed at 0, the next
     // render tick would snap back into the old loop.
     player.seek(1.5);
-    expect(internal._activeLoopSegmentIndex).toBeNull();
-    expect(internal._slidesTargetSegmentIndex).toBe(-1);
+    expect(internal._activeLoopSlideIndex).toBeNull();
+    expect(internal._slidesTargetSlideIndex).toBe(-1);
   });
 
   it('sequence() resets active loop state', async () => {
@@ -533,18 +532,18 @@ describe('Player', () => {
     container = c;
 
     const internal = player as unknown as {
-      _activeLoopSegmentIndex: number | null;
-      _slidesTargetSegmentIndex: number;
+      _activeLoopSlideIndex: number | null;
+      _slidesTargetSlideIndex: number;
     };
-    internal._activeLoopSegmentIndex = 0;
-    internal._slidesTargetSegmentIndex = 0;
+    internal._activeLoopSlideIndex = 0;
+    internal._slidesTargetSlideIndex = 0;
 
     await player.sequence(async (scene) => {
       await scene.wait(1);
     });
 
-    expect(internal._activeLoopSegmentIndex).toBeNull();
-    expect(internal._slidesTargetSegmentIndex).toBe(-1);
+    expect(internal._activeLoopSlideIndex).toBeNull();
+    expect(internal._slidesTargetSlideIndex).toBe(-1);
   });
 
   // ---- loop option ----
@@ -783,7 +782,7 @@ describe('Player _startLoop render loop', () => {
     expect(player.timeline.getCurrentTime()).toBeCloseTo(0.5);
   });
 
-  it('_startLoop rewinds and keeps playing on looped segment boundary in slidesMode', async () => {
+  it('_startLoop rewinds and keeps playing on looped slide boundary in slidesMode', async () => {
     player.dispose();
     container.remove();
     const result = createPlayer({ slidesMode: true });
@@ -791,25 +790,25 @@ describe('Player _startLoop render loop', () => {
     container = result.container;
 
     await player.sequence(async (scene) => {
+      await scene.nextSlide({ loop: true });
       await scene.wait(0.5);
+      await scene.nextSlide();
       await scene.wait(0.5);
     });
-    // Mark segment 0 as looping
-    (player.timeline.getSegments()[0] as { loop: boolean }).loop = true;
 
     player.play();
-    flushRaf(600); // past segment 0's endTime
+    flushRaf(600); // past slide 0's endTime
 
     // Loop should have rewound, NOT paused
     expect(player.isPlaying).toBe(true);
     const t = player.timeline.getCurrentTime();
     expect(t).toBeGreaterThanOrEqual(0);
     expect(t).toBeLessThan(0.5);
-    const internal = player as unknown as { _activeLoopSegmentIndex: number | null };
-    expect(internal._activeLoopSegmentIndex).toBe(0);
+    const internal = player as unknown as { _activeLoopSlideIndex: number | null };
+    expect(internal._activeLoopSlideIndex).toBe(0);
   });
 
-  it('_startLoop rewinds when loop is the final segment (re-plays the underlying timeline)', async () => {
+  it('_startLoop rewinds when loop is the final slide (re-plays the underlying timeline)', async () => {
     player.dispose();
     container.remove();
     const result = createPlayer({ slidesMode: true });
@@ -817,10 +816,9 @@ describe('Player _startLoop render loop', () => {
     container = result.container;
 
     await player.sequence(async (scene) => {
+      await scene.nextSlide({ loop: true });
       await scene.wait(0.3);
     });
-    // Mark only segment (the final one) as looping
-    (player.timeline.getSegments()[0] as { loop: boolean }).loop = true;
 
     player.play();
     flushRaf(400); // past timeline duration
@@ -837,7 +835,7 @@ describe('Player _startLoop render loop', () => {
     expect(player.timeline.getCurrentTime()).toBeGreaterThan(before);
   });
 
-  it('nextSegment from active loop advances to next segment and keeps playing', async () => {
+  it('nextSegment from active loop advances to next slide and keeps playing', async () => {
     player.dispose();
     container.remove();
     const result = createPlayer({ slidesMode: true });
@@ -845,28 +843,29 @@ describe('Player _startLoop render loop', () => {
     container = result.container;
 
     await player.sequence(async (scene) => {
+      await scene.nextSlide({ loop: true });
       await scene.wait(0.5);
+      await scene.nextSlide();
       await scene.wait(0.5);
     });
-    (player.timeline.getSegments()[0] as { loop: boolean }).loop = true;
 
     player.play();
-    flushRaf(600); // triggers rewind: _activeLoopSegmentIndex = 0
+    flushRaf(600); // triggers rewind: _activeLoopSlideIndex = 0
 
     const internal = player as unknown as {
-      _activeLoopSegmentIndex: number | null;
-      _slidesTargetSegmentIndex: number;
+      _activeLoopSlideIndex: number | null;
+      _slidesTargetSlideIndex: number;
     };
-    expect(internal._activeLoopSegmentIndex).toBe(0);
+    expect(internal._activeLoopSlideIndex).toBe(0);
 
     player.nextSegment();
-    expect(internal._activeLoopSegmentIndex).toBeNull();
-    expect(internal._slidesTargetSegmentIndex).toBe(1);
+    expect(internal._activeLoopSlideIndex).toBeNull();
+    expect(internal._slidesTargetSlideIndex).toBe(1);
     expect(player.timeline.getCurrentTime()).toBeCloseTo(0.5);
     expect(player.isPlaying).toBe(true);
   });
 
-  it('nextSegment on a final loop segment seeks to endTime and pauses', async () => {
+  it('nextSegment on a final loop slide seeks to endTime and pauses', async () => {
     player.dispose();
     container.remove();
     const result = createPlayer({ slidesMode: true });
@@ -874,38 +873,196 @@ describe('Player _startLoop render loop', () => {
     container = result.container;
 
     await player.sequence(async (scene) => {
+      await scene.nextSlide({ loop: true });
       await scene.wait(0.3);
     });
-    (player.timeline.getSegments()[0] as { loop: boolean }).loop = true;
 
     player.play();
     flushRaf(400);
 
-    const internal = player as unknown as { _activeLoopSegmentIndex: number | null };
-    expect(internal._activeLoopSegmentIndex).toBe(0);
+    const internal = player as unknown as { _activeLoopSlideIndex: number | null };
+    expect(internal._activeLoopSlideIndex).toBe(0);
 
     player.nextSegment();
-    expect(internal._activeLoopSegmentIndex).toBeNull();
+    expect(internal._activeLoopSlideIndex).toBeNull();
     expect(player.isPlaying).toBe(false);
     expect(player.timeline.getCurrentTime()).toBeCloseTo(0.3);
   });
 
   it('_startLoop ignores loop flag when slidesMode is OFF', async () => {
     await player.sequence(async (scene) => {
+      await scene.nextSlide({ loop: true });
       await scene.wait(0.3);
+      await scene.nextSlide();
       await scene.wait(0.5);
     });
-    (player.timeline.getSegments()[0] as { loop: boolean }).loop = true;
 
     player.play();
     flushRaf(400);
 
     // Without slides mode, the loop flag is a no-op: playback advances past
-    // segment 0 normally.
+    // slide 0 normally.
     expect(player.isPlaying).toBe(true);
     expect(player.timeline.getCurrentTime()).toBeGreaterThan(0.3);
-    const internal = player as unknown as { _activeLoopSegmentIndex: number | null };
-    expect(internal._activeLoopSegmentIndex).toBeNull();
+    const internal = player as unknown as { _activeLoopSlideIndex: number | null };
+    expect(internal._activeLoopSlideIndex).toBeNull();
+  });
+
+  it('_startLoop auto-advances to next slide when current slide has autoNext', async () => {
+    player.dispose();
+    container.remove();
+    const result = createPlayer({ slidesMode: true });
+    player = result.player;
+    container = result.container;
+
+    await player.sequence(async (scene) => {
+      await scene.nextSlide({ autoNext: true });
+      await scene.wait(0.3);
+      await scene.nextSlide();
+      await scene.wait(0.3);
+    });
+
+    player.play();
+    // Past slide 0's endTime — autoNext should seek to slide 1 start and keep playing.
+    flushRaf(400);
+
+    expect(player.isPlaying).toBe(true);
+    const internal = player as unknown as { _slidesTargetSlideIndex: number };
+    expect(internal._slidesTargetSlideIndex).toBe(1);
+    // Time should be inside slide 1's range (slide 0 was 0..0.3, slide 1 is 0.3..0.6)
+    const t = player.timeline.getCurrentTime();
+    expect(t).toBeGreaterThanOrEqual(0.3);
+    expect(t).toBeLessThanOrEqual(0.6);
+  });
+
+  it('_startLoop pauses normally when autoNext is on the final slide', async () => {
+    player.dispose();
+    container.remove();
+    const result = createPlayer({ slidesMode: true });
+    player = result.player;
+    container = result.container;
+
+    await player.sequence(async (scene) => {
+      await scene.nextSlide({ autoNext: true });
+      await scene.wait(0.3);
+    });
+
+    player.play();
+    flushRaf(400);
+
+    expect(player.isPlaying).toBe(false);
+    expect(player.timeline.getCurrentTime()).toBeCloseTo(0.3);
+  });
+
+  it('loop wins over autoNext when both are set on a slide', async () => {
+    player.dispose();
+    container.remove();
+    const result = createPlayer({ slidesMode: true });
+    player = result.player;
+    container = result.container;
+
+    await player.sequence(async (scene) => {
+      await scene.nextSlide({ loop: true, autoNext: true });
+      await scene.wait(0.3);
+      await scene.nextSlide();
+      await scene.wait(0.3);
+    });
+
+    player.play();
+    flushRaf(400);
+
+    // Loop rewound, did not advance to slide 1.
+    const internal = player as unknown as {
+      _activeLoopSlideIndex: number | null;
+      _slidesTargetSlideIndex: number;
+    };
+    expect(internal._activeLoopSlideIndex).toBe(0);
+    expect(internal._slidesTargetSlideIndex).toBe(0);
+    expect(player.isPlaying).toBe(true);
+  });
+
+  it('chained autoNext slides advance through the whole chain', async () => {
+    player.dispose();
+    container.remove();
+    const result = createPlayer({ slidesMode: true });
+    player = result.player;
+    container = result.container;
+
+    await player.sequence(async (scene) => {
+      await scene.nextSlide({ autoNext: true });
+      await scene.wait(0.2);
+      await scene.nextSlide({ autoNext: true });
+      await scene.wait(0.2);
+      await scene.nextSlide();
+      await scene.wait(0.2);
+    });
+
+    player.play();
+    // Play long enough for slide 0 → slide 1 → slide 2; each is 0.2s.
+    for (let i = 0; i < 100; i++) flushRaf(100 + i * 20);
+
+    expect(player.isPlaying).toBe(false);
+    expect(player.timeline.getCurrentTime()).toBeCloseTo(0.6);
+  });
+
+  it('autoNext into a looping slide rewinds rather than pausing', async () => {
+    player.dispose();
+    container.remove();
+    const result = createPlayer({ slidesMode: true });
+    player = result.player;
+    container = result.container;
+
+    await player.sequence(async (scene) => {
+      await scene.nextSlide({ autoNext: true });
+      await scene.wait(0.2);
+      await scene.nextSlide({ loop: true });
+      await scene.wait(0.3);
+    });
+
+    player.play();
+    // Slide 0 autoNexts into slide 1, then slide 1 should loop.
+    for (let i = 0; i < 100; i++) flushRaf(100 + i * 20);
+
+    const internal = player as unknown as {
+      _activeLoopSlideIndex: number | null;
+      _slidesTargetSlideIndex: number;
+    };
+    expect(internal._activeLoopSlideIndex).toBe(1);
+    expect(internal._slidesTargetSlideIndex).toBe(1);
+    expect(player.isPlaying).toBe(true);
+    // Time stays bounded inside slide 1 [0.2, 0.5]
+    const t = player.timeline.getCurrentTime();
+    expect(t).toBeGreaterThanOrEqual(0.2);
+    expect(t).toBeLessThanOrEqual(0.5);
+  });
+
+  it('multi-play slide is treated as a single slide for navigation', async () => {
+    player.dispose();
+    container.remove();
+    const result = createPlayer({ slidesMode: true });
+    player = result.player;
+    container = result.container;
+
+    await player.sequence(async (scene) => {
+      await scene.nextSlide();
+      await scene.wait(0.2);
+      await scene.wait(0.2); // same slide
+      await scene.nextSlide();
+      await scene.wait(0.2);
+    });
+
+    expect(player.timeline.slideCount).toBe(2);
+    const [s0, s1] = player.timeline.getSlides();
+    expect(s0.startSegmentIndex).toBe(0);
+    expect(s0.endSegmentIndex).toBe(1);
+    expect(s0.endTime).toBeCloseTo(0.4);
+    expect(s1.startSegmentIndex).toBe(2);
+
+    // Play through slide 0 — should pause at endTime of slide 0 (= 0.4)
+    player.play();
+    flushRaf(500);
+    expect(player.isPlaying).toBe(false);
+    expect(player.timeline.getCurrentTime()).toBeCloseTo(0.4);
   });
 
   it('_startLoop does NOT auto-pause at segment boundary without slidesMode', async () => {
@@ -1056,20 +1213,21 @@ describe('RecordingScene pass-through methods', () => {
     expect(player.timeline.segmentCount).toBe(1);
   });
 
-  it('loopPlay records a segment with loop=true', async () => {
+  it('nextSlide({loop:true}) before play() produces a looping slide', async () => {
     const { mockAnimation } = createMockAnimation();
     const addSpy = vi.spyOn(player.scene, 'add').mockReturnThis();
 
     await player.sequence(async (scene) => {
-      await scene.loopPlay(mockAnimation as never);
+      await scene.nextSlide({ loop: true });
+      await scene.play(mockAnimation as never);
     });
 
-    expect(player.timeline.segmentCount).toBe(1);
-    expect(player.timeline.getSegments()[0].loop).toBe(true);
+    expect(player.timeline.slideCount).toBe(1);
+    expect(player.timeline.getSlides()[0].loop).toBe(true);
     addSpy.mockRestore();
   });
 
-  it('play records a segment with loop=false (default)', async () => {
+  it('default play() produces a slide with loop=false, autoNext=false', async () => {
     const { mockAnimation } = createMockAnimation();
     const addSpy = vi.spyOn(player.scene, 'add').mockReturnThis();
 
@@ -1077,15 +1235,32 @@ describe('RecordingScene pass-through methods', () => {
       await scene.play(mockAnimation as never);
     });
 
-    expect(player.timeline.getSegments()[0].loop).toBe(false);
+    const slide = player.timeline.getSlides()[0];
+    expect(slide.loop).toBe(false);
+    expect(slide.autoNext).toBe(false);
     addSpy.mockRestore();
   });
 
-  it('loopPlay with no animations is a no-op', async () => {
+  it('nextSlide() inside sequence groups subsequent plays into one slide', async () => {
+    const a1 = createMockAnimation();
+    const a2 = createMockAnimation();
+    const a3 = createMockAnimation();
+    const addSpy = vi.spyOn(player.scene, 'add').mockReturnThis();
+
     await player.sequence(async (scene) => {
-      await scene.loopPlay();
+      await scene.nextSlide();
+      await scene.play(a1.mockAnimation as never);
+      await scene.play(a2.mockAnimation as never);
+      await scene.nextSlide();
+      await scene.play(a3.mockAnimation as never);
     });
-    expect(player.timeline.segmentCount).toBe(0);
+
+    expect(player.timeline.slideCount).toBe(2);
+    expect(player.timeline.segmentCount).toBe(3);
+    const [s0, s1] = player.timeline.getSlides();
+    expect(s0.endSegmentIndex - s0.startSegmentIndex).toBe(1); // 2 segments
+    expect(s1.endSegmentIndex - s1.startSegmentIndex).toBe(0); // 1 segment
+    addSpy.mockRestore();
   });
 });
 

--- a/src/player/Player.ts
+++ b/src/player/Player.ts
@@ -25,7 +25,7 @@
 import { Scene, SceneOptions } from '../core/Scene';
 import { Animation } from '../animation/Animation';
 import { AnimationGroup } from '../animation/AnimationGroup';
-import { MasterTimeline } from '../animation/MasterTimeline';
+import { MasterTimeline, SlideOptions } from '../animation/MasterTimeline';
 import { PlayerUI } from './PlayerUI';
 import { PlayerController } from './PlayerController';
 
@@ -55,18 +55,6 @@ class RecordingScene {
 
   /** Proxy for scene.play() — records animations into the master timeline. */
   async play(...animations: Animation[]): Promise<void> {
-    await this._record(animations, { loop: false });
-  }
-
-  /**
-   * Like play(), but marks the recorded segment so it loops while paused
-   * on it in slidesMode. Outside slidesMode the loop flag is ignored.
-   */
-  async loopPlay(...animations: Animation[]): Promise<void> {
-    await this._record(animations, { loop: true });
-  }
-
-  private async _record(animations: Animation[], opts: { loop: boolean }): Promise<void> {
     if (animations.length === 0) return;
 
     // Collect all nested animations for scene.add + begin()
@@ -84,7 +72,7 @@ class RecordingScene {
     // pre-animation opacity. begin() may modify mobject opacity (e.g.
     // Create's opacity fallback sets it to 0), which would corrupt the
     // saved value used for visibility restoration during seek/playback.
-    this._masterTimeline.addSegment(animations, opts);
+    this._masterTimeline.addSegment(animations);
 
     // Initialize top-level animations
     for (const anim of animations) {
@@ -101,6 +89,18 @@ class RecordingScene {
         anim.mobject.createdAtBeginning = false;
       }
     }
+  }
+
+  /**
+   * Start a new slide. Mirrors manim-slides' `Scene.next_slide(...)`:
+   * options apply to the slide that *follows* this call (every play()/wait()
+   * up to the next `nextSlide()` belongs to that slide).
+   *
+   * If `nextSlide()` is never called inside a `sequence()`, each play()/wait()
+   * becomes its own slide.
+   */
+  async nextSlide(opts: SlideOptions = {}): Promise<void> {
+    this._masterTimeline.beginSlide(opts);
   }
 
   /** Proxy for scene.wait() — records a wait segment. */
@@ -153,13 +153,17 @@ export class Player {
   private _loop: boolean;
   private _autoPlay: boolean;
   private _slidesMode: boolean;
-  private _slidesTargetSegmentIndex: number = -1;
   /**
-   * Index of the segment currently being looped in slidesMode, or null if no
-   * loop is active. When set, the player rewinds to the segment's startTime
+   * Index of the slide that slidesMode playback should stop (or loop / advance)
+   * at when its endTime is reached. -1 means no target armed.
+   */
+  private _slidesTargetSlideIndex: number = -1;
+  /**
+   * Index of the slide currently being looped in slidesMode, or null if no
+   * loop is active. When set, the player rewinds to the slide's startTime
    * on every endTime crossing and keeps playing until the user advances.
    */
-  private _activeLoopSegmentIndex: number | null = null;
+  private _activeLoopSlideIndex: number | null = null;
   private _origWidth: number = 0;
   private _origHeight: number = 0;
   private _onFullscreenChange: () => void;
@@ -241,12 +245,15 @@ export class Player {
   async sequence(builder: (scene: RecordingScene) => Promise<void>): Promise<void> {
     // Reset
     this._masterTimeline = new MasterTimeline();
-    this._activeLoopSegmentIndex = null;
-    this._slidesTargetSegmentIndex = -1;
+    this._activeLoopSlideIndex = null;
+    this._slidesTargetSlideIndex = -1;
 
     // Record
     const recorder = new RecordingScene(this._scene, this._masterTimeline);
     await builder(recorder);
+
+    // Build the slide list from recorded segments + slide boundaries.
+    this._masterTimeline.finalizeSlides();
 
     // Set the master timeline on the scene
     this._scene.setTimeline(this._masterTimeline);
@@ -287,10 +294,10 @@ export class Player {
     this._isPlaying = true;
     this._masterTimeline.play();
     this._ui.setPlaying(true);
-    if (this._slidesMode && this._slidesTargetSegmentIndex < 0) {
-      const current = this._masterTimeline.getCurrentSegment();
+    if (this._slidesMode && this._slidesTargetSlideIndex < 0) {
+      const current = this._masterTimeline.getCurrentSlide();
       if (current) {
-        this._slidesTargetSegmentIndex = current.index;
+        this._slidesTargetSlideIndex = current.index;
       }
     }
     this._startLoop();
@@ -316,29 +323,37 @@ export class Player {
   /** Seek to a specific time in seconds. */
   seek(time: number): void {
     // User-initiated seek is a strong signal — drop any active slide loop and
-    // its target so the next render tick doesn't snap back to the old segment.
-    this._activeLoopSegmentIndex = null;
-    this._slidesTargetSegmentIndex = -1;
+    // its target so the next render tick doesn't snap back to the old slide.
+    this._activeLoopSlideIndex = null;
+    this._slidesTargetSlideIndex = -1;
     this._masterTimeline.seek(time);
     this._scene.render();
     this._ui.updateTime(this._masterTimeline.getCurrentTime(), this._masterTimeline.getDuration());
   }
 
-  /** Jump to the next segment. In slidesMode, plays current segment instead. */
+  /**
+   * Jump to the next slide. In slidesMode, plays through the current slide
+   * to its end, then pauses (or rewinds, or auto-advances depending on the
+   * slide's flags).
+   *
+   * Kept as `nextSegment()` for API stability; the unit of navigation is the
+   * Slide (possibly multi-play). For single-play sequences each slide is one
+   * play() call so the behavior matches the original per-segment navigation.
+   */
   nextSegment(): void {
     if (this._slidesMode) {
       // Exiting an active loop is a special case: snap to the start of the
-      // next segment (or end the deck if the loop is the last slide).
-      if (this._activeLoopSegmentIndex !== null) {
-        const loopIdx = this._activeLoopSegmentIndex;
-        const segments = this._masterTimeline.getSegments();
-        const loopSeg = segments[loopIdx];
-        this._activeLoopSegmentIndex = null;
+      // next slide (or end the deck if the loop is the last slide).
+      if (this._activeLoopSlideIndex !== null) {
+        const loopIdx = this._activeLoopSlideIndex;
+        const slides = this._masterTimeline.getSlides();
+        const loopSlide = slides[loopIdx];
+        this._activeLoopSlideIndex = null;
         const nextIdx = loopIdx + 1;
-        if (nextIdx >= segments.length) {
+        if (nextIdx >= slides.length) {
           // Final loop: land on its endTime and pause normally.
-          this._masterTimeline.seek(loopSeg.endTime);
-          this._slidesTargetSegmentIndex = -1;
+          this._masterTimeline.seek(loopSlide.endTime);
+          this._slidesTargetSlideIndex = -1;
           this._isPlaying = false;
           this._masterTimeline.pause();
           this._ui.setPlaying(false);
@@ -350,26 +365,32 @@ export class Player {
           );
           return;
         }
-        const nextSeg = segments[nextIdx];
-        this._masterTimeline.seek(nextSeg.startTime);
-        this._slidesTargetSegmentIndex = nextIdx;
+        const nextSlide = slides[nextIdx];
+        this._masterTimeline.seek(nextSlide.startTime);
+        this._slidesTargetSlideIndex = nextIdx;
         if (!this._isPlaying) this.play();
         else this._masterTimeline.play();
         return;
       }
-      const current = this._masterTimeline.getCurrentSegment();
+      const current = this._masterTimeline.getCurrentSlide();
       if (!current) return;
       const nextIdx = current.index + 1;
-      // If already at last segment and past its end, do nothing
-      if (nextIdx >= this._masterTimeline.segmentCount && this._masterTimeline.isFinished()) return;
-      // Set the target: pause when we reach the end of the current segment
-      this._slidesTargetSegmentIndex = current.index;
+      // If already at last slide and past its end, do nothing
+      if (nextIdx >= this._masterTimeline.slideCount && this._masterTimeline.isFinished()) return;
+      // Set the target: pause when we reach the end of the current slide
+      this._slidesTargetSlideIndex = current.index;
       if (!this._isPlaying) this.play();
       return;
     }
     if (this._isPlaying) this.pause();
-    const seg = this._masterTimeline.nextSegment();
-    if (seg) {
+    // Non-slides mode: navigate by slide too, so multi-play slides act as one
+    // unit on ← / →.
+    const slides = this._masterTimeline.getSlides();
+    const cur = this._masterTimeline.getCurrentSlide();
+    if (!cur) return;
+    const next = slides[cur.index + 1];
+    if (next) {
+      this._masterTimeline.seek(next.startTime);
       this._scene.render();
       this._ui.updateTime(
         this._masterTimeline.getCurrentTime(),
@@ -378,20 +399,30 @@ export class Player {
     }
   }
 
-  /** Jump to the previous segment. Pauses playback. */
+  /** Alias for nextSegment — navigates by slide. */
+  nextSlide(): void {
+    this.nextSegment();
+  }
+
+  /** Alias for prevSegment — navigates by slide. */
+  prevSlide(): void {
+    this.prevSegment();
+  }
+
+  /** Jump to the previous slide. Pauses playback. */
   prevSegment(): void {
     if (this._isPlaying) this.pause();
     // From an active loop, ← always means "exit to the previous slide" rather
     // than the >0.5s phase-dependent restart-current behavior, since the user
     // is conceptually on the looping slide rather than at a specific offset.
-    if (this._activeLoopSegmentIndex !== null) {
-      const loopIdx = this._activeLoopSegmentIndex;
-      this._activeLoopSegmentIndex = null;
-      this._slidesTargetSegmentIndex = -1;
-      const segments = this._masterTimeline.getSegments();
+    if (this._activeLoopSlideIndex !== null) {
+      const loopIdx = this._activeLoopSlideIndex;
+      this._activeLoopSlideIndex = null;
+      this._slidesTargetSlideIndex = -1;
+      const slides = this._masterTimeline.getSlides();
       const targetIdx = Math.max(0, loopIdx - 1);
-      const targetSeg = segments[targetIdx];
-      this._masterTimeline.seek(targetSeg.startTime);
+      const targetSlide = slides[targetIdx];
+      this._masterTimeline.seek(targetSlide.startTime);
       this._scene.render();
       this._ui.updateTime(
         this._masterTimeline.getCurrentTime(),
@@ -399,15 +430,17 @@ export class Player {
       );
       return;
     }
-    this._slidesTargetSegmentIndex = -1;
-    const prev = this._masterTimeline.prevSegment();
-    if (prev) {
-      this._scene.render();
-      this._ui.updateTime(
-        this._masterTimeline.getCurrentTime(),
-        this._masterTimeline.getDuration(),
-      );
-    }
+    this._slidesTargetSlideIndex = -1;
+    const slides = this._masterTimeline.getSlides();
+    const current = this._masterTimeline.getCurrentSlide();
+    if (!current) return;
+    const elapsed = this._masterTimeline.getCurrentTime() - current.startTime;
+    // If we're well into the current slide, go to its start; otherwise the
+    // previous slide. Matches the per-segment behavior at the slide level.
+    const target = elapsed > 0.5 ? current : (slides[current.index - 1] ?? current);
+    this._masterTimeline.seek(target.startTime);
+    this._scene.render();
+    this._ui.updateTime(this._masterTimeline.getCurrentTime(), this._masterTimeline.getDuration());
   }
 
   /** Set the playback speed multiplier. */
@@ -420,8 +453,8 @@ export class Player {
     this._slidesMode = enabled;
     this._ui.setSlidesMode(enabled);
     if (!enabled) {
-      this._activeLoopSegmentIndex = null;
-      this._slidesTargetSegmentIndex = -1;
+      this._activeLoopSlideIndex = null;
+      this._slidesTargetSlideIndex = -1;
     }
   }
 
@@ -511,19 +544,19 @@ export class Player {
         this._masterTimeline.getDuration(),
       );
 
-      // In slides mode, either rewind a looping segment or auto-pause at
-      // the target segment boundary.
-      if (this._slidesMode && this._slidesTargetSegmentIndex >= 0) {
-        const segments = this._masterTimeline.getSegments();
-        const targetSeg = segments[this._slidesTargetSegmentIndex];
-        if (targetSeg && this._masterTimeline.getCurrentTime() >= targetSeg.endTime) {
-          if (targetSeg.loop) {
+      // In slides mode, branch on the active slide's flags at its endTime.
+      // loop wins over autoNext (a looping slide never reaches its end naturally).
+      if (this._slidesMode && this._slidesTargetSlideIndex >= 0) {
+        const slides = this._masterTimeline.getSlides();
+        const targetSlide = slides[this._slidesTargetSlideIndex];
+        if (targetSlide && this._masterTimeline.getCurrentTime() >= targetSlide.endTime) {
+          if (targetSlide.loop) {
             // Rewind and keep playing. play() is required because Timeline.update
             // self-pauses when currentTime crosses the timeline duration (i.e.
-            // when the looping segment is the final segment).
-            this._masterTimeline.seek(targetSeg.startTime);
+            // when the looping slide is the final slide).
+            this._masterTimeline.seek(targetSlide.startTime);
             this._masterTimeline.play();
-            this._activeLoopSegmentIndex = targetSeg.index;
+            this._activeLoopSlideIndex = targetSlide.index;
             this._scene.render();
             this._ui.updateTime(
               this._masterTimeline.getCurrentTime(),
@@ -531,13 +564,29 @@ export class Player {
             );
             return;
           }
-          this._masterTimeline.seek(targetSeg.endTime);
+          const nextIdx = targetSlide.index + 1;
+          if (targetSlide.autoNext && nextIdx < slides.length) {
+            // Advance to the next slide and keep playing through it.
+            const nextSlide = slides[nextIdx];
+            this._masterTimeline.seek(nextSlide.startTime);
+            this._masterTimeline.play();
+            this._slidesTargetSlideIndex = nextIdx;
+            this._scene.render();
+            this._ui.updateTime(
+              this._masterTimeline.getCurrentTime(),
+              this._masterTimeline.getDuration(),
+            );
+            return;
+          }
+          // Default: pause at the slide boundary. (Final autoNext slide
+          // also falls through here — there is nothing to advance to.)
+          this._masterTimeline.seek(targetSlide.endTime);
           this._scene.render();
           this._ui.updateTime(
             this._masterTimeline.getCurrentTime(),
             this._masterTimeline.getDuration(),
           );
-          this._slidesTargetSegmentIndex = -1;
+          this._slidesTargetSlideIndex = -1;
           this._isPlaying = false;
           this._masterTimeline.pause();
           this._ui.setPlaying(false);

--- a/src/player/PlayerUI.test.ts
+++ b/src/player/PlayerUI.test.ts
@@ -41,12 +41,10 @@ function createContainer(): HTMLElement {
 /**
  * Create a minimal mock MasterTimeline for setSegments().
  */
-function createMockTimeline(
-  segments: Array<{ index: number; startTime: number }>,
-  duration: number,
-) {
+function createMockTimeline(slides: Array<{ index: number; startTime: number }>, duration: number) {
   return {
-    getSegments: () => segments,
+    getSegments: () => slides,
+    getSlides: () => slides,
     getDuration: () => duration,
   } as any;
 }

--- a/src/player/PlayerUI.ts
+++ b/src/player/PlayerUI.ts
@@ -180,11 +180,13 @@ export class PlayerUI {
 
   setSegments(timeline: MasterTimeline): void {
     this._segmentMarkers.innerHTML = '';
-    const segments = timeline.getSegments();
+    // Draw markers at slide boundaries — those are the units that prev/next
+    // navigation operates on.
+    const slides = timeline.getSlides();
     const duration = timeline.getDuration();
     if (duration <= 0) return;
 
-    for (const seg of segments) {
+    for (const seg of slides) {
       if (seg.index === 0) continue; // no marker at 0
       const pct = (seg.startTime / duration) * 100;
       const marker = el('div', {


### PR DESCRIPTION
## Summary

Refactors slidesMode to mirror [manim-slides' `next_slide(loop, auto_next)`](https://manim-slides.eertmans.be/latest/reference/api.html). Builds on #354.

### API

```ts
player.sequence(async (scene) => {
  // Slide 1 (normal — current behavior preserved if nextSlide() is never called)
  await scene.play(new Create(square));

  // Slide 2: loops until → pressed
  await scene.nextSlide({ loop: true });
  await scene.play(new Rotate(square, { angle: Math.PI * 2, duration: 2, rateFunc: linear }));

  // Slide 3: two plays grouped into one slide, advances automatically when done
  await scene.nextSlide({ autoNext: true });
  await scene.play(new FadeIn(label));
  await scene.play(new Indicate(label));

  // Slide 4: normal
  await scene.nextSlide();
  await scene.play(new FadeOut(square));
});
```

- **`scene.nextSlide(opts?)`** — boundary marker (was `scene.loopPlay` in #354, removed).
- **`{ loop: true }`** — slide replays until →.
- **`{ autoNext: true }`** — slide advances into the next slide automatically when done. Final autoNext slide just pauses.
- **Multi-play slides** — every `play()/wait()` between two `nextSlide()` calls forms one slide.
- **Back-compat**: if `nextSlide()` is never called, each segment becomes its own slide → existing per-play slidesMode works unchanged (verified: existing `examples/slides_mode.html` still passes through this path).

### Internals

- Introduces `Slide` in `MasterTimeline` grouping N consecutive `Segment`s: `{ index, startSegmentIndex, endSegmentIndex, startTime, endTime, loop, autoNext }`.
- Drops `Segment.loop` (was per-segment in #354, internal-only) — loop is now a `Slide` property.
- `MasterTimeline.beginSlide(opts)` records boundaries; `finalizeSlides()` builds the slide list at end of `sequence()`. Idempotent. Throws on zero-duration looping slides.
- Player slidesMode state renamed: `_slidesTargetSlideIndex`, `_activeLoopSlideIndex`. `nextSegment`/`prevSegment` keep names + new `nextSlide`/`prevSlide` aliases. Navigation operates on slides — multi-play slides are atomic.
- `_startLoop` slide-boundary branch: `loop` (rewind) > `autoNext` (advance into next slide, keep playing) > default (pause). Final `autoNext` falls through to pause.
- PlayerUI scrubber markers now mark slide boundaries (the navigable unit).

### Out of scope (follow-up)

- Slide titles / presenter notes.
- `auto_next` for non-slidesMode (today the flag is slidesMode-only).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — **5909 passed**
- [x] Browser verify: slide 0 plays then pauses; slide 1 loops bounded inside `[startTime, endTime]`; pressing → exits loop into slide 2 (multi-play autoNext) which then auto-advances through slide 3 to the final pause.

Plan + review trail: #215, #354.
