### PR TITLE
refactor(#340): centralize cross/dot/length/normalize in vectors.ts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,33 @@ npm run docs              # Generate example docs + build Docusaurus site
 - Max 500 lines per file (eslint `max-lines` rule)
 - No `any` types (`@typescript-eslint/no-explicit-any`) — use proper types, never `eslint-disable`
 - camelCase naming convention for methods/properties
+
+## Geometry conventions
+
+Low-level 3-vector math lives in **`src/utils/vectors.ts`**: `dotVec`, `crossVec`,
+`lengthVec`, `normalizeVec`, `unitPerpendicularTo`, `orthonormalFrame`,
+`orientation2D`, `addVec`, `subVec`, `scaleVec`. Higher-level plane / basis
+helpers live in `src/utils/math.ts` and are built on top of those.
+
+- **Never inline component arithmetic for cross/dot/length/normalize.** If you
+  catch yourself writing `a[1] * b[2] - a[2] * b[1]` or
+  `Math.sqrt(dx*dx + dy*dy + dz*dz)`, import the helper instead. New helpers
+  belong in `vectors.ts` so every call site shares one implementation.
+- **No axis-equal-to-Z special cases.** Do not branch on
+  `Math.abs(v[2]) < eps`, "is this the Z axis?", or "is the plane the XY
+  plane?" to pick a basis. Use `orthonormalFrame(normal)` — it gives you a
+  right-handed `{u, v, n}` for any normal.
+  *Exception:* `orthonormalizeBasis` in `src/utils/math.ts` keeps a
+  Z-biased fallback for its collinear-input branch. Callers (fill
+  triangulation in particular) rely on the fallback landing in the same
+  plane the geometry occupies — see the regression test in
+  `src/utils/math.test.ts`. Don't remove that fallback without first
+  rewriting `selectScatteredPoints` so collinear triples can't reach it.
+- **No plane-in-special-configuration shortcuts.** Curvature, perpendicular
+  distance, projection etc. should be written with the full 3D cross / dot
+  product, not their 2D restrictions. The 2D form is fine for genuinely
+  2D problems (e.g. a Graham scan); document the assumption and use
+  `orientation2D` rather than rolling another inline cross.
+- **Prefer vector / matrix products to component arithmetic.** Use
+  `transformPointByMatrix`, `crossVec`, `dotVec`, etc. so geometric intent is
+  visible in the code.

--- a/src/core/VMobjectGeometry.ts
+++ b/src/core/VMobjectGeometry.ts
@@ -19,6 +19,7 @@ import {
   projectToPlane,
   signedArea2DFromStride,
 } from '../utils/math';
+import { crossVec, lengthVec } from '../utils/vectors';
 import type { Point } from './VMobjectCurves';
 
 /**
@@ -54,37 +55,23 @@ const LINEARITY_REL_TOL = 0.01;
  * plane) still sample as curves.
  */
 export function isNearlyLinear(p0: number[], p1: number[], p2: number[], p3: number[]): boolean {
-  const cx = p3[0] - p0[0];
-  const cy = p3[1] - p0[1];
-  const cz = (p3[2] ?? 0) - (p0[2] ?? 0);
-  const len2 = cx * cx + cy * cy + cz * cz;
+  const c: [number, number, number] = [p3[0] - p0[0], p3[1] - p0[1], (p3[2] ?? 0) - (p0[2] ?? 0)];
 
   // Handle distances from p0 — used both as the degenerate-chord fallback
   // and to distinguish a "loop" Bezier (chord ≈ 0 but handles bulge out).
-  const dh = (q: number[]): number => {
-    const dx = q[0] - p0[0];
-    const dy = q[1] - p0[1];
-    const dz = (q[2] ?? 0) - (p0[2] ?? 0);
-    return Math.sqrt(dx * dx + dy * dy + dz * dz);
-  };
+  const dh = (q: number[]): number =>
+    lengthVec([q[0] - p0[0], q[1] - p0[1], (q[2] ?? 0) - (p0[2] ?? 0)]);
 
-  if (len2 < 1e-20) {
+  const chord = lengthVec(c);
+  if (chord < 1e-10) {
     // Chord is effectively zero. Linear only if the whole control polygon
     // collapses to a point; otherwise it's a curl/loop that must be sampled.
     return Math.max(dh(p1), dh(p2)) < 1e-10;
   }
 
-  const chord = Math.sqrt(len2);
-  const perpDist = (q: number[]): number => {
-    const ax = q[0] - p0[0];
-    const ay = q[1] - p0[1];
-    const az = (q[2] ?? 0) - (p0[2] ?? 0);
-    // |a × c| / |c|
-    const rx = ay * cz - az * cy;
-    const ry = az * cx - ax * cz;
-    const rz = ax * cy - ay * cx;
-    return Math.sqrt(rx * rx + ry * ry + rz * rz) / chord;
-  };
+  // |a × c| / |c| is the perpendicular distance from q to the chord.
+  const perpDist = (q: number[]): number =>
+    lengthVec(crossVec([q[0] - p0[0], q[1] - p0[1], (q[2] ?? 0) - (p0[2] ?? 0)], c)) / chord;
 
   return Math.max(perpDist(p1), perpDist(p2)) < LINEARITY_REL_TOL * chord;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -959,7 +959,19 @@ export {
 } from './export';
 
 // Vector math utilities
-export { scaleVec, addVec, subVec, linspace } from './utils/vectors';
+export {
+  scaleVec,
+  addVec,
+  subVec,
+  linspace,
+  dotVec,
+  crossVec,
+  lengthVec,
+  normalizeVec,
+  unitPerpendicularTo,
+  orthonormalFrame,
+  orientation2D,
+} from './utils/vectors';
 
 // Player
 export { Player, type PlayerOptions } from './player';

--- a/src/mobjects/geometry/AngleShapes.ts
+++ b/src/mobjects/geometry/AngleShapes.ts
@@ -3,6 +3,7 @@ import { VMobject } from '../../core/VMobject';
 import { Vector3Tuple } from '../../core/Mobject';
 import { BLUE, WHITE, DEFAULT_STROKE_WIDTH } from '../../constants';
 import { Line } from './Line';
+import { crossVec, dotVec, lengthVec, normalizeVec } from '../../utils/vectors';
 
 /**
  * Options for creating an Angle
@@ -141,12 +142,12 @@ export class Angle extends VMobject {
 
     this._vertex = [...vertex];
 
-    const dir1 = this._normalize3([
+    const dir1 = normalizeVec([
       point1[0] - vertex[0],
       point1[1] - vertex[1],
       point1[2] - vertex[2],
     ]);
-    const dir2 = this._normalize3([
+    const dir2 = normalizeVec([
       point2[0] - vertex[0],
       point2[1] - vertex[1],
       point2[2] - vertex[2],
@@ -154,23 +155,21 @@ export class Angle extends VMobject {
 
     let normal: Vector3Tuple;
     if (axis) {
-      const axisLen = this._length3(axis);
-      if (axisLen < 1e-10) {
+      if (lengthVec(axis) < 1e-10) {
         throw new Error('Angle: axis option must be a non-zero vector');
       }
-      normal = this._normalize3(axis);
+      normal = normalizeVec(axis);
     } else {
-      normal = this._cross3(dir1, dir2);
-      const normalLen = this._length3(normal);
+      normal = crossVec(dir1, dir2);
 
-      if (normalLen < 1e-10) {
+      if (lengthVec(normal) < 1e-10) {
         const arb: Vector3Tuple = Math.abs(dir1[0]) < 0.9 ? [1, 0, 0] : [0, 1, 0];
-        normal = this._cross3(dir1, arb);
+        normal = crossVec(dir1, arb);
         if (normal[2] < 0) {
           normal = [-normal[0], -normal[1], -normal[2]];
         }
       }
-      normal = this._normalize3(normal);
+      normal = normalizeVec(normal);
 
       if (Math.abs(dir1[2]) < 1e-10 && Math.abs(dir2[2]) < 1e-10 && normal[2] < 0) {
         normal = [-normal[0], -normal[1], -normal[2]] as Vector3Tuple;
@@ -180,22 +179,22 @@ export class Angle extends VMobject {
     // Project dir1 onto plane perpendicular to `normal` so `_u` is guaranteed
     // to lie in the reference plane even when the caller-supplied `axis` is
     // not exactly perpendicular to dir1.
-    const dir1Dot = this._dot3(dir1, normal);
+    const dir1Dot = dotVec(dir1, normal);
     let u: Vector3Tuple = [
       dir1[0] - dir1Dot * normal[0],
       dir1[1] - dir1Dot * normal[1],
       dir1[2] - dir1Dot * normal[2],
     ];
-    if (this._length3(u) < 1e-10) {
+    if (lengthVec(u) < 1e-10) {
       // dir1 parallel to normal; fall back to any perpendicular vector.
       const arb: Vector3Tuple = Math.abs(normal[0]) < 0.9 ? [1, 0, 0] : [0, 1, 0];
-      u = this._cross3(normal, arb);
+      u = crossVec(normal, arb);
     }
-    this._u = this._normalize3(u);
-    this._v = this._cross3(normal, this._u);
+    this._u = normalizeVec(u);
+    this._v = crossVec(normal, this._u);
 
-    const cosA = this._dot3(dir2, this._u);
-    const sinA = this._dot3(dir2, this._v);
+    const cosA = dotVec(dir2, this._u);
+    const sinA = dotVec(dir2, this._v);
 
     this._startAngle = 0;
     let deltaAngle = Math.atan2(sinA, cosA);
@@ -225,24 +224,6 @@ export class Angle extends VMobject {
     const dy = p2[1] - p1[1];
     const dz = p2[2] - p1[2];
     return Math.sqrt(dx * dx + dy * dy + dz * dz);
-  }
-
-  private _dot3(a: Vector3Tuple, b: Vector3Tuple): number {
-    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
-  }
-
-  private _cross3(a: Vector3Tuple, b: Vector3Tuple): Vector3Tuple {
-    return [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]];
-  }
-
-  private _length3(v: Vector3Tuple): number {
-    return Math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
-  }
-
-  private _normalize3(v: Vector3Tuple): Vector3Tuple {
-    const len = this._length3(v);
-    if (len < 1e-15) return [0, 0, 0];
-    return [v[0] / len, v[1] / len, v[2] / len];
   }
 
   private _adjustForQuadrant(

--- a/src/mobjects/geometry/CubicBezier.ts
+++ b/src/mobjects/geometry/CubicBezier.ts
@@ -1,6 +1,7 @@
 import { VMobject } from '../../core/VMobject';
 import { Vector3Tuple } from '../../core/Mobject';
 import { BLUE, DEFAULT_STROKE_WIDTH } from '../../constants';
+import { crossVec, lengthVec, normalizeVec } from '../../utils/vectors';
 
 /**
  * Control points for a cubic Bezier curve
@@ -175,15 +176,10 @@ export class CubicBezier extends VMobject {
    */
   normalizedTangentAtT(t: number): Vector3Tuple {
     const tangent = this.tangentAtT(t);
-    const length = Math.sqrt(
-      tangent[0] * tangent[0] + tangent[1] * tangent[1] + tangent[2] * tangent[2],
-    );
-
-    if (length < 1e-10) {
+    if (lengthVec(tangent) < 1e-10) {
       return [1, 0, 0]; // Default direction for degenerate case
     }
-
-    return [tangent[0] / length, tangent[1] / length, tangent[2] / length];
+    return normalizeVec(tangent);
   }
 
   /**
@@ -227,16 +223,14 @@ export class CubicBezier extends VMobject {
     const d1 = this.tangentAtT(t);
     const d2 = this.secondDerivativeAtT(t);
 
-    // Curvature = |d1 x d2| / |d1|^3
-    // For 2D (in XY plane): cross product gives scalar in Z direction
-    const crossZ = d1[0] * d2[1] - d1[1] * d2[0];
-    const d1Mag = Math.sqrt(d1[0] * d1[0] + d1[1] * d1[1] + d1[2] * d1[2]);
-
+    // Curvature = |d1 × d2| / |d1|^3. Use the full 3D cross so curves in
+    // any plane (not just XY) get the right magnitude.
+    const d1Mag = lengthVec(d1);
     if (d1Mag < 1e-10) {
       return 0;
     }
 
-    return Math.abs(crossZ) / (d1Mag * d1Mag * d1Mag);
+    return lengthVec(crossVec(d1, d2)) / (d1Mag * d1Mag * d1Mag);
   }
 
   /**
@@ -265,11 +259,11 @@ export class CubicBezier extends VMobject {
       const t = i / numSamples;
       const point = this.pointAtT(t);
 
-      const dx = point[0] - prevPoint[0];
-      const dy = point[1] - prevPoint[1];
-      const dz = point[2] - prevPoint[2];
-
-      length += Math.sqrt(dx * dx + dy * dy + dz * dz);
+      length += lengthVec([
+        point[0] - prevPoint[0],
+        point[1] - prevPoint[1],
+        point[2] - prevPoint[2],
+      ]);
       prevPoint = point;
     }
 

--- a/src/mobjects/geometry/PolygonExtensions.ts
+++ b/src/mobjects/geometry/PolygonExtensions.ts
@@ -2,6 +2,7 @@
 import { VMobject } from '../../core/VMobject';
 import { Vector3Tuple } from '../../core/Mobject';
 import { BLUE, DEFAULT_STROKE_WIDTH } from '../../constants';
+import { orientation2D } from '../../utils/vectors';
 
 /**
  * Options for creating a RoundedRectangle
@@ -983,16 +984,11 @@ export class ConvexHull extends VMobject {
     // Graham scan
     const hull: Vector3Tuple[] = [pivot];
 
-    // Cross product to determine turn direction
-    const cross = (o: Vector3Tuple, a: Vector3Tuple, b: Vector3Tuple): number => {
-      return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0]);
-    };
-
     for (const item of filtered) {
       // Remove points that make clockwise turn
       while (
         hull.length > 1 &&
-        cross(hull[hull.length - 2], hull[hull.length - 1], item.point) <= 0
+        orientation2D(hull[hull.length - 2], hull[hull.length - 1], item.point) <= 0
       ) {
         hull.pop();
       }
@@ -1104,20 +1100,15 @@ export class ConvexHull extends VMobject {
       return false;
     }
 
-    // Use cross product to check if point is on the same side of all edges
+    // Same-side test via the 2D orientation predicate.
     const n = this._hullVertices.length;
 
     for (let i = 0; i < n; i++) {
       const j = (i + 1) % n;
-      const edge = [
-        this._hullVertices[j][0] - this._hullVertices[i][0],
-        this._hullVertices[j][1] - this._hullVertices[i][1],
-      ];
-      const toPoint = [point[0] - this._hullVertices[i][0], point[1] - this._hullVertices[i][1]];
-      const cross = edge[0] * toPoint[1] - edge[1] * toPoint[0];
-
-      // If the point is on the right side of any edge, it's outside
-      if (cross < 0) {
+      // orientation2D(vi, vj, point) > 0 means `point` is CCW of edge vi→vj.
+      // Hull is CCW (Graham scan above), so a negative value means `point`
+      // is on the outside.
+      if (orientation2D(this._hullVertices[i], this._hullVertices[j], point) < 0) {
         return false;
       }
     }

--- a/src/mobjects/geometry/geometry-extra.test.ts
+++ b/src/mobjects/geometry/geometry-extra.test.ts
@@ -372,6 +372,34 @@ describe('CubicBezier', () => {
     expect(straight.curvatureAtT(0.5)).toBeCloseTo(0, 10);
   });
 
+  // Regression for issue #340: the old 2D-only formula
+  // `|d1[0]*d2[1] - d1[1]*d2[0]| / |d1|^3` ignored the X/Y components of
+  // the 3D cross product, so the same curve rotated out of XY returned the
+  // wrong curvature. With the 3D cross both should agree.
+  it('curvatureAtT is invariant under rotation into the XZ plane', () => {
+    const xy = new CubicBezier({
+      points: [
+        [0, 0, 0],
+        [1, 1, 0],
+        [2, 1, 0],
+        [3, 0, 0],
+      ],
+    });
+    const xz = new CubicBezier({
+      points: [
+        [0, 0, 0],
+        [1, 0, 1],
+        [2, 0, 1],
+        [3, 0, 0],
+      ],
+    });
+    for (const t of [0.1, 0.25, 0.5, 0.75, 0.9]) {
+      expect(xz.curvatureAtT(t)).toBeCloseTo(xy.curvatureAtT(t), 10);
+    }
+    // And both should be nonzero (the curve is genuinely curved).
+    expect(xz.curvatureAtT(0.5)).toBeGreaterThan(0);
+  });
+
   it('getApproximateLength for straight line equals 3', () => {
     const straight = new CubicBezier({
       points: [

--- a/src/mobjects/graphing/Vector.ts
+++ b/src/mobjects/graphing/Vector.ts
@@ -1,5 +1,6 @@
 import { Vector3Tuple } from '../../core/Mobject';
 import { Arrow } from '../geometry';
+import { crossVec, dotVec, lengthVec } from '../../utils/vectors';
 
 /**
  * Options for creating a VectorFieldVector
@@ -61,9 +62,7 @@ export class VectorFieldVector extends Arrow {
     } = options;
 
     // Calculate the actual direction vector
-    const dirLength = Math.sqrt(
-      direction[0] * direction[0] + direction[1] * direction[1] + direction[2] * direction[2],
-    );
+    const dirLength = lengthVec(direction);
 
     // Apply max length constraint
     let scaledDirection = [...direction] as Vector3Tuple;
@@ -112,9 +111,7 @@ export class VectorFieldVector extends Arrow {
     this._direction = [...direction];
 
     // Recalculate length
-    const dirLength = Math.sqrt(
-      direction[0] * direction[0] + direction[1] * direction[1] + direction[2] * direction[2],
-    );
+    const dirLength = lengthVec(direction);
 
     // Apply max length constraint
     let scaledDirection = [...direction] as Vector3Tuple;
@@ -144,11 +141,7 @@ export class VectorFieldVector extends Arrow {
    * Get the magnitude (length) of the vector
    */
   getMagnitude(): number {
-    return Math.sqrt(
-      this._direction[0] * this._direction[0] +
-        this._direction[1] * this._direction[1] +
-        this._direction[2] * this._direction[2],
-    );
+    return lengthVec(this._direction);
   }
 
   /**
@@ -258,7 +251,7 @@ export class VectorFieldVector extends Arrow {
    */
   dot(other: VectorFieldVector | Vector3Tuple): number {
     const dir = Array.isArray(other) ? other : other.getDirection();
-    return this._direction[0] * dir[0] + this._direction[1] * dir[1] + this._direction[2] * dir[2];
+    return dotVec(this._direction, dir);
   }
 
   /**
@@ -266,11 +259,7 @@ export class VectorFieldVector extends Arrow {
    */
   cross(other: VectorFieldVector | Vector3Tuple): Vector3Tuple {
     const dir = Array.isArray(other) ? other : other.getDirection();
-    return [
-      this._direction[1] * dir[2] - this._direction[2] * dir[1],
-      this._direction[2] * dir[0] - this._direction[0] * dir[2],
-      this._direction[0] * dir[1] - this._direction[1] * dir[0],
-    ];
+    return crossVec(this._direction, dir);
   }
 
   /**

--- a/src/utils/math.test.ts
+++ b/src/utils/math.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { lerp, lerpPoint, smoothstep, coordsToPoint, pointToCoords, evalCubicBezier } from './math';
+import {
+  lerp,
+  lerpPoint,
+  smoothstep,
+  coordsToPoint,
+  pointToCoords,
+  evalCubicBezier,
+  orthonormalizeBasis,
+} from './math';
+import { dotVec, lengthVec } from './vectors';
 
 describe('lerp', () => {
   it('returns a at t=0', () => {
@@ -151,5 +160,35 @@ describe('evalCubicBezier', () => {
     // At t=0.5, should be roughly on the unit circle arc
     const dist = Math.sqrt(mid[0] * mid[0] + mid[1] * mid[1]);
     expect(dist).toBeCloseTo(1, 2);
+  });
+});
+
+describe('orthonormalizeBasis', () => {
+  it('returns orthonormal basis for two non-parallel vectors', () => {
+    const { v1, v2 } = orthonormalizeBasis([2, 0, 0], [1, 3, 0]);
+    expect(lengthVec(v1)).toBeCloseTo(1, 10);
+    expect(lengthVec(v2)).toBeCloseTo(1, 10);
+    expect(Math.abs(dotVec(v1, v2))).toBeLessThan(1e-10);
+  });
+
+  // Regression: when v1 and v2 are collinear (or v2 is zero), the fallback
+  // must pick a v2 that lies in the SAME plane as the input geometry — not
+  // an arbitrary world basis. YZ-plane shapes used to silently project onto
+  // X if the fallback picked the world axis with the smallest |dot|.
+  it('collinear fallback for a YZ-plane v1 stays in the YZ plane', () => {
+    const { v1, v2 } = orthonormalizeBasis([0, 1, 1], [0, 0, 0]);
+    expect(lengthVec(v1)).toBeCloseTo(1, 10);
+    expect(lengthVec(v2)).toBeCloseTo(1, 10);
+    expect(Math.abs(dotVec(v1, v2))).toBeLessThan(1e-10);
+    // v2 must have no X component — i.e. it lives in the YZ plane that the
+    // caller's geometry actually occupies.
+    expect(Math.abs(v2[0])).toBeLessThan(1e-10);
+  });
+
+  it('collinear fallback for a Z-aligned v1 picks an X-axis v2', () => {
+    const { v2 } = orthonormalizeBasis([0, 0, 1], [0, 0, 2]);
+    // |u1[2]| ≥ 0.9 → fallback flips to the [1,0,0] world basis.
+    expect(Math.abs(v2[0])).toBeCloseTo(1, 10);
+    expect(Math.abs(v2[2])).toBeLessThan(1e-10);
   });
 });

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,6 +1,12 @@
 /**
  * Shared math utility functions used across the codebase.
+ *
+ * For low-level 3-vector ops (dot, cross, length, normalize, perpendicular,
+ * orthonormal frame, 2D orientation), prefer `src/utils/vectors.ts`. The
+ * helpers in this file build on top of that module.
  */
+
+import { dotVec, lengthVec, normalizeVec } from './vectors';
 
 /**
  * Linear interpolation between two numbers.
@@ -235,13 +241,12 @@ export function projectToPlane(
   v1: number[],
   v2: number[],
 ): [number, number] {
-  const dx = point[0] - origin[0];
-  const dy = point[1] - origin[1];
-  const dz = (point[2] ?? 0) - (origin[2] ?? 0);
-  // Dot products with basis vectors
-  const u = dx * v1[0] + dy * v1[1] + dz * v1[2];
-  const v = dx * v2[0] + dy * v2[1] + dz * v2[2];
-  return [u, v];
+  const d: [number, number, number] = [
+    point[0] - origin[0],
+    point[1] - origin[1],
+    (point[2] ?? 0) - (origin[2] ?? 0),
+  ];
+  return [dotVec(d, v1), dotVec(d, v2)];
 }
 
 /**
@@ -257,25 +262,31 @@ export function orthonormalizeBasis(
   v1: number[];
   v2: number[];
 } {
-  const len1 = Math.sqrt(v1[0] ** 2 + v1[1] ** 2 + v1[2] ** 2);
-  if (len1 < 1e-10) {
+  if (lengthVec(v1) < 1e-10) {
     return { v1: [1, 0, 0], v2: [0, 1, 0] };
   }
-  const u1 = [v1[0] / len1, v1[1] / len1, v1[2] / len1];
+  const u1 = normalizeVec(v1);
 
-  // v2' = v2 - (v2·u1) * u1
-  const dot = v2[0] * u1[0] + v2[1] * u1[1] + v2[2] * u1[2];
-  const v2p = [v2[0] - dot * u1[0], v2[1] - dot * u1[1], v2[2] - dot * u1[2]];
+  // v2' = v2 − (v2·u1) * u1
+  const d = dotVec(v2, u1);
+  const v2p: [number, number, number] = [
+    v2[0] - d * u1[0],
+    v2[1] - d * u1[1],
+    (v2[2] ?? 0) - d * u1[2],
+  ];
 
-  const len2 = Math.sqrt(v2p[0] ** 2 + v2p[1] ** 2 + v2p[2] ** 2);
-  if (len2 < 1e-10) {
-    // v1 and v2 were collinear, pick perpendicular
+  if (lengthVec(v2p) < 1e-10) {
+    // v1 and v2 collinear. Pick a world basis vector that is NOT close to
+    // u1, then Gram–Schmidt against u1. The Z-biased choice below is the
+    // pre-existing behaviour; many callers rely on the fallback landing in
+    // the same plane the geometry actually lies in, so this is intentionally
+    // not routed through `unitPerpendicularTo` (which would pick the world
+    // basis vector with the smallest |dot|, e.g. X for a YZ-plane input).
     const perp = Math.abs(u1[2]) < 0.9 ? [0, 0, 1] : [1, 0, 0];
-    const perpDot = perp[0] * u1[0] + perp[1] * u1[1] + perp[2] * u1[2];
+    const perpDot = dotVec(perp, u1);
     const u2 = [perp[0] - perpDot * u1[0], perp[1] - perpDot * u1[1], perp[2] - perpDot * u1[2]];
-    const u2len = Math.sqrt(u2[0] ** 2 + u2[1] ** 2 + u2[2] ** 2);
-    return { v1: u1, v2: [u2[0] / u2len, u2[1] / u2len, u2[2] / u2len] };
+    return { v1: u1, v2: normalizeVec(u2) };
   }
 
-  return { v1: u1, v2: [v2p[0] / len2, v2p[1] / len2, v2p[2] / len2] };
+  return { v1: u1, v2: normalizeVec(v2p) };
 }

--- a/src/utils/vectors.test.ts
+++ b/src/utils/vectors.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { scaleVec, addVec, subVec, linspace } from './vectors';
+import {
+  scaleVec,
+  addVec,
+  subVec,
+  linspace,
+  dotVec,
+  crossVec,
+  lengthVec,
+  normalizeVec,
+  unitPerpendicularTo,
+  orthonormalFrame,
+  orientation2D,
+} from './vectors';
 
 describe('scaleVec', () => {
   it('scales a vector by a positive scalar', () => {
@@ -94,5 +106,143 @@ describe('linspace', () => {
 
   it('two points returns start and stop', () => {
     expect(linspace(0, 1, 2)).toEqual([0, 1]);
+  });
+});
+
+describe('dotVec', () => {
+  it('orthogonal vectors → 0', () => {
+    expect(dotVec([1, 0, 0], [0, 1, 0])).toBe(0);
+    expect(dotVec([1, 0, 0], [0, 0, 1])).toBe(0);
+  });
+
+  it('parallel vectors → product of magnitudes', () => {
+    expect(dotVec([2, 0, 0], [3, 0, 0])).toBe(6);
+  });
+
+  it('general 3D', () => {
+    expect(dotVec([1, 2, 3], [4, -5, 6])).toBe(4 - 10 + 18);
+  });
+
+  it('treats missing z as 0', () => {
+    expect(dotVec([1, 2], [3, 4])).toBe(11);
+  });
+});
+
+describe('crossVec', () => {
+  it('e_x × e_y = e_z', () => {
+    expect(crossVec([1, 0, 0], [0, 1, 0])).toEqual([0, 0, 1]);
+  });
+  it('e_y × e_z = e_x', () => {
+    expect(crossVec([0, 1, 0], [0, 0, 1])).toEqual([1, 0, 0]);
+  });
+  it('e_z × e_x = e_y', () => {
+    expect(crossVec([0, 0, 1], [1, 0, 0])).toEqual([0, 1, 0]);
+  });
+  it('parallel vectors give zero', () => {
+    expect(crossVec([1, 2, 3], [2, 4, 6])).toEqual([0, 0, 0]);
+  });
+  it('anticommutative: a × b = −(b × a)', () => {
+    const ab = crossVec([1, 2, 3], [4, 5, 6]);
+    const ba = crossVec([4, 5, 6], [1, 2, 3]);
+    expect(ab).toEqual([-ba[0], -ba[1], -ba[2]]);
+  });
+});
+
+describe('lengthVec', () => {
+  it('axis-aligned', () => {
+    expect(lengthVec([3, 0, 0])).toBe(3);
+  });
+  it('3-4-5 triangle in XY', () => {
+    expect(lengthVec([3, 4, 0])).toBe(5);
+  });
+  it('treats missing components as 0', () => {
+    expect(lengthVec([5])).toBe(5);
+  });
+});
+
+describe('normalizeVec', () => {
+  it('produces unit length', () => {
+    const n = normalizeVec([3, 4, 0]);
+    expect(lengthVec(n)).toBeCloseTo(1, 12);
+    expect(n[0]).toBeCloseTo(0.6, 12);
+    expect(n[1]).toBeCloseTo(0.8, 12);
+  });
+  it('returns fallback for zero vector', () => {
+    expect(normalizeVec([0, 0, 0])).toEqual([0, 0, 0]);
+    expect(normalizeVec([0, 0, 0], [1, 0, 0])).toEqual([1, 0, 0]);
+  });
+});
+
+describe('unitPerpendicularTo', () => {
+  it.each([
+    ['X axis', [1, 0, 0] as [number, number, number]],
+    ['Y axis', [0, 1, 0] as [number, number, number]],
+    ['Z axis', [0, 0, 1] as [number, number, number]],
+    ['diagonal', normalizeVec([1, 1, 1])],
+    ['XY diagonal', normalizeVec([1, 1, 0])],
+  ])('orthogonal unit vector for %s', (_, n) => {
+    const p = unitPerpendicularTo(n);
+    expect(lengthVec(p)).toBeCloseTo(1, 10);
+    expect(Math.abs(dotVec(p, n))).toBeLessThan(1e-10);
+  });
+
+  it.each([
+    [[2, 2, 1] as [number, number, number]],
+    [[10, 0, 0] as [number, number, number]],
+    [[3, -4, 5] as [number, number, number]],
+  ])('still orthogonal for non-unit input %j', (n) => {
+    const p = unitPerpendicularTo(n);
+    expect(lengthVec(p)).toBeCloseTo(1, 10);
+    // Dot with original (non-unit) input must vanish — orthogonality is
+    // independent of magnitude.
+    expect(Math.abs(dotVec(p, n))).toBeLessThan(1e-10);
+  });
+});
+
+describe('orthonormalFrame', () => {
+  it.each([
+    ['X axis', [1, 0, 0] as [number, number, number]],
+    ['Y axis', [0, 1, 0] as [number, number, number]],
+    ['Z axis', [0, 0, 1] as [number, number, number]],
+    ['arbitrary', [0.3, -0.7, 0.5] as [number, number, number]],
+  ])('returns a right-handed orthonormal frame for %s', (_, normal) => {
+    const { u, v, n } = orthonormalFrame(normal);
+    expect(lengthVec(u)).toBeCloseTo(1, 10);
+    expect(lengthVec(v)).toBeCloseTo(1, 10);
+    expect(lengthVec(n)).toBeCloseTo(1, 10);
+    expect(Math.abs(dotVec(u, v))).toBeLessThan(1e-10);
+    expect(Math.abs(dotVec(v, n))).toBeLessThan(1e-10);
+    expect(Math.abs(dotVec(u, n))).toBeLessThan(1e-10);
+    // u × v should equal n (right-handed)
+    const uv = crossVec(u, v);
+    expect(uv[0]).toBeCloseTo(n[0], 10);
+    expect(uv[1]).toBeCloseTo(n[1], 10);
+    expect(uv[2]).toBeCloseTo(n[2], 10);
+  });
+
+  it('no Z-axis special case — frame size and properties invariant under axis choice', () => {
+    // All three world axes get a *consistent* orthonormal frame, not
+    // anything specific to Z.
+    const fx = orthonormalFrame([1, 0, 0]);
+    const fy = orthonormalFrame([0, 1, 0]);
+    const fz = orthonormalFrame([0, 0, 1]);
+    expect(lengthVec(fx.u)).toBeCloseTo(1, 10);
+    expect(lengthVec(fy.u)).toBeCloseTo(1, 10);
+    expect(lengthVec(fz.u)).toBeCloseTo(1, 10);
+  });
+});
+
+describe('orientation2D', () => {
+  it('CCW turn is positive', () => {
+    expect(orientation2D([0, 0], [1, 0], [1, 1])).toBeGreaterThan(0);
+  });
+  it('CW turn is negative', () => {
+    expect(orientation2D([0, 0], [1, 0], [1, -1])).toBeLessThan(0);
+  });
+  it('collinear is zero', () => {
+    expect(orientation2D([0, 0], [1, 1], [2, 2])).toBe(0);
+  });
+  it('ignores z component', () => {
+    expect(orientation2D([0, 0, 5], [1, 0, -3], [1, 1, 100])).toBeGreaterThan(0);
   });
 });

--- a/src/utils/vectors.ts
+++ b/src/utils/vectors.ts
@@ -10,7 +10,7 @@
  * `linspace`) which the Python → TypeScript converter emits.
  */
 
-import type { Vector3Tuple } from '../core/Mobject';
+import type { Vector3Tuple } from '../core/MobjectTypes';
 
 /**
  * Scale a direction vector by a scalar.

--- a/src/utils/vectors.ts
+++ b/src/utils/vectors.ts
@@ -1,9 +1,13 @@
 /**
- * Vector math utilities for py2ts-generated code.
+ * 3D vector and basic geometry helpers.
  *
- * These helper functions are used by the py2ts converter to translate
- * Python vector arithmetic (e.g., `2 * LEFT + 1.5 * UP`) into
- * TypeScript calls (`addVec(scaleVec(2, LEFT), scaleVec(1.5, UP))`).
+ * This module is the single source of truth for low-level 3-vector math
+ * (dot, cross, length, normalize, perpendicular, orthonormal frame). Every
+ * call site in the codebase should use these helpers instead of inlining
+ * component arithmetic — see AGENTS.md > "Geometry conventions".
+ *
+ * Also re-exports a few py2ts-era helpers (`addVec`, `subVec`, `scaleVec`,
+ * `linspace`) which the Python → TypeScript converter emits.
  */
 
 import type { Vector3Tuple } from '../core/Mobject';
@@ -63,6 +67,120 @@ export function addVec(...vecs: Vector3Tuple[]): Vector3Tuple {
  */
 export function subVec(a: Vector3Tuple, b: Vector3Tuple): Vector3Tuple {
   return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+/**
+ * 3D dot product (a · b). Accepts plain number arrays so callers that use
+ * `number[]` (e.g. internal helpers in `math.ts`) can share the same impl.
+ *
+ * Missing components default to `0` so 2D points (`[x, y]`) are handled.
+ */
+export function dotVec(a: ArrayLike<number>, b: ArrayLike<number>): number {
+  return (a[0] ?? 0) * (b[0] ?? 0) + (a[1] ?? 0) * (b[1] ?? 0) + (a[2] ?? 0) * (b[2] ?? 0);
+}
+
+/**
+ * 3D cross product (a × b). Right-handed:
+ *   x = a.y*b.z − a.z*b.y, y = a.z*b.x − a.x*b.z, z = a.x*b.y − a.y*b.x.
+ */
+export function crossVec(a: ArrayLike<number>, b: ArrayLike<number>): Vector3Tuple {
+  const ax = a[0] ?? 0;
+  const ay = a[1] ?? 0;
+  const az = a[2] ?? 0;
+  const bx = b[0] ?? 0;
+  const by = b[1] ?? 0;
+  const bz = b[2] ?? 0;
+  return [ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx];
+}
+
+/**
+ * Euclidean length |v|. Missing components default to `0`.
+ */
+export function lengthVec(v: ArrayLike<number>): number {
+  const x = v[0] ?? 0;
+  const y = v[1] ?? 0;
+  const z = v[2] ?? 0;
+  return Math.sqrt(x * x + y * y + z * z);
+}
+
+/**
+ * Return `v` normalised to unit length. If `|v|` is below `eps` the supplied
+ * `fallback` is returned (default `[0, 0, 0]`); the caller decides whether to
+ * treat that as an error.
+ */
+export function normalizeVec(
+  v: ArrayLike<number>,
+  fallback: Vector3Tuple = [0, 0, 0],
+  eps = 1e-15,
+): Vector3Tuple {
+  const len = lengthVec(v);
+  if (len < eps) return fallback;
+  return [(v[0] ?? 0) / len, (v[1] ?? 0) / len, (v[2] ?? 0) / len];
+}
+
+/**
+ * Return a unit vector perpendicular to `n`.
+ *
+ * Picked by Gram–Schmidt against whichever world basis vector has the
+ * smallest |dot(n, e_i)|, then normalized. This is coordinate-free in
+ * spirit — it never uses a hard "is the input close to Z?" branch — but it
+ * does pick from the world basis, so the result can change discontinuously
+ * very near a tie. Treat as "give me *some* perpendicular unit vector"
+ * rather than a temporally-stable frame.
+ */
+export function unitPerpendicularTo(n: Vector3Tuple, eps = 1e-12): Vector3Tuple {
+  // Normalize first so the projection-removal step below
+  // (`basis - (basis·u) u`) is correct regardless of the input's magnitude.
+  const u = normalizeVec(n, [1, 0, 0], eps);
+
+  const ax = Math.abs(u[0]);
+  const ay = Math.abs(u[1]);
+  const az = Math.abs(u[2]);
+
+  let basis: Vector3Tuple;
+  if (ax <= ay && ax <= az) basis = [1, 0, 0];
+  else if (ay <= az) basis = [0, 1, 0];
+  else basis = [0, 0, 1];
+
+  const d = dotVec(basis, u);
+  const p: Vector3Tuple = [basis[0] - d * u[0], basis[1] - d * u[1], basis[2] - d * u[2]];
+  return normalizeVec(p, [0, 0, 1], eps);
+}
+
+/**
+ * Build a right-handed orthonormal frame `{u, v, n}` around the given
+ * normal. `n` is normalised; `u = unitPerpendicularTo(n)`; `v = n × u`.
+ *
+ * Use this instead of writing axis-equal-to-Z special cases in caller code.
+ */
+export function orthonormalFrame(normal: Vector3Tuple): {
+  u: Vector3Tuple;
+  v: Vector3Tuple;
+  n: Vector3Tuple;
+} {
+  const n = normalizeVec(normal, [0, 0, 1]);
+  const u = unitPerpendicularTo(n);
+  const v = crossVec(n, u);
+  return { u, v, n };
+}
+
+/**
+ * 2D orientation predicate (signed twice-area of triangle o-a-b).
+ * Positive: counter-clockwise. Negative: clockwise. Zero: collinear.
+ *
+ * Mathematically this is the z-component of the cross product of
+ * (a-o) and (b-o) — kept as its own helper because it is an orientation
+ * test, not a general vector operation.
+ */
+export function orientation2D(
+  o: ArrayLike<number>,
+  a: ArrayLike<number>,
+  b: ArrayLike<number>,
+): number {
+  return (
+    ((a[0] ?? 0) - (o[0] ?? 0)) * ((b[1] ?? 0) - (o[1] ?? 0)) -
+    ((a[1] ?? 0) - (o[1] ?? 0)) * ((b[0] ?? 0) - (o[0] ?? 0))
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
Refactor for #340: consolidate every inline cross-product, dot-product, length and normalize in `src/utils/vectors.ts`. Also routes the same-spirit helpers in `src/utils/math.ts` (`projectToPlane`, `orthonormalizeBasis`) through the new utilities, fixes `CubicBezier.curvatureAtT` for curves outside the XY plane, and adds a "Geometry conventions" section to `AGENTS.md` so the duplication doesn't grow back.

## Changes
- `src/utils/vectors.ts`: new `dotVec`, `crossVec`, `lengthVec`, `normalizeVec`, `unitPerpendicularTo`, `orthonormalFrame`, `orientation2D` helpers (`unitPerpendicularTo` normalizes its input internally so it's safe for non-unit vectors).
- Migrated call sites:
  - `Angle` (`src/mobjects/geometry/AngleShapes.ts`): four private `_cross3/_dot3/_length3/_normalize3` deleted; semantics preserved.
  - `VectorFieldVector.dot()` / `.cross()` (`src/mobjects/graphing/Vector.ts`): same public API, body delegates to the helpers; also drops three inlined magnitudes in `getMagnitude` / `setDirection` / constructor.
  - `CubicBezier` (`src/mobjects/geometry/CubicBezier.ts`): `curvatureAtT` now uses the full 3D cross; was wrong whenever `d1 × d2` had nonzero X or Y components (i.e. any curve not lying in XY). `normalizedTangentAtT` and `getApproximateLength` also routed through the helpers.
  - `ConvexHull` (`src/mobjects/geometry/PolygonExtensions.ts`): Graham scan turn-direction and `containsPoint` use the new `orientation2D` predicate.
  - `VMobjectGeometry.isNearlyLinear`: uses `crossVec` / `lengthVec` for the perpendicular-distance check.
  - `src/utils/math.ts`: `projectToPlane` uses `dotVec`; `orthonormalizeBasis` uses `lengthVec` / `dotVec` / `normalizeVec`. The legacy Z-biased fallback for its collinear-input branch is preserved deliberately (see AGENTS.md note + the new regression test in `math.test.ts`) — `selectScatteredPoints` can pick triples that include a closing duplicate, which would otherwise project YZ-plane geometry onto X.
- `src/index.ts`: exports the new helpers.
- `AGENTS.md`: new "Geometry conventions" section: prefer the shared helpers, no axis-equal-to-Z special cases, no plane-in-special-configuration shortcuts, prefer vector/matrix products. Includes the explicit exception note for the `orthonormalizeBasis` fallback.

## Tests
- `src/utils/vectors.test.ts`: numeric checks for the new helpers; explicit non-unit-input cases for `unitPerpendicularTo`; right-handed / orthonormal / no-Z-special-case checks for `orthonormalFrame`; CCW/CW/collinear cases for `orientation2D`.
- `src/utils/math.test.ts`: regression for `orthonormalizeBasis` — YZ-plane input must yield a `v2` that lives in the YZ plane (not X), plus the Z-aligned input case.
- `src/mobjects/geometry/geometry-extra.test.ts`: 3D-curvature regression for `CubicBezier` — same curve rotated from XY into XZ must return the same curvature at every sample (it didn't, before this change).

## Testing
- [x] Tests pass (`npm test`) — 5969 passed, 0 failed (was 5963 before).
- [x] Lint passes (`npm run lint`).
- [x] Types check (`npm run typecheck`).
- [x] Format check (`npm run format:check`).
- [x] Build (`npm run build`) — no new warnings.
- [x] Visual smoke: opened `three_d_angle`, `moving_angle`, `vector_arrow` examples in a browser via the dev server — canvases render, no console errors.

## Related Issues
Closes #340
