### PR TITLE
fix(slides): address PR #355 review (#215)

### DIFF
--- a/examples/slides_mode_loop.html
+++ b/examples/slides_mode_loop.html
@@ -90,6 +90,8 @@
       await scene.nextSlide();
       await scene.play(new Transform(square, circle));
       await scene.play(new FadeOut(circle));
+    }).catch((err) => {
+      console.error('sequence() failed:', err);
     });
   </script>
 </body>

--- a/src/animation/MasterTimeline.test.ts
+++ b/src/animation/MasterTimeline.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as THREE from 'three';
 import { Mobject } from '../core/Mobject';
 import { VMobject } from '../core/VMobject';
@@ -228,6 +228,43 @@ describe('MasterTimeline', () => {
       tl.finalizeSlides();
       const second = JSON.parse(JSON.stringify(tl.getSlides()));
       expect(second).toEqual(first);
+    });
+
+    it('finalizeSlides on a completely empty timeline produces no slides', () => {
+      tl.finalizeSlides();
+      expect(tl.slideCount).toBe(0);
+      expect(tl.getCurrentSlide()).toBeNull();
+    });
+
+    it('getSlideAtTime returns null before the first slide', () => {
+      const mob = new TestMobject();
+      tl.beginSlide();
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      tl.finalizeSlides();
+      // First slide starts at 0, but we manufacture a pathological pre-slide
+      // time by querying a negative value.
+      expect(tl.getSlideAtTime(-1)).toBeNull();
+    });
+
+    it('warns on consecutive beginSlide calls that drop non-default opts', () => {
+      const mob = new TestMobject();
+      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      tl.beginSlide({ loop: true });
+      tl.beginSlide(); // drops { loop: true } silently — should warn
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      tl.finalizeSlides();
+      expect(spy).toHaveBeenCalledOnce();
+      spy.mockRestore();
+    });
+
+    it('normalises autoNext to false when loop is true', () => {
+      const mob = new TestMobject();
+      tl.beginSlide({ loop: true, autoNext: true });
+      tl.addSegment([new TestAnimation(mob, { duration: 1 })]);
+      tl.finalizeSlides();
+      const slide = tl.getSlides()[0];
+      expect(slide.loop).toBe(true);
+      expect(slide.autoNext).toBe(false);
     });
 
     it('getCurrentSlide returns slide containing the current time', () => {

--- a/src/animation/MasterTimeline.ts
+++ b/src/animation/MasterTimeline.ts
@@ -30,19 +30,26 @@ export interface Segment {
 
 export interface Slide {
   /** Index in the slides array */
-  index: number;
+  readonly index: number;
   /** First segment in this slide */
-  startSegmentIndex: number;
+  readonly startSegmentIndex: number;
   /** Last segment in this slide (inclusive) */
-  endSegmentIndex: number;
+  readonly endSegmentIndex: number;
   /** = segments[startSegmentIndex].startTime */
-  startTime: number;
+  readonly startTime: number;
   /** = segments[endSegmentIndex].endTime */
-  endTime: number;
-  /** Replay this slide until the user presses → in slidesMode. */
-  loop: boolean;
-  /** Advance to the next slide automatically when this slide finishes. */
-  autoNext: boolean;
+  readonly endTime: number;
+  /**
+   * Replay this slide in slidesMode until the user navigates away
+   * (→, ←, public seek out of the slide, or setSlidesMode(false)).
+   * Wins over `autoNext` when both are set.
+   */
+  readonly loop: boolean;
+  /**
+   * Auto-advance to the next slide when this slide finishes (slidesMode only).
+   * Ignored if `loop` is also true. Final autoNext slide pauses normally.
+   */
+  readonly autoNext: boolean;
 }
 
 export interface SlideOptions {
@@ -213,19 +220,40 @@ export class MasterTimeline extends Timeline {
 
   /**
    * Record a slide boundary: the next segment added will start a new slide
-   * with the given options. Mirrors manim-slides' `next_slide(...)` — the
+   * with the given options. Inspired by manim-slides' `next_slide(...)` — the
    * options configure the slide that *follows* this call.
    *
    * If no boundary is ever recorded, every segment becomes its own slide
    * (per-play behavior, used by existing slidesMode callers).
+   *
+   * Calling `beginSlide()` twice at the same segment index (i.e. with no
+   * intervening play/wait) drops the earlier call's options, since an
+   * empty slide cannot carry options into anything that will play. We warn
+   * to surface the likely user error.
    */
   beginSlide(opts: SlideOptions = {}): void {
-    this._slideBoundaries.push({ atSegmentIndex: this._segments.length, opts });
+    const atSegmentIndex = this._segments.length;
+    const last = this._slideBoundaries[this._slideBoundaries.length - 1];
+    if (
+      last &&
+      last.atSegmentIndex === atSegmentIndex &&
+      (last.opts.loop || last.opts.autoNext) &&
+      typeof console !== 'undefined'
+    ) {
+      console.warn(
+        'MasterTimeline.beginSlide: consecutive nextSlide() calls with no play()/wait() between them — previous opts ' +
+          JSON.stringify(last.opts) +
+          ' will be dropped.',
+      );
+    }
+    this._slideBoundaries.push({ atSegmentIndex, opts });
   }
 
   /**
-   * Build the _slides array from recorded segments and slide boundaries.
-   * Call once at the end of recording (after the sequence builder finishes).
+   * Build the `_slides` array from recorded segments and slide boundaries.
+   * Call once after the recording builder finishes; idempotent — calling
+   * twice with the same `_segments` / `_slideBoundaries` produces the same
+   * `_slides`.
    *
    * - No boundaries recorded: each segment is its own slide.
    * - Otherwise: segments before the first boundary form an implicit slide 0
@@ -234,6 +262,9 @@ export class MasterTimeline extends Timeline {
    *
    * Empty slides (consecutive boundaries with no plays between them) are
    * skipped — they have no animations and no duration to occupy.
+   *
+   * Throws if any slide carries `loop: true` but has zero total duration,
+   * since the player would rewind every frame.
    */
   finalizeSlides(): void {
     this._slides = [];
@@ -242,21 +273,14 @@ export class MasterTimeline extends Timeline {
     if (this._slideBoundaries.length === 0) {
       // Auto-boundary: each segment becomes its own slide with default opts.
       for (const seg of this._segments) {
-        this._slides.push({
-          index: this._slides.length,
-          startSegmentIndex: seg.index,
-          endSegmentIndex: seg.index,
-          startTime: seg.startTime,
-          endTime: seg.endTime,
-          loop: false,
-          autoNext: false,
-        });
+        this._slides.push(this._buildSlide(seg.index, seg.index, {}));
       }
       return;
     }
 
     // Manual boundary mode. Synthesise a leading boundary at index 0 if the
-    // first user boundary is later, so plays before it form slide 0.
+    // first user boundary is later, so plays before it form slide 0 with
+    // default opts.
     const boundaries = [...this._slideBoundaries];
     if (boundaries[0].atSegmentIndex > 0) {
       boundaries.unshift({ atSegmentIndex: 0, opts: {} });
@@ -269,25 +293,40 @@ export class MasterTimeline extends Timeline {
       const start = boundaries[i].atSegmentIndex;
       const end = boundaries[i + 1].atSegmentIndex - 1;
       if (end < start) continue; // empty slide — skip
-      const opts = boundaries[i].opts;
-      const startSeg = this._segments[start];
-      const endSeg = this._segments[end];
-      const loop = opts.loop ?? false;
-      if (loop && endSeg.endTime <= startSeg.startTime) {
-        throw new Error(
-          'MasterTimeline.finalizeSlides: cannot loop a zero-duration slide (would rewind every frame).',
-        );
-      }
-      this._slides.push({
-        index: this._slides.length,
-        startSegmentIndex: start,
-        endSegmentIndex: end,
-        startTime: startSeg.startTime,
-        endTime: endSeg.endTime,
-        loop,
-        autoNext: opts.autoNext ?? false,
-      });
+      this._slides.push(this._buildSlide(start, end, boundaries[i].opts));
     }
+  }
+
+  /**
+   * Single construction site for Slide: enforces invariants, normalises opts
+   * (`loop` wins over `autoNext`), and validates zero-duration loops.
+   */
+  private _buildSlide(start: number, end: number, opts: SlideOptions): Slide {
+    const startSeg = this._segments[start];
+    const endSeg = this._segments[end];
+    if (!startSeg || !endSeg || end < start) {
+      throw new Error(
+        `MasterTimeline._buildSlide: invalid segment range [${start}..${end}] for ${this._segments.length} segments.`,
+      );
+    }
+    const loop = opts.loop ?? false;
+    if (loop && endSeg.endTime <= startSeg.startTime) {
+      throw new Error(
+        'MasterTimeline.finalizeSlides: cannot loop a zero-duration slide (would rewind every frame).',
+      );
+    }
+    // Normalize: loop wins over autoNext so the runtime branch and the type
+    // tell the same story.
+    const autoNext = loop ? false : (opts.autoNext ?? false);
+    return {
+      index: this._slides.length,
+      startSegmentIndex: start,
+      endSegmentIndex: end,
+      startTime: startSeg.startTime,
+      endTime: endSeg.endTime,
+      loop,
+      autoNext,
+    };
   }
 
   /**
@@ -305,7 +344,8 @@ export class MasterTimeline extends Timeline {
   }
 
   /**
-   * Get the slide active at the given time.
+   * Get the slide active at the given time. Returns `null` if `time` is
+   * before the first slide's startTime or no slides exist.
    */
   getSlideAtTime(time: number): Slide | null {
     for (let i = this._slides.length - 1; i >= 0; i--) {
@@ -313,7 +353,7 @@ export class MasterTimeline extends Timeline {
         return this._slides[i];
       }
     }
-    return this._slides[0] ?? null;
+    return null;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -531,7 +531,13 @@ export {
 // Animations
 export { Animation, type AnimationOptions, type RateFunction } from './animation/Animation';
 export { Timeline, type PositionParam } from './animation/Timeline';
-export { MasterTimeline, masterTimeline, type Segment } from './animation/MasterTimeline';
+export {
+  MasterTimeline,
+  masterTimeline,
+  type Segment,
+  type Slide,
+  type SlideOptions,
+} from './animation/MasterTimeline';
 
 // Animation types
 export { FadeIn, fadeIn, FadeOut, fadeOut } from './animation/fading';

--- a/src/player/Player.test.ts
+++ b/src/player/Player.test.ts
@@ -1036,6 +1036,104 @@ describe('Player _startLoop render loop', () => {
     expect(t).toBeLessThanOrEqual(0.5);
   });
 
+  it('public seek inside the current target slide preserves loop+target state', async () => {
+    player.dispose();
+    container.remove();
+    const result = createPlayer({ slidesMode: true });
+    player = result.player;
+    container = result.container;
+
+    await player.sequence(async (scene) => {
+      await scene.nextSlide({ loop: true });
+      await scene.wait(1);
+      await scene.nextSlide();
+      await scene.wait(0.5);
+    });
+
+    const internal = player as unknown as {
+      _activeLoopSlideIndex: number | null;
+      _slidesTargetSlideIndex: number;
+    };
+    internal._activeLoopSlideIndex = 0;
+    internal._slidesTargetSlideIndex = 0;
+
+    // Scrub within slide 0's range (0..1) — must NOT silently kill the loop.
+    player.seek(0.4);
+    expect(internal._activeLoopSlideIndex).toBe(0);
+    expect(internal._slidesTargetSlideIndex).toBe(0);
+
+    // Scrub outside the target slide — clears state.
+    player.seek(1.2);
+    expect(internal._activeLoopSlideIndex).toBeNull();
+    expect(internal._slidesTargetSlideIndex).toBe(-1);
+  });
+
+  it('autoPlay + slidesMode + autoNext walks through the whole deck', async () => {
+    player.dispose();
+    container.remove();
+    const result = createPlayer({ slidesMode: true, autoPlay: true });
+    player = result.player;
+    container = result.container;
+
+    await player.sequence(async (scene) => {
+      await scene.nextSlide({ autoNext: true });
+      await scene.wait(0.2);
+      await scene.nextSlide({ autoNext: true });
+      await scene.wait(0.2);
+      await scene.nextSlide();
+      await scene.wait(0.2);
+    });
+
+    // autoPlay armed the player; flush enough to traverse 0.6s.
+    for (let i = 0; i < 100; i++) flushRaf(100 + i * 20);
+
+    expect(player.isPlaying).toBe(false);
+    expect(player.timeline.getCurrentTime()).toBeCloseTo(0.6);
+  });
+
+  it('non-slidesMode navigation steps by segment, not by slide', async () => {
+    // No slidesMode → nextSegment/prevSegment must move one segment at a time
+    // even when the timeline has multi-play slides.
+    await player.sequence(async (scene) => {
+      await scene.nextSlide();
+      await scene.wait(0.5);
+      await scene.wait(0.5); // same multi-play slide as the wait above
+      await scene.nextSlide();
+      await scene.wait(0.5);
+    });
+
+    // Should have 2 slides, 3 segments.
+    expect(player.timeline.slideCount).toBe(2);
+    expect(player.timeline.segmentCount).toBe(3);
+
+    player.nextSegment();
+    // Advanced to segment 1's start (0.5s) — within slide 0, not slide 1.
+    expect(player.timeline.getCurrentTime()).toBeCloseTo(0.5);
+    player.nextSegment();
+    // Advanced to segment 2's start (1.0s) — start of slide 1.
+    expect(player.timeline.getCurrentTime()).toBeCloseTo(1.0);
+  });
+
+  it('_startLoop disarms stale _slidesTargetSlideIndex instead of asserting', async () => {
+    player.dispose();
+    container.remove();
+    const result = createPlayer({ slidesMode: true });
+    player = result.player;
+    container = result.container;
+
+    await player.sequence(async (scene) => {
+      await scene.wait(0.3);
+    });
+    const internal = player as unknown as { _slidesTargetSlideIndex: number };
+    // Point at a slide that does not exist.
+    internal._slidesTargetSlideIndex = 99;
+    player.play();
+    flushRaf(400);
+
+    // Should have self-healed rather than throwing or freezing playback.
+    expect(internal._slidesTargetSlideIndex).toBe(-1);
+  });
+
   it('multi-play slide is treated as a single slide for navigation', async () => {
     player.dispose();
     container.remove();

--- a/src/player/Player.ts
+++ b/src/player/Player.ts
@@ -23,11 +23,10 @@
  */
 
 import { Scene, SceneOptions } from '../core/Scene';
-import { Animation } from '../animation/Animation';
-import { AnimationGroup } from '../animation/AnimationGroup';
-import { MasterTimeline, SlideOptions } from '../animation/MasterTimeline';
+import { MasterTimeline } from '../animation/MasterTimeline';
 import { PlayerUI } from './PlayerUI';
 import { PlayerController } from './PlayerController';
+import { RecordingScene } from './RecordingScene';
 
 export interface PlayerOptions extends SceneOptions {
   /** Auto-hide controls after this many ms. 0 = never. Default 2500. */
@@ -36,108 +35,8 @@ export interface PlayerOptions extends SceneOptions {
   autoPlay?: boolean;
   /** Loop playback. Default false. */
   loop?: boolean;
-  /** Slides mode: arrows play/pause at segment boundaries like a presentation. Default false. */
+  /** Slides mode: arrows play/pause at slide boundaries like a presentation. Default false. */
   slidesMode?: boolean;
-}
-
-/**
- * A recording-scene proxy that captures play/wait calls
- * without actually running animations. Used by Player.sequence().
- */
-class RecordingScene {
-  private _realScene: Scene;
-  private _masterTimeline: MasterTimeline;
-
-  constructor(scene: Scene, masterTimeline: MasterTimeline) {
-    this._realScene = scene;
-    this._masterTimeline = masterTimeline;
-  }
-
-  /** Proxy for scene.play() — records animations into the master timeline. */
-  async play(...animations: Animation[]): Promise<void> {
-    if (animations.length === 0) return;
-
-    // Collect all nested animations for scene.add + begin()
-    const allAnimations = this._collectAll(animations);
-
-    // Sync geometry so begin() can detect children
-    for (const anim of allAnimations) {
-      if (anim.mobject._dirty) {
-        anim.mobject._syncToThree();
-        anim.mobject._dirty = false;
-      }
-    }
-
-    // Record segment BEFORE begin() so addSegment captures the correct
-    // pre-animation opacity. begin() may modify mobject opacity (e.g.
-    // Create's opacity fallback sets it to 0), which would corrupt the
-    // saved value used for visibility restoration during seek/playback.
-    this._masterTimeline.addSegment(animations);
-
-    // Initialize top-level animations
-    for (const anim of animations) {
-      anim.begin();
-    }
-
-    // Add to real scene (so they're visible when we seek)
-    for (const anim of allAnimations) {
-      if (!this._realScene.mobjects.has(anim.mobject)) {
-        this._realScene.add(anim.mobject);
-        // Mark as animation-introduced so MasterTimeline hides it
-        // until its segment starts (scene.add sets createdAtBeginning=true
-        // which would bypass the hiding logic in MasterTimeline.update).
-        anim.mobject.createdAtBeginning = false;
-      }
-    }
-  }
-
-  /**
-   * Start a new slide. Mirrors manim-slides' `Scene.next_slide(...)`:
-   * options apply to the slide that *follows* this call (every play()/wait()
-   * up to the next `nextSlide()` belongs to that slide).
-   *
-   * If `nextSlide()` is never called inside a `sequence()`, each play()/wait()
-   * becomes its own slide.
-   */
-  async nextSlide(opts: SlideOptions = {}): Promise<void> {
-    this._masterTimeline.beginSlide(opts);
-  }
-
-  /** Proxy for scene.wait() — records a wait segment. */
-  async wait(duration: number = 1): Promise<void> {
-    this._masterTimeline.addWaitSegment(duration);
-  }
-
-  /** Pass-through: add mobjects directly to the scene. */
-  add(...args: Parameters<Scene['add']>): ReturnType<Scene['add']> {
-    return this._realScene.add(...args);
-  }
-
-  /** Pass-through: remove mobjects from the scene. */
-  remove(...args: Parameters<Scene['remove']>): ReturnType<Scene['remove']> {
-    return this._realScene.remove(...args);
-  }
-
-  /** Pass-through: access the camera. */
-  get camera() {
-    return this._realScene.camera;
-  }
-
-  /** Pass-through: batch updates. */
-  batch(callback: () => void): void {
-    this._realScene.batch(callback);
-  }
-
-  private _collectAll(animations: Animation[]): Animation[] {
-    const result: Animation[] = [];
-    for (const anim of animations) {
-      result.push(anim);
-      if (anim instanceof AnimationGroup) {
-        result.push(...this._collectAll(anim.animations));
-      }
-    }
-    return result;
-  }
 }
 
 export class Player {
@@ -320,77 +219,49 @@ export class Player {
     }
   }
 
-  /** Seek to a specific time in seconds. */
+  /**
+   * Seek to a specific time in seconds. If the new time stays inside the
+   * currently-targeted slide (slidesMode), the loop / target armed state is
+   * preserved — scrubbing within a looping slide should not silently kill
+   * the loop. Seeking outside the targeted slide drops both states so the
+   * next render tick doesn't snap back to the old slide.
+   */
   seek(time: number): void {
-    // User-initiated seek is a strong signal — drop any active slide loop and
-    // its target so the next render tick doesn't snap back to the old slide.
-    this._activeLoopSlideIndex = null;
-    this._slidesTargetSlideIndex = -1;
+    if (this._slidesMode && this._slidesTargetSlideIndex >= 0) {
+      const slides = this._masterTimeline.getSlides();
+      const targetSlide = slides[this._slidesTargetSlideIndex];
+      const insideTarget =
+        !!targetSlide && time >= targetSlide.startTime && time < targetSlide.endTime;
+      if (!insideTarget) {
+        this._activeLoopSlideIndex = null;
+        this._slidesTargetSlideIndex = -1;
+      }
+    } else {
+      this._activeLoopSlideIndex = null;
+      this._slidesTargetSlideIndex = -1;
+    }
     this._masterTimeline.seek(time);
     this._scene.render();
     this._ui.updateTime(this._masterTimeline.getCurrentTime(), this._masterTimeline.getDuration());
   }
 
   /**
-   * Jump to the next slide. In slidesMode, plays through the current slide
-   * to its end, then pauses (or rewinds, or auto-advances depending on the
-   * slide's flags).
+   * Jump to the next navigable unit.
    *
-   * Kept as `nextSegment()` for API stability; the unit of navigation is the
-   * Slide (possibly multi-play). For single-play sequences each slide is one
-   * play() call so the behavior matches the original per-segment navigation.
+   * - **slidesMode**: navigates by Slide. Plays through the current slide
+   *   to its end, then pauses (or rewinds / auto-advances per the slide's
+   *   `loop` / `autoNext` flags). Multi-play slides are atomic units.
+   * - **non-slidesMode**: navigates by Segment — one `play()`/`wait()` per
+   *   press, preserving the original per-segment UX.
    */
   nextSegment(): void {
     if (this._slidesMode) {
-      // Exiting an active loop is a special case: snap to the start of the
-      // next slide (or end the deck if the loop is the last slide).
-      if (this._activeLoopSlideIndex !== null) {
-        const loopIdx = this._activeLoopSlideIndex;
-        const slides = this._masterTimeline.getSlides();
-        const loopSlide = slides[loopIdx];
-        this._activeLoopSlideIndex = null;
-        const nextIdx = loopIdx + 1;
-        if (nextIdx >= slides.length) {
-          // Final loop: land on its endTime and pause normally.
-          this._masterTimeline.seek(loopSlide.endTime);
-          this._slidesTargetSlideIndex = -1;
-          this._isPlaying = false;
-          this._masterTimeline.pause();
-          this._ui.setPlaying(false);
-          this._stopLoop();
-          this._scene.render();
-          this._ui.updateTime(
-            this._masterTimeline.getCurrentTime(),
-            this._masterTimeline.getDuration(),
-          );
-          return;
-        }
-        const nextSlide = slides[nextIdx];
-        this._masterTimeline.seek(nextSlide.startTime);
-        this._slidesTargetSlideIndex = nextIdx;
-        if (!this._isPlaying) this.play();
-        else this._masterTimeline.play();
-        return;
-      }
-      const current = this._masterTimeline.getCurrentSlide();
-      if (!current) return;
-      const nextIdx = current.index + 1;
-      // If already at last slide and past its end, do nothing
-      if (nextIdx >= this._masterTimeline.slideCount && this._masterTimeline.isFinished()) return;
-      // Set the target: pause when we reach the end of the current slide
-      this._slidesTargetSlideIndex = current.index;
-      if (!this._isPlaying) this.play();
+      this._slidesModeNext();
       return;
     }
     if (this._isPlaying) this.pause();
-    // Non-slides mode: navigate by slide too, so multi-play slides act as one
-    // unit on ← / →.
-    const slides = this._masterTimeline.getSlides();
-    const cur = this._masterTimeline.getCurrentSlide();
-    if (!cur) return;
-    const next = slides[cur.index + 1];
-    if (next) {
-      this._masterTimeline.seek(next.startTime);
+    const seg = this._masterTimeline.nextSegment();
+    if (seg) {
       this._scene.render();
       this._ui.updateTime(
         this._masterTimeline.getCurrentTime(),
@@ -399,29 +270,89 @@ export class Player {
     }
   }
 
-  /** Alias for nextSegment — navigates by slide. */
+  /** Alias for nextSegment. In slidesMode navigates by slide; otherwise by segment. */
   nextSlide(): void {
     this.nextSegment();
   }
 
-  /** Alias for prevSegment — navigates by slide. */
+  /** Alias for prevSegment. In slidesMode navigates by slide; otherwise by segment. */
   prevSlide(): void {
     this.prevSegment();
   }
 
-  /** Jump to the previous slide. Pauses playback. */
+  /** Jump to the previous navigable unit. Same per-mode semantics as nextSegment. */
   prevSegment(): void {
+    if (this._slidesMode) {
+      this._slidesModePrev();
+      return;
+    }
     if (this._isPlaying) this.pause();
-    // From an active loop, ← always means "exit to the previous slide" rather
-    // than the >0.5s phase-dependent restart-current behavior, since the user
-    // is conceptually on the looping slide rather than at a specific offset.
+    const prev = this._masterTimeline.prevSegment();
+    if (prev) {
+      this._scene.render();
+      this._ui.updateTime(
+        this._masterTimeline.getCurrentTime(),
+        this._masterTimeline.getDuration(),
+      );
+    }
+  }
+
+  private _slidesModeNext(): void {
+    const slides = this._masterTimeline.getSlides();
+    // Exiting an active loop: snap to the next slide (or end the deck if last).
+    if (this._activeLoopSlideIndex !== null) {
+      const loopIdx = this._activeLoopSlideIndex;
+      const loopSlide = slides[loopIdx];
+      this._activeLoopSlideIndex = null;
+      if (!loopSlide) {
+        this._slidesTargetSlideIndex = -1;
+        return;
+      }
+      const nextIdx = loopIdx + 1;
+      const nextSlide = slides[nextIdx];
+      if (!nextSlide) {
+        // Final loop: land on its endTime and pause normally.
+        this._masterTimeline.seek(loopSlide.endTime);
+        this._slidesTargetSlideIndex = -1;
+        this._isPlaying = false;
+        this._masterTimeline.pause();
+        this._ui.setPlaying(false);
+        this._stopLoop();
+        this._scene.render();
+        this._ui.updateTime(
+          this._masterTimeline.getCurrentTime(),
+          this._masterTimeline.getDuration(),
+        );
+        return;
+      }
+      this._masterTimeline.seek(nextSlide.startTime);
+      this._slidesTargetSlideIndex = nextIdx;
+      if (!this._isPlaying) this.play();
+      else this._masterTimeline.play();
+      return;
+    }
+    const current = this._masterTimeline.getCurrentSlide();
+    if (!current) return;
+    const nextIdx = current.index + 1;
+    if (nextIdx >= slides.length && this._masterTimeline.isFinished()) return;
+    // Set the target: pause / loop / advance when we reach the end of the
+    // current slide. Same target whether we're playing through or just armed.
+    this._slidesTargetSlideIndex = current.index;
+    if (!this._isPlaying) this.play();
+  }
+
+  private _slidesModePrev(): void {
+    if (this._isPlaying) this.pause();
+    const slides = this._masterTimeline.getSlides();
+    // From an active loop, ← always exits to the previous slide rather than
+    // the >0.5s phase-dependent restart-current behavior — the user is
+    // conceptually on the looping slide rather than at a specific offset.
     if (this._activeLoopSlideIndex !== null) {
       const loopIdx = this._activeLoopSlideIndex;
       this._activeLoopSlideIndex = null;
       this._slidesTargetSlideIndex = -1;
-      const slides = this._masterTimeline.getSlides();
-      const targetIdx = Math.max(0, loopIdx - 1);
-      const targetSlide = slides[targetIdx];
+      const targetSlide = slides[Math.max(0, loopIdx - 1)] ?? slides[0];
+      if (!targetSlide) return;
       this._masterTimeline.seek(targetSlide.startTime);
       this._scene.render();
       this._ui.updateTime(
@@ -431,12 +362,10 @@ export class Player {
       return;
     }
     this._slidesTargetSlideIndex = -1;
-    const slides = this._masterTimeline.getSlides();
     const current = this._masterTimeline.getCurrentSlide();
     if (!current) return;
     const elapsed = this._masterTimeline.getCurrentTime() - current.startTime;
-    // If we're well into the current slide, go to its start; otherwise the
-    // previous slide. Matches the per-segment behavior at the slide level.
+    // Well into the current slide → restart it; otherwise step to previous.
     const target = elapsed > 0.5 ? current : (slides[current.index - 1] ?? current);
     this._masterTimeline.seek(target.startTime);
     this._scene.render();
@@ -549,7 +478,12 @@ export class Player {
       if (this._slidesMode && this._slidesTargetSlideIndex >= 0) {
         const slides = this._masterTimeline.getSlides();
         const targetSlide = slides[this._slidesTargetSlideIndex];
-        if (targetSlide && this._masterTimeline.getCurrentTime() >= targetSlide.endTime) {
+        if (!targetSlide) {
+          // Stale index after a re-record / slidesMode toggle. Disarm rather
+          // than silently letting playback drift past every slide boundary.
+          this._slidesTargetSlideIndex = -1;
+          this._activeLoopSlideIndex = null;
+        } else if (this._masterTimeline.getCurrentTime() >= targetSlide.endTime) {
           if (targetSlide.loop) {
             // Rewind and keep playing. play() is required because Timeline.update
             // self-pauses when currentTime crosses the timeline duration (i.e.

--- a/src/player/RecordingScene.ts
+++ b/src/player/RecordingScene.ts
@@ -1,0 +1,114 @@
+/**
+ * RecordingScene - the scene proxy passed to `Player.sequence(builder)`.
+ *
+ * Captures `play()` / `wait()` / `nextSlide()` calls into the player's
+ * MasterTimeline without actually running animations. Visible to user code
+ * only via the builder callback; not exported from the public surface.
+ */
+
+import { Scene } from '../core/Scene';
+import { Animation } from '../animation/Animation';
+import { AnimationGroup } from '../animation/AnimationGroup';
+import { MasterTimeline, SlideOptions } from '../animation/MasterTimeline';
+
+export class RecordingScene {
+  private _realScene: Scene;
+  private _masterTimeline: MasterTimeline;
+
+  constructor(scene: Scene, masterTimeline: MasterTimeline) {
+    this._realScene = scene;
+    this._masterTimeline = masterTimeline;
+  }
+
+  /** Proxy for scene.play() — records animations into the master timeline. */
+  async play(...animations: Animation[]): Promise<void> {
+    if (animations.length === 0) return;
+
+    // Collect all nested animations for scene.add + begin()
+    const allAnimations = this._collectAll(animations);
+
+    // Sync geometry so begin() can detect children
+    for (const anim of allAnimations) {
+      if (anim.mobject._dirty) {
+        anim.mobject._syncToThree();
+        anim.mobject._dirty = false;
+      }
+    }
+
+    // Record segment BEFORE begin() so addSegment captures the correct
+    // pre-animation opacity. begin() may modify mobject opacity (e.g.
+    // Create's opacity fallback sets it to 0), which would corrupt the
+    // saved value used for visibility restoration during seek/playback.
+    this._masterTimeline.addSegment(animations);
+
+    // Initialize top-level animations
+    for (const anim of animations) {
+      anim.begin();
+    }
+
+    // Add to real scene (so they're visible when we seek)
+    for (const anim of allAnimations) {
+      if (!this._realScene.mobjects.has(anim.mobject)) {
+        this._realScene.add(anim.mobject);
+        // Mark as animation-introduced so MasterTimeline hides it
+        // until its segment starts (scene.add sets createdAtBeginning=true
+        // which would bypass the hiding logic in MasterTimeline.update).
+        anim.mobject.createdAtBeginning = false;
+      }
+    }
+  }
+
+  /**
+   * Start a new slide. Inspired by manim-slides' `Scene.next_slide(...)`:
+   * options apply to the slide that *follows* this call (every play()/wait()
+   * up to the next `nextSlide()` belongs to that slide).
+   *
+   * Supported options: `{ loop, autoNext }`. manim-slides' `name`,
+   * `playback_rate`, and `notes` are not implemented.
+   *
+   * If `nextSlide()` is never called inside a `sequence()`, each play()/wait()
+   * becomes its own slide. The moment the first `nextSlide()` appears, all
+   * plays in the sequence — including any before that first call — are grouped
+   * by boundary; plays before the first boundary form an implicit slide 0 with
+   * default options.
+   */
+  async nextSlide(opts: SlideOptions = {}): Promise<void> {
+    this._masterTimeline.beginSlide(opts);
+  }
+
+  /** Proxy for scene.wait() — records a wait segment. */
+  async wait(duration: number = 1): Promise<void> {
+    this._masterTimeline.addWaitSegment(duration);
+  }
+
+  /** Pass-through: add mobjects directly to the scene. */
+  add(...args: Parameters<Scene['add']>): ReturnType<Scene['add']> {
+    return this._realScene.add(...args);
+  }
+
+  /** Pass-through: remove mobjects from the scene. */
+  remove(...args: Parameters<Scene['remove']>): ReturnType<Scene['remove']> {
+    return this._realScene.remove(...args);
+  }
+
+  /** Pass-through: access the camera. */
+  get camera() {
+    return this._realScene.camera;
+  }
+
+  /** Pass-through: batch updates. */
+  batch(callback: () => void): void {
+    this._realScene.batch(callback);
+  }
+
+  private _collectAll(animations: Animation[]): Animation[] {
+    const result: Animation[] = [];
+    for (const anim of animations) {
+      result.push(anim);
+      if (anim instanceof AnimationGroup) {
+        result.push(...this._collectAll(anim.animations));
+      }
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #355 addressing review findings from `/pr-review-toolkit:review-pr`.

## Fixes

**Player**
- Non-slidesMode `nextSegment`/`prevSegment` step by segment again (regression — they were navigating by slide after #355, skipping multiple plays in non-presentation contexts).
- Public `seek()` inside the currently-targeted slide preserves the loop + target state. Scrubbing within an active looping slide no longer silently drops the loop. Seeking outside the target still clears, as before.
- `_startLoop` self-heals when `_slidesTargetSlideIndex` points past the slide array (stale after re-record / slidesMode toggle). Was silently letting playback drift past every slide boundary.
- All `slides[idx]` dereferences in `nextSegment`/`prevSegment`/`_startLoop` bounds-checked.

**MasterTimeline**
- Single Slide construction site (`_buildSlide`) enforces invariants and normalises opts so `loop: true` always implies `autoNext: false` — types and runtime tell the same story.
- `beginSlide()` warns when consecutive calls would discard non-default opts (footgun: `scene.nextSlide({loop:true})` followed immediately by `scene.nextSlide()`).
- `getSlideAtTime()` returns `null` for `time < firstSlide.startTime` instead of snapping to slide 0.
- `Slide` fields are now `readonly`.

**Structure / API surface**
- `RecordingScene` extracted to its own module (`src/player/RecordingScene.ts`).
- `Slide` and `SlideOptions` exported from `src/index.ts`.

**Docs**
- `nextSegment` JSDoc covers slidesMode + non-slidesMode behavior.
- `RecordingScene.nextSlide` JSDoc downgraded "Mirrors" → "Inspired by" manim-slides and lists which `next_slide` options aren't implemented (`name`, `notes`, `playback_rate`).

**Tests** — new coverage for the gaps the reviewer flagged:
- Seek inside vs outside the target slide
- `autoPlay + slidesMode + autoNext` chain
- Non-slidesMode steps by segment
- `_startLoop` disarms stale target index
- `finalizeSlides` on empty timeline
- `getSlideAtTime` negative time
- `console.warn` on opts-dropping `beginSlide()` pair
- `autoNext` normalised to `false` when `loop: true`

**Example**
- `examples/slides_mode_loop.html` adds `.catch` on the `sequence()` promise — builder errors surface in console rather than being silent unhandled rejections.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — **5917 passed** (was 5909; 8 new tests)
- [x] Browser-verified slide structure unchanged in `examples/slides_mode_loop.html`.

Reviewed via `/pr-review-toolkit:review-pr`: 5 parallel reviewers (test-analyzer, silent-failure-hunter, comment-analyzer, type-design-analyzer, code-reviewer). All flagged findings addressed.

Plan + review trail: #215, #354, #355.
