### PR TITLE
docs(#378): document changelog conventions and release process

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,13 @@
 ## Summary
 Brief description of changes.
 
+> The PR title becomes the squash-commit subject and lands verbatim in
+> `CHANGELOG.md`. Use Conventional Commits (`feat(#NNN): ...`,
+> `fix(#NNN): ...`). For breaking changes append `!` to the type/scope
+> **and** include a `BREAKING CHANGE: <migration note>` line in this PR
+> description (it will end up in the squash commit body and the release
+> notes). See `AGENTS.md` → *Commits, Changelog & Releases*.
+
 ## Changes
 - ...
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,96 @@ helpers live in `src/utils/math.ts` and are built on top of those.
 - **Prefer vector / matrix products to component arithmetic.** Use
   `transformPointByMatrix`, `crossVec`, `dotVec`, etc. so geometric intent is
   visible in the code.
+
+## Commits, Changelog & Releases
+
+`CHANGELOG.md` is **generated**, not hand-written. It is produced by
+[`standard-version`](https://github.com/conventional-changelog/standard-version)
+from the [Conventional Commits](https://www.conventionalcommits.org/) history,
+using the type → section mapping in `.versionrc.json`. Commit subject lines are
+therefore user-facing release notes — write them as such.
+
+### Commit message format
+
+```
+<type>(<scope>): <imperative subject>
+
+<optional body>
+
+<optional footer(s)>
+```
+
+Allowed `<type>` values and where they land in `CHANGELOG.md`:
+
+| Type       | Section in CHANGELOG | Notes                                |
+| ---------- | -------------------- | ------------------------------------ |
+| `feat`     | Features             | Triggers a **minor** version bump    |
+| `fix`      | Bug Fixes            | Triggers a **patch** bump            |
+| `perf`     | Performance          | Patch bump                           |
+| `refactor` | Refactoring          | Patch bump                           |
+| `docs`     | Documentation        | Patch bump                           |
+| `test`     | Tests                | Patch bump                           |
+| `chore`    | *(hidden)*           | Still counts toward release if cut   |
+
+`<scope>` should be the issue number for work tied to a tracked issue:
+`fix(#344): ...`, `feat(#358): ...`. For tooling commits use a topical scope
+(`chore(deps-dev): ...`, `fix(ci): ...`).
+
+The subject must be short, imperative, and stand alone in release notes
+(`add multi-camera example scenes`, not `WIP changes`). It is the *only* part
+of the commit that downstream consumers reliably see.
+
+### Breaking changes
+
+A commit is breaking iff it changes the public API or runtime behaviour in a
+way users must adapt to. Mark it **both** ways:
+
+1. Append `!` after the type/scope: `feat(scene)!: drop legacy add() overload`.
+2. Add a `BREAKING CHANGE:` footer with a one-paragraph migration note:
+
+   ```
+   feat(scene)!: drop legacy add() overload
+
+   BREAKING CHANGE: Scene.add() no longer accepts a raw THREE.Object3D. Wrap
+   it in a Mobject (see docs/migration/0.4.md) before passing it in.
+   ```
+
+`standard-version` bumps to a **major** version when it sees `!` or
+`BREAKING CHANGE:`. The footer text is what users will read — make it
+actionable.
+
+### PR titles → CHANGELOG
+
+The repo allows squash merging. When squashing, **leave the squash commit
+subject equal to the PR title** — don't retype it in the merge dialog. PR
+titles must therefore also follow Conventional Commits; treat the PR title
+as the release-notes entry it will become.
+
+### Release process
+
+Releases are cut locally, then finished by CI:
+
+1. From a clean `main` (or release branch), run the appropriate script:
+   - `npm run release` — auto-detects bump from commits since the last tag.
+   - `npm run release:minor` / `npm run release:major` — force a bump (rare;
+     only when the commit history under-states the change).
+2. `standard-version` updates `package.json` and regenerates the relevant
+   section of `CHANGELOG.md`. **Review the generated diff.** If a subject
+   line reads badly as a release note, do **not** rewrite the already-merged
+   commit on `main`; instead add a short clarifying note immediately above
+   the generated release section, and fix the habit at the source (PR title
+   review) for next time.
+3. Push the release commit (and the tag `standard-version` created) to
+   `origin/main`.
+4. `.github/workflows/release.yml` fires on the `package.json` change. It
+   creates the tag if missing, opens a GitHub Release, and publishes to npm.
+
+Caveats agents should know:
+
+- **GitHub Release notes** are built from `git log`, *not* from
+  `CHANGELOG.md` — bad commit subjects show up in two places, not one.
+- **Never hand-edit generated release entries** in `CHANGELOG.md`. Fix the
+  underlying commit message and regenerate, or add a note above the
+  generated section.
+- **Don't run `npm run release`** as part of a feature PR. Version bumps are
+  a separate, deliberate commit on `main`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+All notable changes to this project will be documented in this file. This file
+is **auto-generated** by [`standard-version`](https://github.com/conventional-changelog/standard-version)
+from the Conventional Commits history; do not hand-edit the generated release
+sections below. For commit conventions, breaking-change markers, and the
+release process see [`AGENTS.md`](./AGENTS.md#commits-changelog--releases).
 
 ### [0.3.16](https://github.com/maloyan/manim-js/compare/v0.3.13...v0.3.16) (2026-03-16)
 


### PR DESCRIPTION
## Summary
- `CHANGELOG.md` is auto-generated by `standard-version` from Conventional Commits, but `AGENTS.md` / README did not document the rules — agents had no source of truth for commit types, breaking-change markers, or the release flow.
- Adds a `Commits, Changelog & Releases` section to `AGENTS.md` covering allowed types (mirrors `.versionrc.json`), the `feat(#NNN):` / `fix(#NNN):` scope convention, both `!` + `BREAKING CHANGE:` footer for major bumps, the local-`npm run release` → `release.yml`-publish flow, and the gotcha that GitHub Release notes come from `git log` (not `CHANGELOG.md`).
- Adds a one-paragraph reminder in `.github/pull_request_template.md` that the PR title becomes the squash commit subject and lands in `CHANGELOG.md`, with explicit guidance on the breaking-change footer.
- Adds a short pointer in `CHANGELOG.md`'s header back to `AGENTS.md`, with a "don't hand-edit generated sections" note.

## Changes
- `AGENTS.md` — new `Commits, Changelog & Releases` section.
- `.github/pull_request_template.md` — Conventional Commits + breaking-change reminder.
- `CHANGELOG.md` — header pointer to the rules.

## Testing
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [x] `npx standard-version --dry-run` confirms the documented type → section mapping matches what `standard-version` produces (feat → Features, fix → Bug Fixes, test → Tests, refactor → Refactoring, chore hidden)
- Docs-only change — no source or unit tests touched.

## Plan & review
Plan posted as a comment on the issue, then reviewed with `codex`. Codex flagged three issues which are all addressed in this branch:
1. Don't tell people to rewrite already-merged commits on `main` — instead add a clarifying note above the generated section and fix PR titles upstream.
2. PR template must require the `BREAKING CHANGE:` footer, not just `!`.
3. Phrase the "squash uses PR title" rule as policy ("leave the squash subject equal to the PR title"), not as an inevitable fact.

Closes #378