### PR TITLE
feat(#342): customizable PolarPlane angle/radius labels

### DIFF
--- a/docs/docs/examples/graphing.mdx
+++ b/docs/docs/examples/graphing.mdx
@@ -11,6 +11,7 @@ import HeatDiagramPlotExample from '@site/src/components/examples/HeatDiagramPlo
 import FollowingGraphCameraExample from '@site/src/components/examples/FollowingGraphCameraExample';
 import MovingZoomedSceneAroundExample from '@site/src/components/examples/MovingZoomedSceneAroundExample';
 import StreamLinesContinuousMotionExample from '@site/src/components/examples/StreamLinesContinuousMotionExample';
+import PolarPlaneCustomLabelsExample from '@site/src/components/examples/PolarPlaneCustomLabelsExample';
 
 Coordinate systems, function plotting, and data visualization examples.
 
@@ -559,9 +560,9 @@ scene.add(streamLines);
 
 // Start continuous flowing animation
 streamLines.startAnimation({
-  warmUp: true,     // randomize initial phases
-  flowSpeed: 1.5,   // speed multiplier
-  timeWidth: 0.3,   // visible window fraction
+  warmUp: true, // randomize initial phases
+  flowSpeed: 1.5, // speed multiplier
+  timeWidth: 0.3, // visible window fraction
 });
 
 await scene.wait(10);
@@ -573,3 +574,62 @@ streamLines.endAnimation();
 </details>
 
 **Learn More:** [**StreamLines**](/api/classes/StreamLines) · [**NumberPlane**](/api/classes/NumberPlane)
+
+---
+
+## Polar Plane with Custom Labels
+
+Renders a `PolarPlane` with custom τ-based angle labels and `r₁/r₂/r₃` radius labels.
+The `angleLabels` and `radiusLabels` options accept arrays of `string` (rendered as `Text`)
+or pre-built `Mobject` instances (used as-is — useful for `MathTex` / LaTeX rendering).
+Array length must match `angularDivisions` / `radialDivisions`.
+
+<PolarPlaneCustomLabelsExample />
+
+<details>
+<summary>Source Code</summary>
+
+```typescript
+import { Scene, PolarPlane, MathTex, BLACK } from 'manim-web';
+
+const scene = new Scene(document.getElementById('container'), {
+  width: 600,
+  height: 600,
+  backgroundColor: BLACK,
+});
+
+const angleLatex = [
+  '0',
+  '\\tau/12',
+  '\\tau/6',
+  '\\tau/4',
+  '\\tau/3',
+  '5\\tau/12',
+  '\\tau/2',
+  '7\\tau/12',
+  '2\\tau/3',
+  '3\\tau/4',
+  '5\\tau/6',
+  '11\\tau/12',
+];
+const angleLabels = angleLatex.map((latex) => new MathTex({ latex, fontSize: 28 }));
+const radiusLabels = ['r_1', 'r_2', 'r_3'].map((latex) => new MathTex({ latex, fontSize: 24 }));
+
+// Wait for LaTeX rendering so PolarPlane can place labels using real glyph bounds.
+await Promise.all([...angleLabels, ...radiusLabels].map((l) => l.waitForRender()));
+
+scene.add(
+  new PolarPlane({
+    radius: 3,
+    size: 6,
+    angularDivisions: 12,
+    radialDivisions: 3,
+    angleLabels,
+    radiusLabels,
+  }),
+);
+```
+
+</details>
+
+**Learn More:** [**PolarPlane**](/api/classes/PolarPlane) · [**MathTex**](/api/classes/MathTex)

--- a/docs/src/components/examples/PolarPlaneCustomLabelsExample.tsx
+++ b/docs/src/components/examples/PolarPlaneCustomLabelsExample.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import ManimExample from '../ManimExample';
+
+async function animate(scene: any) {
+  const { PolarPlane, MathTex } = await import('manim-web');
+
+  // Build MathTex labels for τ-based angles and r₁/r₂/r₃ radii.
+  // Wait for LaTeX to render before passing them to PolarPlane so
+  // that the plane's positioning math has real glyph bounds.
+  const angleLatex = [
+    '0',
+    '\\tau/12',
+    '\\tau/6',
+    '\\tau/4',
+    '\\tau/3',
+    '5\\tau/12',
+    '\\tau/2',
+    '7\\tau/12',
+    '2\\tau/3',
+    '3\\tau/4',
+    '5\\tau/6',
+    '11\\tau/12',
+  ];
+  const angleLabels = angleLatex.map((latex) => new MathTex({ latex, fontSize: 28 }));
+  const radiusLabels = ['r_1', 'r_2', 'r_3'].map((latex) => new MathTex({ latex, fontSize: 24 }));
+  await Promise.all([...angleLabels, ...radiusLabels].map((l) => l.waitForRender()));
+
+  const plane = new PolarPlane({
+    radius: 3,
+    size: 6,
+    angularDivisions: 12,
+    radialDivisions: 3,
+    angleLabels,
+    radiusLabels,
+  });
+  scene.add(plane);
+  await scene.wait(1);
+}
+
+export default function PolarPlaneCustomLabelsExample() {
+  return <ManimExample animationFn={animate} />;
+}

--- a/examples/polar_plane_custom_labels.html
+++ b/examples/polar_plane_custom_labels.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ManimWeb - PolarPlane Custom Labels (issue #342)</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: #1a1a2e;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        min-height: 100vh;
+        font-family: system-ui, sans-serif;
+        gap: 16px;
+        padding: 24px;
+      }
+      .row {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        justify-content: center;
+      }
+      .panel {
+        border: 2px solid #333;
+        border-radius: 8px;
+        overflow: hidden;
+        padding: 8px;
+        background: #0f0f1a;
+      }
+      .panel h2 {
+        color: #eee;
+        font-size: 14px;
+        margin-bottom: 6px;
+        text-align: center;
+      }
+      h1 {
+        color: #eee;
+        font-size: 22px;
+      }
+      p {
+        color: #aaa;
+        font-size: 13px;
+        text-align: center;
+        max-width: 800px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>PolarPlane custom labels</h1>
+    <p>
+      Left: default (π-based) labels. Middle: compass-string overrides (rendered as Text).
+      Right: tauist (τ) MathTex overrides (pre-built MathTex mobjects). Demonstrates
+      issue #342 — strings or pre-built Mobjects can be passed as
+      <code>angleLabels</code>/<code>radiusLabels</code>.
+    </p>
+
+    <div class="row">
+      <div class="panel">
+        <h2>default</h2>
+        <div id="c-default"></div>
+      </div>
+      <div class="panel">
+        <h2>compass</h2>
+        <div id="c-compass"></div>
+      </div>
+      <div class="panel">
+        <h2>τ (tauist) + custom radii</h2>
+        <div id="c-tau"></div>
+      </div>
+    </div>
+
+    <script type="module">
+      import { Scene, PolarPlane, MathTex, BLACK } from '../src/index.ts';
+
+      const W = 380,
+        H = 380;
+
+      // 1) Default polar plane — pi/6, pi/4 etc.
+      const sDefault = new Scene(document.getElementById('c-default'), {
+        width: W,
+        height: H,
+        backgroundColor: BLACK,
+      });
+      sDefault.add(new PolarPlane({ radius: 3, size: 5, angularDivisions: 12 }));
+
+      // 2) Compass overrides — strings rendered via Text.
+      const sCompass = new Scene(document.getElementById('c-compass'), {
+        width: W,
+        height: H,
+        backgroundColor: BLACK,
+      });
+      sCompass.add(
+        new PolarPlane({
+          radius: 3,
+          size: 5,
+          angularDivisions: 4,
+          radialDivisions: 3,
+          angleLabels: ['E', 'N', 'W', 'S'],
+          radiusLabels: ['1u', '2u', '3u'],
+        }),
+      );
+
+      // 3) tauist (τ) overrides via MathTex — pre-built MathTex mobjects
+      //    are used as-is (caller owns LaTeX styling), positioned by the
+      //    plane, and reparented into the angle/radius label groups.
+      const sTau = new Scene(document.getElementById('c-tau'), {
+        width: W,
+        height: H,
+        backgroundColor: BLACK,
+      });
+      const tauAngleLatex = [
+        '0',
+        '\\tau/12',
+        '\\tau/6',
+        '\\tau/4',
+        '\\tau/3',
+        '5\\tau/12',
+        '\\tau/2',
+        '7\\tau/12',
+        '2\\tau/3',
+        '3\\tau/4',
+        '5\\tau/6',
+        '11\\tau/12',
+      ];
+      const tauAngleLabels = tauAngleLatex.map((latex) => new MathTex({ latex, fontSize: 28 }));
+      const tauRadiusLabels = ['r_1', 'r_2', 'r_3'].map(
+        (latex) => new MathTex({ latex, fontSize: 24 }),
+      );
+      // Wait for LaTeX to render before letting PolarPlane position the
+      // labels — `moveTo` needs real bounds to compute placement.
+      await Promise.all([...tauAngleLabels, ...tauRadiusLabels].map((l) => l.waitForRender()));
+      sTau.add(
+        new PolarPlane({
+          radius: 3,
+          size: 5,
+          angularDivisions: 12,
+          radialDivisions: 3,
+          angleLabels: tauAngleLabels,
+          radiusLabels: tauRadiusLabels,
+        }),
+      );
+    </script>
+  </body>
+</html>

--- a/src/mobjects/graphing/ComplexPlane.ts
+++ b/src/mobjects/graphing/ComplexPlane.ts
@@ -508,6 +508,26 @@ export interface PolarPlaneOptions {
   labelColor?: string;
   /** Azimuth offset angle in radians (0 = right). Default: 0 */
   azimuthOffset?: number;
+  /**
+   * Custom angle labels. Length must equal {@link angularDivisions}.
+   * - `string` entries render via {@link Text} with `labelFontSize` / `labelColor`.
+   * - `Mobject` entries are used as-is (caller owns styling); they are positioned
+   *   by the plane and reparented into the angle-labels group.
+   *
+   * Entries are placed in division order starting at `azimuthOffset` and rotating
+   * counter-clockwise — index 0 is the first division, not a fixed compass point.
+   */
+  angleLabels?: (string | Mobject)[];
+  /**
+   * Custom radius labels. Length must equal {@link radialDivisions}.
+   * - `string` entries render via {@link Text} at `labelFontSize * 0.8`
+   *   (matches default radius-label sizing).
+   * - `Mobject` entries are used as-is; they are positioned along the
+   *   positive x-axis and reparented into the radius-labels group.
+   *
+   * Index `i` corresponds to radius `((i + 1) / radialDivisions) * radius`.
+   */
+  radiusLabels?: (string | Mobject)[];
 }
 
 /**
@@ -541,6 +561,8 @@ export class PolarPlane extends Group {
   private _labelFontSize: number;
   private _labelColor: string;
   private _azimuthOffset: number;
+  private _angleLabelOverrides?: (string | Mobject)[];
+  private _radiusLabelOverrides?: (string | Mobject)[];
 
   private _concentricCircles: Group;
   private _radialLines: Group;
@@ -564,7 +586,25 @@ export class PolarPlane extends Group {
       labelFontSize = 20,
       labelColor = WHITE,
       azimuthOffset = 0,
+      angleLabels,
+      radiusLabels,
     } = options;
+
+    if (angleLabels !== undefined && angleLabels.length !== angularDivisions) {
+      throw new Error(
+        `PolarPlane: angleLabels length (${angleLabels.length}) must equal angularDivisions (${angularDivisions})`,
+      );
+    }
+    if (radiusLabels !== undefined && radiusLabels.length !== radialDivisions) {
+      throw new Error(
+        `PolarPlane: radiusLabels length (${radiusLabels.length}) must equal radialDivisions (${radialDivisions})`,
+      );
+    }
+    // Reject duplicate Mobject instances — `Group.add()` reparents, so the
+    // same Mobject appearing in multiple slots would silently leave only the
+    // final slot populated.
+    PolarPlane._assertUniqueMobjects(angleLabels, 'angleLabels');
+    PolarPlane._assertUniqueMobjects(radiusLabels, 'radiusLabels');
 
     this._radius = radius;
     this._size = size;
@@ -578,6 +618,8 @@ export class PolarPlane extends Group {
     this._labelFontSize = labelFontSize;
     this._labelColor = labelColor;
     this._azimuthOffset = azimuthOffset;
+    this._angleLabelOverrides = angleLabels ? [...angleLabels] : undefined;
+    this._radiusLabelOverrides = radiusLabels ? [...radiusLabels] : undefined;
 
     this._concentricCircles = new Group();
     this._radialLines = new Group();
@@ -653,17 +695,21 @@ export class PolarPlane extends Group {
     if (this._includeAngleLabels) {
       for (let i = 0; i < this._angularDivisions; i++) {
         const angle = this._azimuthOffset + (i / this._angularDivisions) * 2 * Math.PI;
-        const normalizedAngle = ((angle % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI);
-        const labelText = this._formatAngleLabel(normalizedAngle);
-
         const labelX = (outerRadius + labelOffset) * Math.cos(angle);
         const labelY = (outerRadius + labelOffset) * Math.sin(angle);
 
-        const label = new Text({
-          text: labelText,
-          fontSize: this._labelFontSize,
-          color: this._labelColor,
-        });
+        const override = this._angleLabelOverrides?.[i];
+        const label =
+          override !== undefined
+            ? this._resolveLabelSpec(override, this._labelFontSize)
+            : (() => {
+                const normalized = ((angle % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI);
+                return new Text({
+                  text: this._formatAngleLabel(normalized),
+                  fontSize: this._labelFontSize,
+                  color: this._labelColor,
+                });
+              })();
         label.moveTo([labelX, labelY, 0]);
 
         this._angleLabels.add(label);
@@ -675,19 +721,67 @@ export class PolarPlane extends Group {
       for (let i = 1; i <= this._radialDivisions; i++) {
         const r = (i / this._radialDivisions) * this._radius;
         const visualR = r * scaleFactor;
-        const labelText = Number.isInteger(r) ? `${r}` : r.toFixed(1);
 
-        const label = new Text({
-          text: labelText,
-          fontSize: this._labelFontSize * 0.8,
-          color: this._labelColor,
-        });
+        const override = this._radiusLabelOverrides?.[i - 1];
+        const label =
+          override !== undefined
+            ? this._resolveLabelSpec(override, this._labelFontSize * 0.8)
+            : new Text({
+                text: Number.isInteger(r) ? `${r}` : r.toFixed(1),
+                fontSize: this._labelFontSize * 0.8,
+                color: this._labelColor,
+              });
         // Position radius labels along the positive x-axis, slightly below
         label.moveTo([visualR, -0.2, 0]);
 
         this._radiusLabels.add(label);
       }
     }
+  }
+
+  /**
+   * Resolve a label override spec into a Mobject.
+   *
+   * Strings render via {@link Text} at the given fontSize and the plane's
+   * `labelColor`. Mobjects are used as-is — callers own their styling.
+   * The returned Mobject will be {@link moveTo}'d and reparented into the
+   * appropriate label group.
+   */
+  /**
+   * Throw if the same Mobject instance appears in more than one slot.
+   *
+   * `Group.add()` reparents the Mobject into the new container, so the same
+   * instance reused across slots would silently end up at only one position
+   * (the last slot). Detect this at construction so callers fail loudly
+   * instead of debugging a missing label.
+   */
+  private static _assertUniqueMobjects(
+    labels: (string | Mobject)[] | undefined,
+    optionName: string,
+  ): void {
+    if (!labels) return;
+    const seen = new Set<Mobject>();
+    for (let i = 0; i < labels.length; i++) {
+      const spec = labels[i];
+      if (typeof spec === 'string') continue;
+      if (seen.has(spec)) {
+        throw new Error(
+          `PolarPlane: ${optionName} contains the same Mobject instance more than once (slot ${i}). Each Mobject slot needs its own instance.`,
+        );
+      }
+      seen.add(spec);
+    }
+  }
+
+  private _resolveLabelSpec(spec: string | Mobject, fontSize: number): Mobject {
+    if (typeof spec === 'string') {
+      return new Text({
+        text: spec,
+        fontSize,
+        color: this._labelColor,
+      });
+    }
+    return spec;
   }
 
   /**
@@ -911,6 +1005,8 @@ export class PolarPlane extends Group {
       labelFontSize: this._labelFontSize,
       labelColor: this._labelColor,
       azimuthOffset: this._azimuthOffset,
+      angleLabels: this._angleLabelOverrides?.map((s) => (typeof s === 'string' ? s : s.copy())),
+      radiusLabels: this._radiusLabelOverrides?.map((s) => (typeof s === 'string' ? s : s.copy())),
     });
   }
 }

--- a/src/mobjects/graphing/graphing-complex.test.ts
+++ b/src/mobjects/graphing/graphing-complex.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { ComplexPlane, PolarPlane } from './ComplexPlane';
+import { Text } from '../text';
+import { Mobject } from '../../core/Mobject';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -856,6 +858,162 @@ describe('ComplexPlane with canvas mock', () => {
     it('should handle non-integer radius for radius labels', () => {
       const pp = new PolarPlane({ radius: 2.5, radialDivisions: 3 });
       expect(pp.getRadiusLabels().children.length).toBe(3);
+    });
+  });
+
+  describe('PolarPlane custom labels (issue #342)', () => {
+    it('uses custom angle label strings, rendered as Text in division order', () => {
+      const pp = new PolarPlane({
+        angularDivisions: 4,
+        labelFontSize: 20,
+        angleLabels: ['E', 'N', 'W', 'S'],
+      });
+      const labels = pp.getAngleLabels().children;
+      expect(labels.length).toBe(4);
+      // Verify the actual rendered text — would catch a regression that
+      // fell back to default π-formatting.
+      expect(labels.map((m) => (m as Text).getText())).toEqual(['E', 'N', 'W', 'S']);
+      // Strings render via Text at full labelFontSize.
+      for (const m of labels) expect((m as Text & { _fontSize: number })._fontSize).toBe(20);
+    });
+
+    it('uses custom radius label strings at labelFontSize * 0.8', () => {
+      const pp = new PolarPlane({
+        radialDivisions: 3,
+        labelFontSize: 20,
+        radiusLabels: ['A', 'B', 'C'],
+      });
+      const labels = pp.getRadiusLabels().children;
+      expect(labels.length).toBe(3);
+      expect(labels.map((m) => (m as Text).getText())).toEqual(['A', 'B', 'C']);
+      // Radius labels render slightly smaller than angle labels (preserves
+      // the default-rendering size convention).
+      for (const m of labels) expect((m as Text & { _fontSize: number })._fontSize).toBe(20 * 0.8);
+    });
+
+    it('preserves a non-Text Mobject override identity (no re-wrapping)', () => {
+      // Use a non-Text Mobject to confirm the resolver does not rewrap into Text.
+      // Mobject is abstract — use a minimal concrete shim.
+      class StubMobject extends Mobject {
+        protected override _createCopy(): Mobject {
+          return new StubMobject();
+        }
+      }
+      const stubs = [new StubMobject(), new StubMobject(), new StubMobject(), new StubMobject()];
+      const pp = new PolarPlane({ angularDivisions: 4, angleLabels: stubs });
+      const labels = pp.getAngleLabels().children;
+      for (let i = 0; i < 4; i++) {
+        expect(labels[i]).toBe(stubs[i]);
+        expect(labels[i]).toBeInstanceOf(StubMobject);
+      }
+    });
+
+    it('accepts pre-built Mobject entries (used as-is, reparented)', () => {
+      const custom = new Text({ text: 'τ/4', fontSize: 30, color: '#ff00ff' });
+      const pp = new PolarPlane({
+        angularDivisions: 4,
+        angleLabels: [custom, 'N', 'W', 'S'],
+      });
+      expect(pp.getAngleLabels().children.length).toBe(4);
+      // Custom mobject reparented into the angle-labels group at index 0.
+      expect(pp.getAngleLabels().children[0]).toBe(custom);
+    });
+
+    it('throws when angleLabels length mismatches angularDivisions', () => {
+      expect(() => new PolarPlane({ angularDivisions: 4, angleLabels: ['E', 'N', 'W'] })).toThrow(
+        /angleLabels length \(3\) must equal angularDivisions \(4\)/,
+      );
+    });
+
+    it('throws when radiusLabels length mismatches radialDivisions', () => {
+      expect(() => new PolarPlane({ radialDivisions: 3, radiusLabels: ['A', 'B'] })).toThrow(
+        /radiusLabels length \(2\) must equal radialDivisions \(3\)/,
+      );
+    });
+
+    it('throws when the same Mobject instance appears in multiple slots', () => {
+      const shared = new Text({ text: 'X' });
+      // Reusing the same instance would silently leave one slot empty after
+      // Group.add() reparents — detect at construction instead.
+      expect(
+        () =>
+          new PolarPlane({
+            angularDivisions: 4,
+            angleLabels: [shared, 'N', shared, 'S'] as (string | Mobject)[],
+          }),
+      ).toThrow(/same Mobject instance more than once \(slot 2\)/);
+    });
+
+    it('snapshots input arrays — post-construction mutation does not affect copy', () => {
+      const labels = ['E', 'N', 'W', 'S'];
+      const pp = new PolarPlane({ angularDivisions: 4, angleLabels: labels });
+      labels[0] = 'MUTATED';
+      const cp = pp.copy() as PolarPlane;
+      // If snapshotting were broken, the copy's first slot would render 'MUTATED'.
+      expect((cp.getAngleLabels().children[0] as Text).getText()).toBe('E');
+    });
+
+    it('copy() produces independent custom-label mobjects', () => {
+      const pp = new PolarPlane({
+        angularDivisions: 4,
+        radialDivisions: 2,
+        angleLabels: ['E', 'N', 'W', 'S'],
+        radiusLabels: ['A', 'B'],
+      });
+      const cp = pp.copy() as PolarPlane;
+
+      expect(cp).toBeInstanceOf(PolarPlane);
+      expect(cp).not.toBe(pp);
+      expect(cp.getAngleLabels().children.length).toBe(4);
+      expect(cp.getRadiusLabels().children.length).toBe(2);
+
+      // Original and copy own distinct label mobject instances.
+      for (let i = 0; i < 4; i++) {
+        expect(cp.getAngleLabels().children[i]).not.toBe(pp.getAngleLabels().children[i]);
+      }
+      for (let i = 0; i < 2; i++) {
+        expect(cp.getRadiusLabels().children[i]).not.toBe(pp.getRadiusLabels().children[i]);
+      }
+    });
+
+    it('copy() with Mobject overrides deep-copies the override entries', () => {
+      const custom = new Text({ text: 'τ/4', fontSize: 30 });
+      const pp = new PolarPlane({
+        angularDivisions: 4,
+        angleLabels: [custom, 'N', 'W', 'S'],
+      });
+      const cp = pp.copy() as PolarPlane;
+      // The copy must not share the same Mobject instance as the original.
+      expect(cp.getAngleLabels().children[0]).not.toBe(custom);
+      expect(pp.getAngleLabels().children[0]).toBe(custom);
+    });
+
+    it('overrides respect azimuthOffset by placing index 0 at the offset angle', () => {
+      const pp = new PolarPlane({
+        angularDivisions: 4,
+        azimuthOffset: Math.PI / 2,
+        angleLabels: ['N', 'W', 'S', 'E'],
+      });
+      const first = pp.getAngleLabels().children[0];
+      // With azimuthOffset = PI/2, index 0 is placed near +y (x ~ 0, y > 0).
+      expect(Math.abs(first.position.x)).toBeLessThan(1e-6);
+      expect(first.position.y).toBeGreaterThan(0);
+    });
+
+    it('radius label positions track ((i+1)/radialDivisions) * radius along +x', () => {
+      const pp = new PolarPlane({
+        radius: 3,
+        size: 6, // scaleFactor = 6 / (2*3) = 1
+        radialDivisions: 3,
+        radiusLabels: ['A', 'B', 'C'],
+      });
+      const labels = pp.getRadiusLabels().children;
+      // visualR_i = (i/3) * 3 * scaleFactor = i for i in {1,2,3}
+      expect(closeTo(labels[0].position.x, 1)).toBe(true);
+      expect(closeTo(labels[1].position.x, 2)).toBe(true);
+      expect(closeTo(labels[2].position.x, 3)).toBe(true);
+      // Each placed slightly below the x-axis (matches default convention).
+      for (const l of labels) expect(closeTo(l.position.y, -0.2)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #342. Adds `angleLabels` / `radiusLabels` options to `PolarPlane` so callers can override the hard-coded π-based angle labels and integer radius labels with arbitrary strings or pre-built mobjects (e.g. `MathTex` for τ-based labels or custom units).

- New options on `PolarPlaneOptions`:
  - `angleLabels?: (string | Mobject)[]` — length must equal `angularDivisions`.
  - `radiusLabels?: (string | Mobject)[]` — length must equal `radialDivisions`.
- `string` entries render via `Text` using the plane's `labelFontSize` (angle) or `labelFontSize * 0.8` (radius) and `labelColor`.
- `Mobject` entries are used as-is (caller owns styling), positioned by `moveTo`, and reparented into the angle/radius label groups.
- Constructor validates array length and rejects duplicate `Mobject` instances (which would otherwise silently drop a label because `Group.add()` reparents).
- Input arrays are snapshotted so post-construction mutation doesn't leak into copies.
- `_createCopy()` clones override mobjects so copied planes own independent labels.
- Default behavior unchanged when the options are omitted.

## Test plan

- [x] `npx vitest run src/mobjects/graphing/graphing-complex.test.ts` — 104 tests, including new coverage:
  - rendered text equals input strings (not the default π formatter),
  - radius-label sizing follows the `* 0.8` convention,
  - Mobject overrides preserve identity (no rewrapping),
  - length mismatch throws,
  - duplicate-Mobject reuse throws,
  - array mutation after construction does not affect the copy,
  - `copy()` produces independent label mobjects,
  - radius label positions track `((i+1)/radialDivisions) * radius` along `+x`,
  - `azimuthOffset` rotates the override placement.
- [x] `npx vitest run` — full suite (5981 tests) green.
- [x] Visual check via `examples/polar_plane_custom_labels.html` (default / compass strings / τ-MathTex panels).
- [x] Docs site preview via new `## Polar Plane with Custom Labels` section in `docs/docs/examples/graphing.mdx`.