### PR TITLE
fix(#324): MathTex preserves pre-applied scale

### DIFF
--- a/examples/mathtex_scale_before_render.html
+++ b/examples/mathtex_scale_before_render.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script>if(new URLSearchParams(location.search).has('embed'))document.documentElement.classList.add('embed')</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ManimWeb - MathTex scale before render (#324)</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #1a1a2e;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+    }
+    #container {
+      border: 2px solid #333;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    html.embed, html.embed body { margin:0!important;padding:0!important;overflow:hidden;background:#000!important;width:100%;height:100%; }
+    html.embed body { display:flex;justify-content:center;align-items:center; }
+    html.embed #container { border:none!important;border-radius:0!important;width:100vw;height:100vh;display:flex;justify-content:center;align-items:center; }
+  </style>
+</head>
+<body>
+  <div id="container"></div>
+  <script type="module" src="./mathtex_scale_before_render.ts"></script>
+</body>
+</html>

--- a/examples/mathtex_scale_before_render.ts
+++ b/examples/mathtex_scale_before_render.ts
@@ -1,0 +1,28 @@
+/**
+ * Issue #324 demo: `MathTex.scale(...)` was a silent no-op when called before
+ * `await waitForRender()`, because `VGroup.scale` iterated children and the
+ * glyphs were not rendered yet. After the fix the pre-render scale is recorded
+ * on the group's own `scaleVector` and applied via Three.js once glyphs
+ * materialize, with no explicit await required.
+ *
+ * The orange `x^2` is built with `scale(2)` before being added to the scene
+ * and should render at twice the size of the blue baseline.
+ */
+import { Scene, MathTex, BLACK, Create } from '../src/index.ts';
+
+const container = document.getElementById('container');
+const scene = new Scene(container, {
+  width: 800,
+  height: 450,
+  backgroundColor: BLACK,
+});
+
+const baseline = new MathTex({ latex: 'x^2', color: '#6aa9ff' });
+baseline.moveTo([-2, 0, 0]);
+
+const scaled = new MathTex({ latex: 'x^2', color: '#ffaa66' });
+scaled.scale(2);
+scaled.moveTo([2, 0, 0]);
+
+scene.add(baseline);
+await scene.play(new Create(scaled));

--- a/src/core/VGroup.ts
+++ b/src/core/VGroup.ts
@@ -231,14 +231,24 @@ export class VGroup extends VMobject {
   }
 
   /**
-   * Scale all children about the group's center.
-   * Each child's size is scaled, and their positions are repositioned
-   * relative to the group center — matching Manim Python behavior.
-   * Does not change the group's own scaleVector.
+   * Scale this group.
+   *
+   * For populated groups, scale each child about the group's center by
+   * modifying child geometry and positions — matching Manim Python behavior.
+   *
+   * For empty groups (e.g. MathTex / Tex whose glyphs are still being
+   * rendered asynchronously — issue #324), record the scale on the group's
+   * own `scaleVector`. Three.js then applies the parent transform to any
+   * children added later. MathTex / Tex bake this pending scale into glyph
+   * geometry once their async render finishes, so downstream callers see a
+   * consistent coordinate frame regardless of which mode produced the scale.
    * @param factor - Scale factor (number for uniform, tuple for non-uniform)
    * @returns this for chaining
    */
   override scale(factor: number | Vector3Tuple): this {
+    if (this.children.length === 0) {
+      return super.scale(factor);
+    }
     const center = this.getCenter();
     const fx = typeof factor === 'number' ? factor : factor[0];
     const fy = typeof factor === 'number' ? factor : factor[1];

--- a/src/mobjects/text/MathTex.ts
+++ b/src/mobjects/text/MathTex.ts
@@ -230,6 +230,10 @@ export class MathTex extends VGroup {
     // Scale to target height if specified, otherwise use a sensible default
     this._scaleToTarget();
 
+    // Bake any pre-render scale() call into glyph geometry so subsequent
+    // transforms operate in a consistent coordinate frame (#324).
+    this._consumePendingScale();
+
     // Set fillOpacity on this VGroup so Create animation detects it has fill
     // and properly hides it during the stroke-draw phase before fading it in.
     this.fillOpacity = this._svgFillOpacity;
@@ -320,6 +324,37 @@ export class MathTex extends VGroup {
   }
 
   /**
+   * Bake any pending parent `scaleVector` (e.g. from a pre-render `scale()`)
+   * into descendant geometry so post-render `shift`/`moveTo` operate in the
+   * same coordinate frame as the rendered glyphs. Without this step the
+   * parent's Three.js scale would silently multiply any later child-frame
+   * translations, producing a mismatch between `getCenter()` and the
+   * rendered position. See issue #324.
+   */
+  protected _consumePendingScale(): void {
+    const sx = this.scaleVector.x;
+    const sy = this.scaleVector.y;
+    const sz = this.scaleVector.z;
+    if (sx === 1 && sy === 1 && sz === 1) return;
+
+    const visit = (mob: Mobject) => {
+      mob.position.set(mob.position.x * sx, mob.position.y * sy, mob.position.z * sz);
+      if (mob instanceof VMobject && !(mob instanceof VGroup)) {
+        const pts = mob.getPoints();
+        const scaled = pts.map((p) => [p[0] * sx, p[1] * sy, p[2] * sz]);
+        mob.setPoints3D(scaled);
+      }
+      if ('children' in mob) {
+        for (const child of (mob as any).children) visit(child);
+      }
+      mob._markDirty();
+    };
+    for (const child of this.children) visit(child);
+    this.scaleVector.set(1, 1, 1);
+    this._markDirty();
+  }
+
+  /**
    * Render a multi-part expression by:
    * 1. Rendering the FULL expression as one MathJax call (correct layout)
    * 2. Rendering each part separately to count its glyphs
@@ -396,6 +431,10 @@ export class MathTex extends VGroup {
 
     // Scale and center the full expression
     this._scaleToTarget();
+
+    // Bake any pre-render scale() call into glyph geometry so subsequent
+    // transforms operate in a consistent coordinate frame (#324).
+    this._consumePendingScale();
 
     // Set fillOpacity on the parent VGroup for Create animation
     this.fillOpacity = this._svgFillOpacity;

--- a/src/mobjects/text/mathtex-prescale.test.ts
+++ b/src/mobjects/text/mathtex-prescale.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+/**
+ * Regression tests for GitHub issue #324.
+ *
+ * `MathTex` glyphs are built asynchronously. Calling `scale(...)` before
+ * `waitForRender()` used to be a silent no-op because `VGroup.scale` iterated
+ * children, and at that moment the glyphs were not rendered yet. After the
+ * fix in `VGroup.scale`, the pre-render scale is stored on the group's own
+ * `scaleVector` and applied via Three.js once children are populated.
+ *
+ * Mirrors the shape of the `shift()` fallback fix (issue #318).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { MathTex } from './MathTex';
+
+describe('MathTex pre-render scale (issue #324)', () => {
+  it('records scale on parent scaleVector when called before render', () => {
+    const tex = new MathTex({ latex: 'x^2' });
+    tex.scale(2);
+    expect(tex.scaleVector.x).toBe(2);
+    expect(tex.scaleVector.y).toBe(2);
+    expect(tex.scaleVector.z).toBe(2);
+  });
+
+  it('bakes the pre-render scale into geometry once render completes', async () => {
+    const tex = new MathTex({ latex: 'x' });
+    tex.scale(2);
+    await tex.waitForRender();
+    // After bake, parent scale is back to identity so subsequent transforms
+    // run in the same coordinate frame as the rendered glyphs.
+    expect(tex.scaleVector.x).toBe(1);
+    expect(tex.scaleVector.y).toBe(1);
+    expect(tex.scaleVector.z).toBe(1);
+  });
+
+  it('single-glyph: bounding box reflects pre-render scale after waitForRender', async () => {
+    const baseline = new MathTex({ latex: 'x' });
+    const scaled = new MathTex({ latex: 'x' });
+    scaled.scale(2);
+
+    await Promise.all([baseline.waitForRender(), scaled.waitForRender()]);
+
+    const ba = baseline.getBoundingBox();
+    const bs = scaled.getBoundingBox();
+    expect(bs.width).toBeCloseTo(ba.width * 2, 2);
+    expect(bs.height).toBeCloseTo(ba.height * 2, 2);
+  });
+
+  it('multi-glyph: bounding box reflects pre-render scale after waitForRender', async () => {
+    const baseline = new MathTex({ latex: 'x^2' });
+    const scaled = new MathTex({ latex: 'x^2' });
+    scaled.scale(2);
+
+    await Promise.all([baseline.waitForRender(), scaled.waitForRender()]);
+
+    const ba = baseline.getBoundingBox();
+    const bs = scaled.getBoundingBox();
+    expect(bs.width).toBeCloseTo(ba.width * 2, 2);
+    expect(bs.height).toBeCloseTo(ba.height * 2, 2);
+  });
+
+  it('multi-part: bounding box reflects pre-render scale after waitForRender', async () => {
+    const baseline = new MathTex({ latex: ['a', '+', 'b'] });
+    const scaled = new MathTex({ latex: ['a', '+', 'b'] });
+    scaled.scale(2);
+
+    await Promise.all([baseline.waitForRender(), scaled.waitForRender()]);
+
+    const ba = baseline.getBoundingBox();
+    const bs = scaled.getBoundingBox();
+    expect(bs.width).toBeCloseTo(ba.width * 2, 2);
+    expect(bs.height).toBeCloseTo(ba.height * 2, 2);
+  });
+
+  it('matches reporter repro shape: scale then moveTo before render', async () => {
+    const baseline = new MathTex({ latex: 'x' });
+    baseline.moveTo([-2, 0, 0]);
+
+    const scaled = new MathTex({ latex: 'x' });
+    scaled.scale(2);
+    scaled.moveTo([2, 0, 0]);
+
+    await Promise.all([baseline.waitForRender(), scaled.waitForRender()]);
+
+    const ba = baseline.getBoundingBox();
+    const bs = scaled.getBoundingBox();
+    expect(bs.height).toBeCloseTo(ba.height * 2, 2);
+    expect(scaled.getCenter()[0]).toBeCloseTo(2, 2);
+    expect(baseline.getCenter()[0]).toBeCloseTo(-2, 2);
+  });
+
+  it('pre-render scale then post-render shift preserves world-space translation', async () => {
+    const baseline = new MathTex({ latex: 'x' });
+    const tex = new MathTex({ latex: 'x' });
+    tex.scale(2);
+    await Promise.all([baseline.waitForRender(), tex.waitForRender()]);
+
+    tex.shift([1, 0, 0]);
+
+    // Logical center matches rendered position: both should land at x = 1.
+    expect(tex.getCenter()[0]).toBeCloseTo(1, 2);
+    // Width still doubled.
+    expect(tex.getBoundingBox().width).toBeCloseTo(baseline.getBoundingBox().width * 2, 2);
+  });
+
+  it('pre-render scale then post-render moveTo lands at target', async () => {
+    const tex = new MathTex({ latex: 'x' });
+    tex.scale(2);
+    await tex.waitForRender();
+
+    tex.moveTo([3, -1, 0]);
+
+    expect(tex.getCenter()[0]).toBeCloseTo(3, 2);
+    expect(tex.getCenter()[1]).toBeCloseTo(-1, 2);
+  });
+
+  it('non-uniform pre-render scale is preserved', async () => {
+    const baseline = new MathTex({ latex: 'x' });
+    const scaled = new MathTex({ latex: 'x' });
+    scaled.scale([2, 3, 1]);
+
+    expect(scaled.scaleVector.x).toBe(2);
+    expect(scaled.scaleVector.y).toBe(3);
+    expect(scaled.scaleVector.z).toBe(1);
+
+    await Promise.all([baseline.waitForRender(), scaled.waitForRender()]);
+
+    const ba = baseline.getBoundingBox();
+    const bs = scaled.getBoundingBox();
+    expect(bs.width).toBeCloseTo(ba.width * 2, 2);
+    expect(bs.height).toBeCloseTo(ba.height * 3, 2);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #324. `MathTex.scale(...)` called before `await waitForRender()` was silently dropped because `VGroup.scale` iterated children and the async MathJax render had not populated them yet.

## Changes

- **`src/core/VGroup.ts`** — empty-children fallback in `scale()`, mirroring the existing pattern in `shift()` (#318). When called on an empty group, the scale is recorded on the group's own `scaleVector` rather than being lost.
- **`src/mobjects/text/MathTex.ts`** — new `_consumePendingScale()` runs at the end of `_render()` / `_renderMultiPart()`. It bakes any pending parent `scaleVector` into glyph geometry and resets the parent scale to identity, so subsequent `shift`/`moveTo` operate in the same coordinate frame as the rendered output. Without baking, the parent Three.js scale would silently multiply later child-frame translations and `getCenter()` would diverge from the visual position.
- **`src/mobjects/text/mathtex-prescale.test.ts`** — 9 regression tests covering: parent `scaleVector` storage, bake-on-render, single-glyph / multi-glyph / multi-part bounding box, reporter repro shape (scale + moveTo + Create), non-uniform scale, and post-render `shift`/`moveTo` after pre-render scale.
- **`examples/mathtex_scale_before_render.{html,ts}`** — visual demo showing blue baseline `x²` next to an orange `scale(2)` `x²` rendered via `Create`.

## Test plan

- [x] `npm test` — 5934/5934 pass (3 new tests added beyond the 6 in the initial implementation after codex review)
- [x] `npm run lint`, `npm run typecheck` — clean
- [x] Visual check via vite + browser: orange `x²` renders at approximately 2× the size of the blue baseline.