### PR TITLE
docs(#358): surface multi-camera examples on docs site

### DIFF
--- a/docs/docs/examples/3d-scenes.mdx
+++ b/docs/docs/examples/3d-scenes.mdx
@@ -10,8 +10,13 @@ import ThreeDSurfacePlotExample from '@site/src/components/examples/ThreeDSurfac
 import ThreeDCameraRotationExample from '@site/src/components/examples/ThreeDCameraRotationExample';
 import ThreeDCameraIllusionRotationExample from '@site/src/components/examples/ThreeDCameraIllusionRotationExample';
 import ThreeDAngleExample from '@site/src/components/examples/ThreeDAngleExample';
+import SplitScreenCameraExample from '@site/src/components/examples/SplitScreenCameraExample';
+import PictureInPictureCameraExample from '@site/src/components/examples/PictureInPictureCameraExample';
+import QuadViewCameraExample from '@site/src/components/examples/QuadViewCameraExample';
 
-3D scene examples with camera controls, lighting, and surfaces.
+3D scene examples with camera controls, lighting, and surfaces — plus 2D
+multi-camera compositions (split screen, picture-in-picture, quad view) at the
+bottom of the page.
 
 ## Fixed In Frame Mobject Test
 
@@ -417,3 +422,208 @@ await scene.wait(Infinity);
 </details>
 
 **Learn More:** [**ThreeDScene**](/api/classes/ThreeDScene) · [**ThreeDAxes**](/api/classes/ThreeDAxes) · [**Line3D**](/api/classes/Line3D) · [**Angle**](/api/classes/Angle)
+
+## Split Screen Camera
+
+Renders the same scene through two Camera2D instances side by side via SplitScreenCamera. The left pane is centered on a circle; the right pane zooms in on a square. Each viewport gets its own aspect ratio at render time. Demonstrates Scene.useMultiCamera() for split-screen layouts.
+
+<SplitScreenCameraExample />
+
+<details>
+<summary>Source Code</summary>
+
+```typescript
+import {
+  BLUE,
+  Camera2D,
+  Circle,
+  Create,
+  RED,
+  Scene,
+  SplitScreenCamera,
+  Square,
+  YELLOW,
+} from 'manim-web';
+
+const scene = new Scene(document.getElementById('container'), {
+  width: 800,
+  height: 450,
+  backgroundColor: '#1a1a2e',
+});
+
+const leftCamera = new Camera2D({ frameWidth: 14, frameHeight: 8, position: [-3, 0, 10] });
+const rightCamera = new Camera2D({ frameWidth: 6, frameHeight: 8, position: [3, 0, 10] });
+
+const split = new SplitScreenCamera({
+  leftCamera,
+  rightCamera,
+  split: 'horizontal',
+  splitRatio: 0.5,
+});
+scene.useMultiCamera(split.getMultiCamera());
+
+const circle = new Circle({ radius: 1, color: RED, strokeWidth: 4 });
+circle.shift([-3, 0, 0]);
+const square = new Square({ sideLength: 1.5, color: BLUE, strokeWidth: 4 });
+square.shift([3, 0, 0]);
+const marker = new Circle({ radius: 0.15, color: YELLOW, strokeWidth: 3 });
+
+scene.add(marker);
+await scene.play(new Create(circle));
+await scene.play(new Create(square));
+await scene.wait(0.8);
+
+scene.useMultiCamera(null);
+```
+
+</details>
+
+**Learn More:** [**Scene**](/api/classes/Scene) · [**Camera2D**](/api/classes/Camera2D) · [**SplitScreenCamera**](/api/classes/SplitScreenCamera) · [**MultiCamera**](/api/classes/MultiCamera)
+
+## Picture In Picture Camera
+
+Main camera shows the full scene while a small picture-in-picture inset follows an orbiting dot at higher zoom. Uses MultiCamera.setupPictureInPicture() and an updater to keep the inset camera tracking the target.
+
+<PictureInPictureCameraExample />
+
+<details>
+<summary>Source Code</summary>
+
+```typescript
+import {
+  Camera2D,
+  Circle,
+  Create,
+  GREEN,
+  MultiCamera,
+  PURPLE,
+  Scene,
+  Square,
+  Triangle,
+  ValueTracker,
+  YELLOW,
+} from 'manim-web';
+
+const scene = new Scene(document.getElementById('container'), {
+  width: 800,
+  height: 450,
+  backgroundColor: '#1a1a2e',
+});
+
+const mainCamera = new Camera2D({ frameWidth: 14, frameHeight: 8, position: [0, 0, 10] });
+const pipCamera = new Camera2D({ frameWidth: 4, frameHeight: 4, position: [0, 0, 10] });
+
+const mc = new MultiCamera();
+mc.setupPictureInPicture(mainCamera, pipCamera, 'top-right', 0.3);
+scene.useMultiCamera(mc);
+
+const square = new Square({ sideLength: 1.5, color: PURPLE, strokeWidth: 4 });
+const triangle = new Triangle({ color: GREEN, strokeWidth: 4 });
+triangle.shift([-4, 1, 0]);
+const orbiter = new Circle({ radius: 0.35, color: YELLOW, strokeWidth: 4 });
+
+const t = new ValueTracker(0);
+orbiter.addUpdater(() => {
+  const a = t.getValue();
+  orbiter.moveTo([3 * Math.cos(a), 2 * Math.sin(a), 0]);
+  const p = orbiter.getCenter();
+  pipCamera.position.set(p[0], p[1], 10);
+});
+scene.add(t, square, triangle, orbiter);
+
+await scene.play(new Create(square));
+await scene.play(new Create(triangle));
+await scene.play(new Create(orbiter));
+await scene.play(t.animateTo(Math.PI * 4, { duration: 4 }));
+await scene.wait(0.5);
+
+scene.useMultiCamera(null);
+```
+
+</details>
+
+**Learn More:** [**Scene**](/api/classes/Scene) · [**Camera2D**](/api/classes/Camera2D) · [**MultiCamera**](/api/classes/MultiCamera) · [**ValueTracker**](/api/classes/ValueTracker)
+
+## Quad View Camera
+
+Four simultaneous viewports of the same scene — one overview plus three close-ups — composed with MultiCamera.setupQuadView(). A ball animates between regions, visible at full detail in whichever quadrant currently frames it.
+
+<QuadViewCameraExample />
+
+<details>
+<summary>Source Code</summary>
+
+```typescript
+import {
+  BLUE,
+  Camera2D,
+  Circle,
+  Create,
+  GREEN,
+  MultiCamera,
+  ORANGE,
+  RED,
+  Scene,
+  Square,
+  Triangle,
+  ValueTracker,
+  YELLOW,
+} from 'manim-web';
+
+const scene = new Scene(document.getElementById('container'), {
+  width: 800,
+  height: 450,
+  backgroundColor: '#1a1a2e',
+});
+
+const overviewPane = new Camera2D({ frameWidth: 14, frameHeight: 8, position: [0, 0, 10] });
+const circlePane = new Camera2D({ frameWidth: 4, frameHeight: 4, position: [-3, 2, 10] });
+const squarePane = new Camera2D({ frameWidth: 4, frameHeight: 4, position: [3, 2, 10] });
+const trianglePane = new Camera2D({ frameWidth: 6, frameHeight: 4, position: [0, -2, 10] });
+
+const mc = new MultiCamera();
+mc.setupQuadView([overviewPane, circlePane, squarePane, trianglePane]);
+scene.useMultiCamera(mc);
+
+const circle = new Circle({ radius: 0.9, color: RED, strokeWidth: 4 });
+circle.shift([-3, 2, 0]);
+const square = new Square({ sideLength: 1.4, color: BLUE, strokeWidth: 4 });
+square.shift([3, 2, 0]);
+const triangle = new Triangle({ color: GREEN, strokeWidth: 4 });
+triangle.shift([0, -2, 0]);
+const ball = new Circle({ radius: 0.25, color: YELLOW, strokeWidth: 3 });
+
+const t = new ValueTracker(0);
+ball.addUpdater(() => {
+  const a = t.getValue();
+  const path: Array<[number, number]> = [
+    [-3, 2],
+    [3, 2],
+    [0, -2],
+    [-3, 2],
+  ];
+  const seg = Math.floor(a) % (path.length - 1);
+  const f = a - Math.floor(a);
+  const [x0, y0] = path[seg];
+  const [x1, y1] = path[seg + 1];
+  ball.moveTo([x0 + (x1 - x0) * f, y0 + (y1 - y0) * f, 0]);
+});
+scene.add(t);
+
+const marker = new Circle({ radius: 0.12, color: ORANGE, strokeWidth: 2 });
+scene.add(marker);
+
+scene.add(circle, square, triangle, ball);
+await scene.play(new Create(circle));
+await scene.play(new Create(square));
+await scene.play(new Create(triangle));
+await scene.play(new Create(ball));
+await scene.play(t.animateTo(3, { duration: 4 }));
+await scene.wait(0.5);
+
+scene.useMultiCamera(null);
+```
+
+</details>
+
+**Learn More:** [**Scene**](/api/classes/Scene) · [**Camera2D**](/api/classes/Camera2D) · [**MultiCamera**](/api/classes/MultiCamera) · [**ValueTracker**](/api/classes/ValueTracker)


### PR DESCRIPTION
## Summary
- The multi-camera example **components** (`PictureInPictureCameraExample`, `QuadViewCameraExample`, `SplitScreenCameraExample`) were generated under `docs/src/components/examples/` by #383 and included in the auto-generated `docs/docs/examples.mdx` dump page — but that file isn't wired into the sidebar.
- The per-category mdx files under `docs/docs/examples/` are hand-curated and were never updated, so the live docs site never showed these examples.
- This PR adds the three sections to `3d-scenes.mdx` (the closest existing category — it already hosts camera-rotation examples) with imports, code blocks, descriptions and *Learn More* links.

## Changes
- `docs/docs/examples/3d-scenes.mdx`:
  - Import the three new example components.
  - Expand the page intro to mention 2D multi-camera composition (these examples use `Scene` + `Camera2D`, not `ThreeDScene`).
  - Three new sections with live components, source-code blocks, and *Learn More* links.
  - Each code block ends with `scene.useMultiCamera(null);` to match the generated source.

## Testing
- [x] `npm run build` inside `docs/` succeeds.
- [x] Built `docs/build/examples/3d-scenes/index.html` contains the three new section headings.
- Docs-only change — no source or unit tests touched.

## Plan & review
Reviewed with `codex` after the first draft. It caught:
1. 2D `Scene` + `Camera2D` examples land on the "3D Scenes" page — page intro now flags this.
2. Code samples drifted from the generated source — added back the missing `scene.useMultiCamera(null)` cleanup at the end of each block.

## Follow-up (out of scope)
The generator script (`scripts/generate-example-docs.mjs`) currently only writes the unused `examples.mdx` dump file. A future PR could teach it to emit / patch the per-category files so this manual-sync gap can't reappear.

Refs #358