### PR TITLE
fix(#321): silence coverage stderr noise

### DIFF
--- a/src/animation/Animation.ts
+++ b/src/animation/Animation.ts
@@ -76,17 +76,29 @@ export abstract class Animation {
    */
   begin(): void {
     if (!this._preAnimationState) {
-      try {
-        this._preAnimationState = this.mobject.copy();
-      } catch (err) {
-        // Some mobjects (test mocks, minimal subclasses) don't support copy().
-        // Fall back to a lightweight property-only snapshot.
-        console.warn(
-          'Animation.begin(): mobject.copy() failed, using minimal state snapshot. ' +
-            'Backward seeking may not fully restore this mobject.',
-          err,
-        );
+      // Some mobjects (test mocks, minimal subclasses) don't implement the
+      // abstract `_createCopy()` at all — TypeScript catches this at compile
+      // time, so it's only reachable from test mocks. Detect via prototype
+      // lookup and fall back silently rather than triggering copy()'s throw
+      // and the noisy warning. Errors thrown _from inside_ a real
+      // `_createCopy` are still surfaced loudly below.
+      const hasCreateCopy =
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        typeof (this.mobject as any)._createCopy === 'function';
+      if (!hasCreateCopy) {
         this._preAnimationState = this._captureMinimalState();
+      } else {
+        try {
+          this._preAnimationState = this.mobject.copy();
+        } catch (err) {
+          // Real failure inside a subclass's copy — still loud.
+          console.warn(
+            'Animation.begin(): mobject.copy() failed, using minimal state snapshot. ' +
+              'Backward seeking may not fully restore this mobject.',
+            err,
+          );
+          this._preAnimationState = this._captureMinimalState();
+        }
       }
     }
     this._hasBegun = true;

--- a/src/animation/MasterTimeline.test.ts
+++ b/src/animation/MasterTimeline.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as THREE from 'three';
 import { Mobject } from '../core/Mobject';
 import { VMobject } from '../core/VMobject';
@@ -16,6 +16,9 @@ class TestMobject extends Mobject {
     return new THREE.Object3D();
   }
   protected _syncToThree(): void {}
+  protected _createCopy(): Mobject {
+    return new TestMobject();
+  }
 }
 
 /** Concrete Animation that tracks interpolation calls. */
@@ -962,13 +965,13 @@ describe('MasterTimeline', () => {
 // =============================================================================
 
 describe('Animation _captureMinimalState and reset', () => {
-  /** Mobject whose copy() always throws, forcing the minimal-state fallback. */
+  /** Mobject whose _createCopy() throws, forcing the catch+warn fallback. */
   class NoCopyMobject extends Mobject {
     protected _createThreeObject(): THREE.Object3D {
       return new THREE.Object3D();
     }
     protected _syncToThree(): void {}
-    override copy(): Mobject {
+    protected _createCopy(): Mobject {
       throw new Error('copy not supported');
     }
   }
@@ -982,44 +985,18 @@ describe('Animation _captureMinimalState and reset', () => {
     }
   }
 
-  it('falls back to _captureMinimalState when copy() throws', () => {
-    const mob = new NoCopyMobject();
-    mob.opacity = 0.8;
-    mob.color = '#00ff00';
-
-    const anim = new StateTestAnimation(mob, { duration: 1, rateFunc: linear });
-    // begin() should not throw even though copy() does
-    expect(() => anim.begin()).not.toThrow();
-
-    // The snapshot should have been captured
-    const snapshot = (anim as any)._preAnimationState;
-    expect(snapshot).not.toBeNull();
-    expect(snapshot.opacity).toBe(0.8);
-    expect(snapshot.color).toBe('#00ff00');
-  });
-
-  it('reset() restores mobject from minimal snapshot', () => {
-    const mob = new NoCopyMobject();
-    mob.opacity = 1;
-    mob.color = '#ffffff';
-    mob.strokeWidth = 2;
-    mob.fillOpacity = 0.5;
-
-    const anim = new StateTestAnimation(mob, { duration: 1, rateFunc: linear });
-    anim.begin();
-
-    // Simulate the animation mutating the mobject
-    anim.interpolate(0.5);
-    expect(mob.opacity).toBe(0.5);
-    expect(mob.color).toBe('#ff0000');
-
-    // Reset should restore original values
-    anim.reset();
-    expect(mob.opacity).toBe(1);
-    expect(mob.color).toBe('#ffffff');
-    expect(mob.strokeWidth).toBe(2);
-    expect(mob.fillOpacity).toBe(0.5);
-  });
+  // Silence the expected `Animation.begin(): mobject.copy() failed` warn —
+  // scoped to the NoCopyMobject-using tests below, since the VMobject test
+  // and any future additions should still surface unexpected warnings.
+  function silenceCopyWarn(): void {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+  }
 
   it('reset() restores VMobject points when saved state is a VMobject copy', () => {
     const mob = new VMobject();
@@ -1056,38 +1033,81 @@ describe('Animation _captureMinimalState and reset', () => {
     ]);
   });
 
-  it('reset() clears _startTime, _isFinished, and _hasBegun', () => {
-    const mob = new NoCopyMobject();
-    const anim = new StateTestAnimation(mob, { duration: 1, rateFunc: linear });
+  describe('with NoCopyMobject (deliberately throws from _createCopy)', () => {
+    silenceCopyWarn();
 
-    anim.begin();
-    anim.update(0, 0);
-    anim.update(0, 1.5); // past duration
-    expect(anim.isFinished()).toBe(true);
+    it('falls back to _captureMinimalState when copy() throws', () => {
+      const mob = new NoCopyMobject();
+      mob.opacity = 0.8;
+      mob.color = '#00ff00';
 
-    anim.reset();
-    expect(anim.isFinished()).toBe(false);
-    expect(anim.startTime).toBeNull();
-    expect((anim as any)._hasBegun).toBe(false);
-  });
+      const anim = new StateTestAnimation(mob, { duration: 1, rateFunc: linear });
+      // begin() should not throw even though copy() does
+      expect(() => anim.begin()).not.toThrow();
 
-  it('begin() only captures snapshot on the first call', () => {
-    const mob = new NoCopyMobject();
-    mob.opacity = 0.9;
+      // The snapshot should have been captured
+      const snapshot = (anim as any)._preAnimationState;
+      expect(snapshot).not.toBeNull();
+      expect(snapshot.opacity).toBe(0.8);
+      expect(snapshot.color).toBe('#00ff00');
+    });
 
-    const anim = new StateTestAnimation(mob, { duration: 1, rateFunc: linear });
-    anim.begin();
+    it('reset() restores mobject from minimal snapshot', () => {
+      const mob = new NoCopyMobject();
+      mob.opacity = 1;
+      mob.color = '#ffffff';
+      mob.strokeWidth = 2;
+      mob.fillOpacity = 0.5;
 
-    const firstSnapshot = (anim as any)._preAnimationState;
-    expect(firstSnapshot.opacity).toBe(0.9);
+      const anim = new StateTestAnimation(mob, { duration: 1, rateFunc: linear });
+      anim.begin();
 
-    // Mutate and call begin again - snapshot should NOT be overwritten
-    mob.opacity = 0.1;
-    anim.reset();
-    anim.begin();
+      // Simulate the animation mutating the mobject
+      anim.interpolate(0.5);
+      expect(mob.opacity).toBe(0.5);
+      expect(mob.color).toBe('#ff0000');
 
-    const secondSnapshot = (anim as any)._preAnimationState;
-    expect(secondSnapshot).toBe(firstSnapshot); // same reference
-    expect(secondSnapshot.opacity).toBe(0.9); // original value
+      // Reset should restore original values
+      anim.reset();
+      expect(mob.opacity).toBe(1);
+      expect(mob.color).toBe('#ffffff');
+      expect(mob.strokeWidth).toBe(2);
+      expect(mob.fillOpacity).toBe(0.5);
+    });
+
+    it('reset() clears _startTime, _isFinished, and _hasBegun', () => {
+      const mob = new NoCopyMobject();
+      const anim = new StateTestAnimation(mob, { duration: 1, rateFunc: linear });
+
+      anim.begin();
+      anim.update(0, 0);
+      anim.update(0, 1.5); // past duration
+      expect(anim.isFinished()).toBe(true);
+
+      anim.reset();
+      expect(anim.isFinished()).toBe(false);
+      expect(anim.startTime).toBeNull();
+      expect((anim as any)._hasBegun).toBe(false);
+    });
+
+    it('begin() only captures snapshot on the first call', () => {
+      const mob = new NoCopyMobject();
+      mob.opacity = 0.9;
+
+      const anim = new StateTestAnimation(mob, { duration: 1, rateFunc: linear });
+      anim.begin();
+
+      const firstSnapshot = (anim as any)._preAnimationState;
+      expect(firstSnapshot.opacity).toBe(0.9);
+
+      // Mutate and call begin again - snapshot should NOT be overwritten
+      mob.opacity = 0.1;
+      anim.reset();
+      anim.begin();
+
+      const secondSnapshot = (anim as any)._preAnimationState;
+      expect(secondSnapshot).toBe(firstSnapshot); // same reference
+      expect(secondSnapshot.opacity).toBe(0.9); // original value
+    });
   });
 });

--- a/src/animation/creation.test.ts
+++ b/src/animation/creation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Mobject } from '../core/Mobject';
 import { VMobject } from '../core/VMobject';
 import { Group } from '../core/Group';
@@ -76,6 +76,18 @@ describe('Create', () => {
   });
 
   describe('Group with per-child opacities (opacity fallback)', () => {
+    // These tests intentionally add bare `new Mobject()` children to a Group.
+    // The abstract `_createCopy` is missing on those children, so when
+    // Group.copy() iterates them via Mobject.copy() the catch-and-warn in
+    // Animation.begin() fires. The warn is expected here — silence it.
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
     it('preserves per-child opacities after finish (#109)', () => {
       const group = new Group();
       const child1 = new Mobject();

--- a/src/animation/creation/creation-coverage.test.ts
+++ b/src/animation/creation/creation-coverage.test.ts
@@ -76,6 +76,10 @@ class MockTextMobject extends Mobject {
   }
 
   protected _syncToThree(): void {}
+
+  protected _createCopy(): Mobject {
+    return new MockTextMobject(this._text);
+  }
 }
 
 /** Mock MathTex-like with setRevealProgress */
@@ -95,6 +99,10 @@ class MockMathTexMobject extends Mobject {
   }
 
   protected _syncToThree(): void {}
+
+  protected _createCopy(): Mobject {
+    return new MockMathTexMobject();
+  }
 }
 
 /** Create a VMobject with points */

--- a/src/animation/creation/creation.test.ts
+++ b/src/animation/creation/creation.test.ts
@@ -63,6 +63,10 @@ class MockTextMobject extends Mobject {
   }
 
   protected _syncToThree(): void {}
+
+  protected _createCopy(): Mobject {
+    return new MockTextMobject(this._text);
+  }
 }
 
 // =============================================================================
@@ -93,6 +97,10 @@ class MockMathTexMobject extends Mobject {
   }
 
   protected _syncToThree(): void {}
+
+  protected _createCopy(): Mobject {
+    return new MockMathTexMobject();
+  }
 }
 
 class MockPlainMobject extends Mobject {

--- a/src/animation/transform.test.ts
+++ b/src/animation/transform.test.ts
@@ -432,6 +432,10 @@ describe('Transform', () => {
         protected _createThreeObject(): THREE.Object3D {
           return new THREE.Group();
         }
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        protected _createCopy(): Mobject {
+          return new SimpleMobject();
+        }
       }
       const m1 = new SimpleMobject();
       const m2 = new SimpleMobject();
@@ -730,6 +734,10 @@ describe('cross-fade finish()', () => {
       protected _createThreeObject(): THREE.Object3D {
         return new THREE.Group();
       }
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      protected _createCopy(): Mobject {
+        return new SimpleMobject();
+      }
     }
     const m1 = new SimpleMobject();
     const m2 = new SimpleMobject();
@@ -782,6 +790,10 @@ describe('cross-fade finish()', () => {
       protected _createThreeObject(): THREE.Object3D {
         return new THREE.Group();
       }
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      protected _createCopy(): Mobject {
+        return new SimpleMobject();
+      }
     }
     const m1 = new SimpleMobject();
     const m2 = new SimpleMobject();
@@ -804,6 +816,10 @@ describe('cross-fade finish()', () => {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       protected _createThreeObject(): THREE.Object3D {
         return new THREE.Group();
+      }
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      protected _createCopy(): Mobject {
+        return new SimpleMobject();
       }
     }
     const m1 = new SimpleMobject();
@@ -871,6 +887,11 @@ describe('cross-fade finish() with getTextureMesh (Text-like)', () => {
       getTextureMesh(): THREE.Mesh | null {
         return this._mesh;
       }
+
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      protected _createCopy(): Mobject {
+        return new TextLikeMobject();
+      }
     }
 
     const m1 = new TextLikeMobject();
@@ -920,6 +941,11 @@ describe('cross-fade finish() with getTextureMesh (Text-like)', () => {
 
       getTextureMesh(): THREE.Mesh | null {
         return this._mesh;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      protected _createCopy(): Mobject {
+        return new TextLikeMobject();
       }
     }
 

--- a/src/mobjects/text/async-error-handling.test.ts
+++ b/src/mobjects/text/async-error-handling.test.ts
@@ -6,7 +6,7 @@
  * render/load operations fail, instead of silently resolving.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MathTexImage } from './MathTexImage';
 import { MathTex } from './MathTex';
 
@@ -41,38 +41,52 @@ function createMathTexMock() {
 // ===========================================================================
 
 describe('MathTexImage async error propagation', () => {
-  it('should reject waitForRender when _renderLatex throws an Error', async () => {
-    const tex = createMathTexImageMock();
-    tex._renderLatex = vi.fn().mockRejectedValue(new Error('simulated render failure'));
-    tex._startRender();
+  describe('paths that intentionally log to console.error', () => {
+    // These tests deliberately reject from _renderLatex to exercise the
+    // catch path in _startRender, which logs `MathTexImage rendering error:`
+    // via console.error. Scope the spy so the multipart tests below still
+    // surface unexpected logs.
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+    afterEach(() => {
+      errorSpy.mockRestore();
+    });
 
-    await expect(tex.waitForRender()).rejects.toThrow('simulated render failure');
-    // renderError should be the original Error instance (instanceof branch)
-    expect(tex._renderState.renderError).toBeInstanceOf(Error);
-    expect(tex._renderState.renderError.message).toBe('simulated render failure');
-  });
+    it('should reject waitForRender when _renderLatex throws an Error', async () => {
+      const tex = createMathTexImageMock();
+      tex._renderLatex = vi.fn().mockRejectedValue(new Error('simulated render failure'));
+      tex._startRender();
 
-  it('should set isRendering to false even on error', async () => {
-    const tex = createMathTexImageMock();
-    tex._renderLatex = vi.fn().mockRejectedValue(new Error('fail'));
-    tex._startRender();
+      await expect(tex.waitForRender()).rejects.toThrow('simulated render failure');
+      // renderError should be the original Error instance (instanceof branch)
+      expect(tex._renderState.renderError).toBeInstanceOf(Error);
+      expect(tex._renderState.renderError.message).toBe('simulated render failure');
+    });
 
-    try {
-      await tex.waitForRender();
-    } catch {
-      // expected
-    }
+    it('should set isRendering to false even on error', async () => {
+      const tex = createMathTexImageMock();
+      tex._renderLatex = vi.fn().mockRejectedValue(new Error('fail'));
+      tex._startRender();
 
-    expect(tex.isRendering()).toBe(false);
-  });
+      try {
+        await tex.waitForRender();
+      } catch {
+        // expected
+      }
 
-  it('should wrap non-Error rejection values in a new Error', async () => {
-    const tex = createMathTexImageMock();
-    // Reject with a plain string — exercises the `new Error(String(error))` branch
-    tex._renderLatex = vi.fn().mockRejectedValue('string error');
-    tex._startRender();
+      expect(tex.isRendering()).toBe(false);
+    });
 
-    await expect(tex.waitForRender()).rejects.toThrow('string error');
+    it('should wrap non-Error rejection values in a new Error', async () => {
+      const tex = createMathTexImageMock();
+      // Reject with a plain string — exercises the `new Error(String(error))` branch
+      tex._renderLatex = vi.fn().mockRejectedValue('string error');
+      tex._startRender();
+
+      await expect(tex.waitForRender()).rejects.toThrow('string error');
+    });
   });
 
   it('should propagate errors through multipart waitForRender', async () => {
@@ -126,25 +140,39 @@ describe('MathTexImage async error propagation', () => {
 // ===========================================================================
 
 describe('MathTex async error propagation', () => {
-  it('should reject waitForRender when _render throws an Error', async () => {
-    const tex = createMathTexMock();
-    tex._render = vi.fn().mockRejectedValue(new Error('simulated SVG render failure'));
-    tex._startRender();
+  describe('paths that intentionally log to console.error', () => {
+    // Silence the expected `MathTex rendering error:` console.error from
+    // the catch path so test output stays clean. Scoped to error-triggering
+    // tests only — the "no error" case below must still surface unexpected
+    // console.error calls.
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+    afterEach(() => {
+      errorSpy.mockRestore();
+    });
 
-    await expect(tex.waitForRender()).rejects.toThrow('simulated SVG render failure');
-    // _renderError should be the original Error instance
-    expect(tex._renderError).toBeInstanceOf(Error);
-    expect(tex._renderError.message).toBe('simulated SVG render failure');
-  });
+    it('should reject waitForRender when _render throws an Error', async () => {
+      const tex = createMathTexMock();
+      tex._render = vi.fn().mockRejectedValue(new Error('simulated SVG render failure'));
+      tex._startRender();
 
-  it('should wrap non-Error rejection values in a new Error', async () => {
-    const tex = createMathTexMock();
-    tex._render = vi.fn().mockRejectedValue('plain string SVG error');
-    tex._startRender();
+      await expect(tex.waitForRender()).rejects.toThrow('simulated SVG render failure');
+      // _renderError should be the original Error instance
+      expect(tex._renderError).toBeInstanceOf(Error);
+      expect(tex._renderError.message).toBe('simulated SVG render failure');
+    });
 
-    await expect(tex.waitForRender()).rejects.toThrow('plain string SVG error');
-    // Should be wrapped in a real Error
-    expect(tex._renderError).toBeInstanceOf(Error);
+    it('should wrap non-Error rejection values in a new Error', async () => {
+      const tex = createMathTexMock();
+      tex._render = vi.fn().mockRejectedValue('plain string SVG error');
+      tex._startRender();
+
+      await expect(tex.waitForRender()).rejects.toThrow('plain string SVG error');
+      // Should be wrapped in a real Error
+      expect(tex._renderError).toBeInstanceOf(Error);
+    });
   });
 
   it('should not throw from waitForRender when no error occurred', async () => {

--- a/src/mobjects/text/mathtex-svg.test.ts
+++ b/src/mobjects/text/mathtex-svg.test.ts
@@ -7,7 +7,7 @@
  * verifies that MathTex and Tex are VGroup instances (SVG-based), not plain
  * Mobject instances (rasterized).
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { MathTex, MathTexSVG } from './MathTex';
 import { MathTexImage } from './MathTexImage';
 import { Tex } from './Tex';
@@ -16,6 +16,46 @@ import { VGroup } from '../../core/VGroup';
 import { Mobject } from '../../core/Mobject';
 import { VMobject } from '../../core/VMobject';
 import { DEFAULT_FONT_SIZE_IN_WORLD_SPACE } from '../../constants/fontRender';
+
+/**
+ * MathTexImage's KaTeX path renders into a 2D canvas. happy-dom returns null
+ * from `canvas.getContext('2d')`, which leaks a `MathTexImage rendering error`
+ * log even though the renderer falls back to MathJax. Stub the 2D context to
+ * keep stderr clean.
+ */
+beforeAll(() => {
+  const proto = HTMLCanvasElement.prototype as HTMLCanvasElement & {
+    getContext: (type: string, ...rest: unknown[]) => unknown;
+  };
+  const orig = proto.getContext;
+  proto.getContext = function (this: HTMLCanvasElement, type: string, ...args: unknown[]) {
+    if (type === '2d') {
+      return {
+        scale: () => {},
+        clearRect: () => {},
+        fillRect: () => {},
+        fillText: () => {},
+        beginPath: () => {},
+        closePath: () => {},
+        moveTo: () => {},
+        lineTo: () => {},
+        fill: () => {},
+        stroke: () => {},
+        measureText: (t: string) => ({
+          width: t.length * 10,
+          fontBoundingBoxAscent: 30,
+        }),
+        drawImage: () => {},
+        font: '',
+        fillStyle: '',
+        globalAlpha: 1,
+        textBaseline: 'alphabetic',
+        textAlign: 'left',
+      } as unknown as CanvasRenderingContext2D;
+    }
+    return orig.call(this, type, ...(args as []));
+  } as typeof proto.getContext;
+});
 
 describe('Issue #228: MathTex defaults to SVG mode', () => {
   it('MathTex should be an instance of VGroup (SVG path-based)', () => {

--- a/src/test-setup/happy-dom-patches.ts
+++ b/src/test-setup/happy-dom-patches.ts
@@ -1,0 +1,33 @@
+/**
+ * happy-dom test patches.
+ *
+ * Runs once per worker before any test file imports modules.
+ * Skips when document is unavailable (node-env tests).
+ *
+ * Force standards mode so KaTeX does not permanently override `render()`
+ * to throw `KaTeX doesn't work in quirks mode.` at module-load time
+ * (see node_modules/katex/dist/katex.mjs check on `document.compatMode`).
+ */
+
+if (typeof document !== 'undefined' && document.compatMode !== 'CSS1Compat') {
+  Object.defineProperty(document, 'compatMode', {
+    value: 'CSS1Compat',
+    configurable: true,
+  });
+}
+
+// happy-dom does not implement the FontFaceSet API. Stub `document.fonts.load`
+// so consumers that probe font availability (e.g. MathTexImage) resolve cleanly
+// in tests instead of throwing "Cannot read properties of undefined (reading
+// 'load')". Production code paths through real browsers are unaffected.
+if (typeof document !== 'undefined' && !(document as { fonts?: unknown }).fonts) {
+  Object.defineProperty(document, 'fonts', {
+    value: {
+      load: () => Promise.resolve([]),
+      ready: Promise.resolve(),
+      check: () => true,
+    },
+    configurable: true,
+    writable: true,
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,15 @@ export default defineConfig({
   test: {
     pool: 'threads',
     include: ['src/**/*.test.ts'],
+    setupFiles: ['./src/test-setup/happy-dom-patches.ts'],
+    environmentOptions: {
+      happyDOM: {
+        settings: {
+          disableCSSFileLoading: true,
+          handleDisabledFileLoadingAsSuccess: true,
+        },
+      },
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
Closes #321.

## Summary

Coverage runs printed hundreds of unhandled `DOMException`s, KaTeX quirks-mode errors, and `Animation.begin(): mobject.copy() failed` warnings — drowning out real test failures in CI logs.

## Changes

- **`src/test-setup/happy-dom-patches.ts`** (new vitest setupFile)
  - Patches `document.compatMode = 'CSS1Compat'` so KaTeX does not permanently override `render()` to throw at module-load time (`node_modules/katex/dist/katex.mjs` checks `compatMode !== 'CSS1Compat'`).
  - Stubs `document.fonts` so `MathTexImage` font probing (`document.fonts.load(...)`) resolves cleanly under happy-dom.
- **`vitest.config.ts`** — disable real CSS fetches from happy-dom via `environmentOptions.happyDOM.settings.disableCSSFileLoading` + `handleDisabledFileLoadingAsSuccess`. Kills the `cdn.jsdelivr.net/.../katex.min.css` AbortError/NetworkError leaks and the `invalid.example.com` DNS leak from the onerror test.
- **`src/animation/Animation.ts`** — `begin()` uses a prototype lookup instead of catching after the throw: if `_createCopy` is missing on the mobject (only reachable from incomplete test mocks — TypeScript enforces it at compile time), silently use the minimal snapshot. Real failures inside a subclass's `_createCopy` still warn loudly.
- Add `_createCopy()` to the test mocks (`MockTextMobject`, `MockMathTexMobject`, inline `SimpleMobject` / `TextLikeMobject`, `TestMobject`) so they exercise the normal copy path.
- Update `NoCopyMobject` to throw from `_createCopy` (not override `copy()`) so the fallback-warn path stays under test, and scope the silencing `console.warn` spy to the `NoCopyMobject` subset via a nested describe.
- Scope `console.error` spies in `async-error-handling.test.ts` to nested describe blocks containing only the error-triggering tests; the "no error occurred" cases still surface unexpected logs.
- Per-file canvas 2D context stub in `mathtex-svg.test.ts` (replaces an overly broad global stub from an earlier draft) so the KaTeX path doesn't fall through to a null context.

## Results

| Reporter | stderr lines before | stderr lines after |
|---|---|---|
| default (`npm run test:coverage`) | 109 | **0** |
| verbose (CI mode) | 6,415 | **104** |

The 104 remaining verbose lines are all intentional warnings from test fixtures (FunctionGraph/ParametricFunction error-recovery tests, MasterTimeline slide warning, `THREE.Color` RGBA warnings from `Code.highlightLines`, opentype.js deprecation) — out of scope for this issue.

All 5,925 tests still pass. Lint + typecheck clean.

## Test plan
- [x] `npm run test` — 5925/5925 pass
- [x] `npm run test:coverage` — passes, **0 lines of stderr noise** (was 109)
- [x] `npx vitest run --reporter=verbose 2>&1` — passes, **0 matches** for any of `mobject.copy|createCopy|quirks mode|MathTexImage rendering|MathTex rendering|AbortError|NetworkError|ENOTFOUND` (was hundreds)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`