### PR TITLE
fix(#344): register AnimateProxy when Scene loads

### DIFF
--- a/src/core/AnimateProxy.ts
+++ b/src/core/AnimateProxy.ts
@@ -240,5 +240,14 @@ export class AnimateProxy extends Animation {
   }
 }
 
-// Register with Mobject to break circular dependency
-registerAnimateProxy((mobject: Mobject) => new AnimateProxy(mobject));
+// Register with Mobject to break the Mobject -> AnimateProxy -> Transform ->
+// VGroup -> Mobject cycle.
+let registered = false;
+export function ensureAnimateProxyRegistered(): void {
+  if (registered) return;
+  registerAnimateProxy((mobject: Mobject) => new AnimateProxy(mobject));
+  registered = true;
+}
+
+// Eager registration for callers that import AnimateProxy directly.
+ensureAnimateProxyRegistered();

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -11,6 +11,14 @@ import { MANIM_BACKGROUND } from '../constants/colors';
 import { VMobject } from './VMobject';
 import { SceneStateManager, SceneSnapshot } from './StateManager';
 import { AudioManager, type AddSoundOptions, type AudioTrack } from './AudioManager';
+import { ensureAnimateProxyRegistered } from './AnimateProxy';
+
+// AnimateProxy self-registers with Mobject via a top-level side effect
+// (see AnimateProxy.ts) to avoid the Mobject -> AnimateProxy -> Transform ->
+// VGroup -> Mobject cycle. Touching the export here forces module evaluation
+// so `mobject.animate` works even when callers import Scene without ever
+// referencing AnimateProxy directly (e.g. Scene.createHeadless() in tests).
+ensureAnimateProxyRegistered();
 
 /**
  * Options for scene.export() convenience method.

--- a/src/core/animate-proxy-registration.test.ts
+++ b/src/core/animate-proxy-registration.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Regression test for #344: importing Scene (e.g. via Scene.createHeadless)
+// without any other reference to AnimateProxy used to leave the animate
+// proxy factory unregistered, so `mobject.animate` threw. Each case below
+// resets the module graph and dynamically imports only Scene + a Mobject
+// subclass via direct module paths, mirroring a minimal user setup.
+describe('AnimateProxy registration via Scene import (issue #344)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  // 30s timeout: vi.resetModules forces a cold reload of the project's module
+  // graph (Scene pulls in animations, geometry, three.js), which can exceed
+  // the default 5s timer on slower CI workers.
+  const TIMEOUT_MS = 30_000;
+
+  it(
+    'Scene.createHeadless registers AnimateProxy so mobject.animate works',
+    async () => {
+      const { Scene } = await import('./Scene');
+      const { Circle } = await import('../mobjects/geometry/Circle');
+
+      const scene = Scene.createHeadless();
+      const circle = new Circle();
+      scene.add(circle);
+
+      expect(() => circle.animate.shift([1, 0, 0])).not.toThrow();
+      scene.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    'new Scene(null, { headless: true }) also registers AnimateProxy',
+    async () => {
+      const { Scene } = await import('./Scene');
+      const { Circle } = await import('../mobjects/geometry/Circle');
+
+      const scene = new Scene(null, { headless: true });
+      const circle = new Circle();
+      scene.add(circle);
+
+      expect(() => circle.animate.scale(2)).not.toThrow();
+      scene.dispose();
+    },
+    TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
## Summary
- Fixes #344. `Scene.createHeadless()` no longer throws `AnimateProxy not registered` when callers reach for `mobject.animate` without having imported `AnimateProxy` elsewhere.
- Added an idempotent `ensureAnimateProxyRegistered()` in `AnimateProxy.ts` and call it from `Scene.ts`, so registration is guaranteed whenever any `Scene` (or subclass) module loads, while preserving the existing eager registration path for direct `AnimateProxy` imports.
- Regression test (`src/core/animate-proxy-registration.test.ts`) uses `vi.resetModules()` plus dynamic direct imports to reproduce the original failure (verified failing without the fix, passing with it).

## Root cause
`AnimateProxy` self-registers with `Mobject` via a top-level side effect to break the `Mobject -> AnimateProxy -> Transform -> VGroup -> Mobject` cycle. `Scene.ts` did not import `AnimateProxy`, so `Scene.createHeadless()` users only got registration if some other module in their graph happened to pull it in. The existing test suite hid this because other tests transitively load `AnimateProxy`.

## Test plan
- [x] `npm test` — 5983 / 5983 pass
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run circular` — no new cycles
- [x] New regression test fails on `main` and passes on this branch