### PR TITLE
fix(vgroup): apply shift to group position when empty (#318)

### DIFF
--- a/examples/mathtex_shift_before_render.html
+++ b/examples/mathtex_shift_before_render.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script>if(new URLSearchParams(location.search).has('embed'))document.documentElement.classList.add('embed')</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ManimWeb - MathTex shift before render (#318)</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #1a1a2e;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+    }
+    #container {
+      border: 2px solid #333;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    html.embed, html.embed body { margin:0!important;padding:0!important;overflow:hidden;background:#000!important;width:100%;height:100%; }
+    html.embed body { display:flex;justify-content:center;align-items:center; }
+    html.embed #container { border:none!important;border-radius:0!important;width:100vw;height:100vh;display:flex;justify-content:center;align-items:center; }
+  </style>
+</head>
+<body>
+  <div id="container"></div>
+  <script type="module" src="./mathtex_shift_before_render.ts"></script>
+</body>
+</html>

--- a/examples/mathtex_shift_before_render.ts
+++ b/examples/mathtex_shift_before_render.ts
@@ -1,0 +1,28 @@
+/**
+ * Issue #318 demo: `MathTex.shift(...)` (and any transform that delegates to it)
+ * used to be a silent no-op when called before `await waitForRender()`, because
+ * `VGroup.shift` iterated children and the glyphs were not rendered yet. After
+ * the fix, the pre-render shift is recorded on the group's own `position` and
+ * the glyphs render at the expected location without an explicit await.
+ */
+import { Scene, MathTex, WHITE, GOLD, RED, BLACK } from '../src/index.ts';
+
+const container = document.getElementById('container');
+const scene = new Scene(container, {
+  width: 800,
+  height: 450,
+  backgroundColor: BLACK,
+});
+
+// Three labels, each constructed and shifted to its slot BEFORE any render.
+// Pre-fix: all three would have collapsed to the origin on top of each other.
+const left = new MathTex({ latex: '0', color: WHITE, fontSize: 64 });
+left.shift([-4, 0, 0]);
+
+const middle = new MathTex({ latex: '\\pi', color: GOLD, fontSize: 64 });
+middle.moveTo([0, 1.5, 0]); // moveTo also delegates to shift internally
+
+const right = new MathTex({ latex: '\\infty', color: RED, fontSize: 64 });
+right.shift([4, -1.5, 0]);
+
+scene.add(left, middle, right);

--- a/src/core/VGroup.ts
+++ b/src/core/VGroup.ts
@@ -161,10 +161,20 @@ export class VGroup extends VMobject {
    * Shift all children by the given delta.
    * Only shifts children's internal positions, not the group's own position,
    * to avoid double-counting in THREE.js hierarchy.
+   *
+   * When the group has no children yet (e.g. MathTex / Tex whose glyphs are
+   * still being rendered asynchronously — issue #318), shift the group's
+   * own `position` instead so the translation is not silently dropped.
+   * THREE.js propagates the parent position to children that get added
+   * later, and `getCenter()` already adds `this.position` to the children
+   * average, so subsequent shifts on the populated group stay consistent.
    * @param delta - Translation vector [x, y, z]
    * @returns this for chaining
    */
   override shift(delta: Vector3Tuple): this {
+    if (this.children.length === 0) {
+      return super.shift(delta);
+    }
     for (const child of this.children) {
       child.shift(delta);
     }

--- a/src/core/core-extra.test.ts
+++ b/src/core/core-extra.test.ts
@@ -1753,6 +1753,42 @@ describe('VGroup - extended coverage', () => {
     expect(a.position.x).toBe(5);
   });
 
+  it('shift on empty VGroup mutates group position (issue #318)', () => {
+    const vg = new VGroup();
+    vg.shift([-8, 0, 0]);
+    expect(vg.position.x).toBe(-8);
+    expect(vg.getCenter()[0]).toBe(-8);
+
+    // Children added after a pre-shift should inherit the parent transform
+    // and combine cleanly with a subsequent populated shift.
+    const a = new VMobject();
+    a.position.set(0, 0, 0);
+    vg.add(a);
+    vg.shift([1, 0, 0]);
+    expect(vg.position.x).toBe(-8);
+    expect(a.position.x).toBe(1);
+    expect(vg.getCenter()[0]).toBeCloseTo(-7, 5);
+  });
+
+  it('pre-shifted VGroup keeps consistent center after matrixWorld update', () => {
+    // Codex review of #318: materialize the THREE hierarchy and confirm we
+    // don't double-count parent.position once the world matrix is current.
+    const vg = new VGroup();
+    vg.shift([-8, 0, 0]);
+    const a = new VMobject();
+    a.setPoints3D([
+      [1, 0, 0],
+      [2, 0, 0],
+      [3, 1, 0],
+      [2, 2, 0],
+    ]);
+    vg.add(a);
+    vg.getThreeObject().updateMatrixWorld(true);
+    // Child geometry centers at local (2, 1, 0); group offsets by (-8, 0, 0).
+    expect(vg.getCenter()[0]).toBeCloseTo(-6, 5);
+    expect(vg.getCenter()[1]).toBeCloseTo(1, 5);
+  });
+
   it('moveTo with point moves VGroup center', () => {
     const a = new VMobject();
     a.position.set(0, 0, 0);

--- a/src/core/fixed-orientation.test.ts
+++ b/src/core/fixed-orientation.test.ts
@@ -287,6 +287,33 @@ describe('addFixedOrientationMobjects', () => {
     scene.dispose();
   });
 
+  it('VGroup pre-shifted while empty, then populated, still billboards correctly (#318/#264)', () => {
+    const scene = ThreeDScene.createHeadless();
+    const group = new VGroup();
+    // Empty pre-shift (issue #318 path): the translation is recorded on
+    // group.position rather than a child. Adding the child later should
+    // not break the billboard, which reads mob.getCenter() rather than
+    // threeObject.position.
+    group.moveTo([2, 3, -1]);
+    group.add(new Circle());
+    scene.add(group);
+    scene.addFixedOrientationMobjects(group);
+
+    expect(group.getCenter()[0]).toBeCloseTo(2, 5);
+    expect(group.getCenter()[1]).toBeCloseTo(3, 5);
+    expect(group.getCenter()[2]).toBeCloseTo(-1, 5);
+
+    scene.setCameraOrientation(Math.PI / 3, Math.PI / 4, 15);
+    scene.render();
+
+    const [x, y, z] = visualCenterWorld(group);
+    expect(x).toBeCloseTo(2, 3);
+    expect(y).toBeCloseTo(3, 3);
+    expect(z).toBeCloseTo(-1, 3);
+
+    scene.dispose();
+  });
+
   it('removeFixedOrientationMobjects restores the displaced position', () => {
     const scene = ThreeDScene.createHeadless();
     const group = new VGroup();

--- a/src/mobjects/text/mathtex-svg.test.ts
+++ b/src/mobjects/text/mathtex-svg.test.ts
@@ -132,6 +132,56 @@ describe('MathTex stroke width', () => {
   });
 });
 
+describe('Issue #318: translations before waitForRender are not silently dropped', () => {
+  it('shift() before render persists after render', async () => {
+    const tex = new MathTex({ latex: '0', fillOpacity: 1 });
+    tex.shift([-8, 0, 0]);
+    expect(tex.position.x).toBe(-8);
+    await tex.waitForRender();
+    expect(tex.position.x).toBe(-8);
+    const center = tex.getCenter();
+    expect(center[0]).toBeCloseTo(-8, 3);
+  });
+
+  it('moveTo([target]) before render places the rendered glyph at target', async () => {
+    const tex = new MathTex({ latex: 'x' });
+    tex.moveTo([3, 2, 0]);
+    await tex.waitForRender();
+    const center = tex.getCenter();
+    expect(center[0]).toBeCloseTo(3, 2);
+    expect(center[1]).toBeCloseTo(2, 2);
+  });
+
+  it('shift() before render combines with shift() after render', async () => {
+    const tex = new MathTex({ latex: 'a' });
+    tex.shift([-5, 0, 0]); // pre-render: lands on this.position
+    await tex.waitForRender();
+    tex.shift([1, 0, 0]); // post-render: lands on each child
+    const center = tex.getCenter();
+    expect(center[0]).toBeCloseTo(-4, 2);
+  });
+
+  it('shift() before render keeps this.position when subsequent scale() runs', async () => {
+    const tex = new MathTex({ latex: 'x' });
+    tex.shift([-3, 0, 0]);
+    await tex.waitForRender();
+    tex.scale(2);
+    // The pre-render shift is recorded on the parent's position; subsequent
+    // VGroup.scale operates on children and must not clobber that.
+    expect(tex.position.x).toBe(-3);
+  });
+
+  it('multi-part MathTex shift before render persists on this.position', async () => {
+    const tex = new MathTex({ latex: ['x', '=', '5'] });
+    tex.shift([2, 1, 0]);
+    expect(tex.position.x).toBe(2);
+    expect(tex.position.y).toBe(1);
+    await tex.waitForRender();
+    expect(tex.position.x).toBe(2);
+    expect(tex.position.y).toBe(1);
+  });
+});
+
 describe('MathTex size consistency', () => {
   it('MathTex em dash should be approximately 1 em wide', async () => {
     // Em dash in math mode: use \text{—} with actual em dash character (U+2014)


### PR DESCRIPTION
Closes #318.

## Summary
- `VGroup.shift` iterated `this.children` and silently dropped any pre-render shift / moveTo / nextTo on async-rendered mobjects (`MathTex`, `Tex`). Fall back to `super.shift(delta)` when `children.length === 0` so the translation lands on the group's own `position`. THREE.js propagates that to glyphs as soon as they get added.
- `getCenter()` already adds `this.position` to the children average and tests confirm no double-count even after `updateMatrixWorld(true)`.
- Populated-group path is unchanged, so the #264 / #252 invariants ("state lives in children") still hold.

## What's covered
- `MathTex` regression suite: single-part shift before render, `moveTo` before render, mixed pre/post-render shifts, shift then scale, multi-part shift.
- `VGroup` core regression: empty shift mutates `position`, subsequent populated shift composes cleanly, and `matrixWorld` update doesn't double-count.
- Fixed-orientation regression for the pre-shift → populate → billboard sequence (guards #264).
- Demo `examples/mathtex_shift_before_render.{ts,html}` reproducing the original snippet from the issue without an explicit `await waitForRender()`.

## Out of scope (intentionally not fixed by this PR)
- `scale()` / `rotate()` before render — still iterate empty children. Test explicitly checks that `tex.position.x` survives a post-render `scale`, but pre-render scale magnitude is still dropped. Worth a separate issue if needed.
- `nextTo()` before render — shift now persists, but bounds are still unknown until glyphs exist.
- `MathTex.animate.shift(...)` before render — pathological, blocked on `AnimateProxy` VGroup parent-state handling.

## Test plan
- [x] `npx vitest run` — 5925 / 5925 passing
- [x] `npm run typecheck` — clean
- [x] Manual browser check on `examples/mathtex_shift_before_render.html` — three glyphs render at three distinct positions (left band 559 / mid 402 / right 667 non-black pixels)
- [x] Codex review of plan and implementation