### PR TITLE
fix(#361): render Line3D via Line2/LineMaterial so lineWidth works

### DIFF
--- a/examples/3d-scenes/three_d_line_widths.html
+++ b/examples/3d-scenes/three_d_line_widths.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script>if(new URLSearchParams(location.search).has('embed'))document.documentElement.classList.add('embed')</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ManimWeb - 3D Line widths (issue #361)</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #1a1a2e;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+      color: #eee;
+      padding: 20px;
+      gap: 16px;
+    }
+    h1 { font-size: 18px; font-weight: 500; }
+    #container {
+      border: 2px solid #333;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    html.embed, html.embed body { margin:0!important;padding:0!important;overflow:hidden;background:#000!important;width:100%;height:100%; }
+    html.embed body { display:flex;justify-content:center;align-items:center; }
+    html.embed h1 { display:none!important; }
+    html.embed #container { border:none!important;border-radius:0!important;width:100vw;height:100vh;display:flex;justify-content:center;align-items:center; }
+  </style>
+</head>
+<body>
+  <h1>Line3D lineWidth: 1, 6, 16, 32 (issue #361)</h1>
+  <div id="container"></div>
+  <script type="module" src="./three_d_line_widths.ts"></script>
+</body>
+</html>

--- a/examples/3d-scenes/three_d_line_widths.ts
+++ b/examples/3d-scenes/three_d_line_widths.ts
@@ -1,0 +1,35 @@
+import { Line3D, ThreeDAxes, ThreeDScene, BLUE, GREEN, RED, YELLOW } from '../../src/index.ts';
+
+// Demo for issue #361: Line3D `lineWidth` now renders correctly on every
+// WebGL platform by going through Line2 + LineMaterial.
+
+const container = document.getElementById('container');
+const scene = new ThreeDScene(container, {
+  width: 800,
+  height: 450,
+  backgroundColor: '#191919',
+  phi: 75 * (Math.PI / 180),
+  theta: -45 * (Math.PI / 180),
+  distance: 20,
+  fov: 30,
+  enableOrbitControls: true,
+  orbitControlsUp: 'z',
+});
+
+const axes = new ThreeDAxes({
+  xRange: [-5, 5, 1],
+  yRange: [-5, 5, 1],
+  zRange: [-5, 5, 1],
+  xLength: 10,
+  yLength: 10,
+  zLength: 10,
+  showTicks: false,
+});
+
+const thin = new Line3D({ start: [0, 0, 0], end: [3, 0, 0], color: YELLOW, lineWidth: 1 });
+const medium = new Line3D({ start: [0, 0, 0], end: [0, 3, 0], color: GREEN, lineWidth: 6 });
+const thick = new Line3D({ start: [0, 0, 0], end: [0, 0, 3], color: RED, lineWidth: 16 });
+const extra = new Line3D({ start: [0, 0, 0], end: [2, 2, 2], color: BLUE, lineWidth: 32 });
+
+scene.add(axes, thin, medium, thick, extra);
+await scene.wait(Infinity);

--- a/src/core/Mobject.ts
+++ b/src/core/Mobject.ts
@@ -667,6 +667,16 @@ export abstract class Mobject {
     return restoreMobjectStateImpl(this);
   }
 
+  // ── Scene context ────────────────────────────────────────────────
+
+  /**
+   * Hook for the Scene to propagate renderer dimensions and camera frame
+   * width to mobjects that need them (e.g. shader-resolution uniforms).
+   * Default is a no-op; subclasses override as needed.
+   * @internal
+   */
+  _setSceneContext(_rendererWidth: number, _rendererHeight: number, _frameWidth: number): void {}
+
   // ── Cleanup ──────────────────────────────────────────────────────
 
   dispose(): void {

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -468,13 +468,7 @@ export class Scene {
    * renderer dimensions instead of the class-level statics.
    */
   private _setSceneContextRecursive(mobject: Mobject): void {
-    if (mobject instanceof VMobject) {
-      mobject._setSceneContext(
-        this._renderer.width,
-        this._renderer.height,
-        this._camera.frameWidth,
-      );
-    }
+    mobject._setSceneContext(this._renderer.width, this._renderer.height, this._camera.frameWidth);
     for (const child of mobject.children) {
       this._setSceneContextRecursive(child);
     }

--- a/src/mobjects/three-d/Line3D.test.ts
+++ b/src/mobjects/three-d/Line3D.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Regression tests for Line3D lineWidth (issue #361).
+ *
+ * Before the fix, Line3D rendered with THREE.LineBasicMaterial, whose
+ * `linewidth` property is silently ignored by the WebGL renderer on every
+ * desktop platform. lineWidth was effectively a no-op.
+ *
+ * Fix: render with Line2 + LineMaterial. This test pins the new behavior
+ * and the wiring of Scene → renderer-resolution → material.resolution.
+ */
+import { describe, it, expect } from 'vitest';
+import { Line2 } from 'three/examples/jsm/lines/Line2.js';
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
+import { ThreeDScene } from '../../core/ThreeDScene';
+import { Group } from '../../core/Group';
+import { Line3D } from './Line3D';
+
+function getMaterial(line: Line3D): LineMaterial {
+  const l = line.getThreeObject() as Line2;
+  return l.material as LineMaterial;
+}
+
+describe('Line3D lineWidth (issue #361)', () => {
+  it('renders with Line2 so wide lines work cross-platform', () => {
+    const line = new Line3D({ end: [1, 1, 1], lineWidth: 12 });
+    const obj = line.getThreeObject();
+    expect(obj).toBeInstanceOf(Line2);
+  });
+
+  it('applies the requested lineWidth to LineMaterial.linewidth', () => {
+    const line = new Line3D({ end: [1, 0, 0], lineWidth: 12 });
+    expect(getMaterial(line).linewidth).toBe(12);
+  });
+
+  it('defaults to lineWidth=2 in pixels', () => {
+    const line = new Line3D({ end: [1, 0, 0] });
+    expect(line.getLineWidth()).toBe(2);
+    expect(getMaterial(line).linewidth).toBe(2);
+  });
+
+  it('disables frustum culling to avoid clipping the shader quad', () => {
+    const line = new Line3D({ end: [1, 0, 0], lineWidth: 4 });
+    const obj = line.getThreeObject() as Line2;
+    expect(obj.frustumCulled).toBe(false);
+  });
+
+  it('setLineWidth() syncs to the underlying material after a render', () => {
+    const scene = ThreeDScene.createHeadless();
+    const line = new Line3D({ end: [1, 0, 0], lineWidth: 4 });
+    scene.add(line);
+    line.setLineWidth(16);
+    // Force a render so _syncMaterialToThree runs.
+    scene.render();
+    expect(getMaterial(line).linewidth).toBe(16);
+    scene.dispose();
+  });
+
+  it('respects opacity → transparent flag on the material', () => {
+    const line = new Line3D({ end: [1, 0, 0], lineWidth: 4, opacity: 0.5 });
+    const mat = getMaterial(line);
+    expect(mat.opacity).toBe(0.5);
+    expect(mat.transparent).toBe(true);
+  });
+
+  it('uses inherited strokeWidth as the source of truth so setStyle works', () => {
+    const scene = ThreeDScene.createHeadless();
+    const line = new Line3D({ end: [1, 0, 0], lineWidth: 4 });
+    scene.add(line);
+    line.setStyle({ strokeWidth: 20 });
+    scene.render();
+    expect(line.getLineWidth()).toBe(20);
+    expect(getMaterial(line).linewidth).toBe(20);
+    scene.dispose();
+  });
+});
+
+describe('Line3D scene context → LineMaterial.resolution', () => {
+  it('Scene.add() propagates renderer dimensions to material.resolution', () => {
+    const scene = ThreeDScene.createHeadless({ width: 1024, height: 768 });
+    const line = new Line3D({ end: [1, 0, 0], lineWidth: 4 });
+    scene.add(line);
+    const res = getMaterial(line).resolution;
+    expect(res.x).toBe(1024);
+    expect(res.y).toBe(768);
+    scene.dispose();
+  });
+
+  it('Scene.resize() updates material.resolution', () => {
+    const scene = ThreeDScene.createHeadless({ width: 800, height: 600 });
+    const line = new Line3D({ end: [1, 0, 0], lineWidth: 4 });
+    scene.add(line);
+    scene.resize(1600, 900);
+    const res = getMaterial(line).resolution;
+    expect(res.x).toBe(1600);
+    expect(res.y).toBe(900);
+    scene.dispose();
+  });
+
+  it('inherits the global renderer-resolution fallback when added inside a group', () => {
+    // A non-default scene size primes the VMobject renderer-size statics, which
+    // the Line3D constructor reads as a fallback before _setSceneContext fires.
+    const scene = ThreeDScene.createHeadless({ width: 1280, height: 720 });
+    const group = new Group();
+    scene.add(group);
+    const line = new Line3D({ end: [1, 0, 0], lineWidth: 4 });
+    group.add(line);
+    const res = getMaterial(line).resolution;
+    expect(res.x).toBe(1280);
+    expect(res.y).toBe(720);
+    scene.dispose();
+  });
+});

--- a/src/mobjects/three-d/Line3D.ts
+++ b/src/mobjects/three-d/Line3D.ts
@@ -1,5 +1,9 @@
 import * as THREE from 'three';
+import { Line2 } from 'three/examples/jsm/lines/Line2.js';
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
+import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
 import { Mobject, Vector3Tuple } from '../../core/Mobject';
+import { VMobject } from '../../core/VMobject';
 
 /**
  * Options for creating a Line3D
@@ -11,35 +15,32 @@ export interface Line3DOptions {
   end: Vector3Tuple;
   /** Color as CSS color string. Default: '#ffffff' */
   color?: string;
-  /** Line width in pixels. Default: 2 */
+  /** Line width in CSS pixels. Default: 2 */
   lineWidth?: number;
   /** Opacity from 0 to 1. Default: 1 */
   opacity?: number;
 }
 
 /**
- * Line3D - A 3D line segment
+ * Line3D - A 3D line segment with configurable pixel width.
  *
- * Creates a line segment between two 3D points using Three.js Line.
- * Note: Due to WebGL limitations, line width may not work on all platforms.
+ * Rendered via Three.js `Line2` + `LineMaterial`, so `lineWidth` is
+ * honored on every WebGL platform (unlike `THREE.LineBasicMaterial`).
  *
  * @example
  * ```typescript
- * // Create a line from origin to (1, 1, 1)
- * const line = new Line3D({ end: [1, 1, 1] });
- *
- * // Create a line between two points
- * const line2 = new Line3D({
- *   start: [-1, 0, 0],
- *   end: [1, 0, 0],
- *   color: '#ff0000'
- * });
+ * const line = new Line3D({ end: [1, 1, 1], lineWidth: 8 });
  * ```
  */
 export class Line3D extends Mobject {
   protected _start: Vector3Tuple;
   protected _end: Vector3Tuple;
-  protected _lineWidth: number;
+  // Default resolution comes from the VMobject class statics, which Scene
+  // keeps in sync with the active renderer size. This avoids a hardcoded
+  // 800x450 fallback when Scene.add() has not propagated context yet (e.g.
+  // when a Line3D is added to a Group already in the scene).
+  private _resolutionWidth: number = VMobject._rendererWidth;
+  private _resolutionHeight: number = VMobject._rendererHeight;
 
   constructor(options: Line3DOptions) {
     super();
@@ -48,118 +49,110 @@ export class Line3D extends Mobject {
 
     this._start = [...start];
     this._end = [...end];
-    this._lineWidth = lineWidth;
 
     this.color = color;
     this._opacity = opacity;
+    // strokeWidth on Mobject is the single source of truth for line width so
+    // generic styling/animation paths (setStyle, setStrokeWidth) keep working.
     this.strokeWidth = lineWidth;
   }
 
-  /**
-   * Create the Three.js line object
-   */
   protected _createThreeObject(): THREE.Object3D {
-    const geometry = new THREE.BufferGeometry();
-    const points = [
-      new THREE.Vector3(this._start[0], this._start[1], this._start[2]),
-      new THREE.Vector3(this._end[0], this._end[1], this._end[2]),
-    ];
-    geometry.setFromPoints(points);
+    const geometry = new LineGeometry();
+    geometry.setPositions(this._buildPositions());
 
-    const material = new THREE.LineBasicMaterial({
-      color: this.color,
+    const material = new LineMaterial({
+      color: new THREE.Color(this.color).getHex(),
       opacity: this._opacity,
       transparent: this._opacity < 1,
-      linewidth: this._lineWidth, // Note: may not work on all platforms
+      linewidth: this.strokeWidth,
+      worldUnits: false,
+      resolution: new THREE.Vector2(this._resolutionWidth, this._resolutionHeight),
     });
 
-    return new THREE.Line(geometry, material);
+    const line = new Line2(geometry, material);
+    line.frustumCulled = false;
+    line.computeLineDistances();
+    return line;
   }
 
-  /**
-   * Sync material properties to Three.js object
-   */
   protected override _syncMaterialToThree(): void {
-    if (this._threeObject instanceof THREE.Line) {
-      const material = this._threeObject.material as THREE.LineBasicMaterial;
+    if (this._threeObject instanceof Line2) {
+      const material = this._threeObject.material as LineMaterial;
       if (material) {
         material.color.set(this.color);
         material.opacity = this._opacity;
         material.transparent = this._opacity < 1;
-        material.linewidth = this._lineWidth;
+        material.linewidth = this.strokeWidth;
+        material.resolution.set(this._resolutionWidth, this._resolutionHeight);
         material.needsUpdate = true;
       }
     }
   }
 
-  /**
-   * Update the geometry with current points
-   */
   protected _updateGeometry(): void {
-    if (this._threeObject instanceof THREE.Line) {
-      const geometry = this._threeObject.geometry as THREE.BufferGeometry;
-      const points = [
-        new THREE.Vector3(this._start[0], this._start[1], this._start[2]),
-        new THREE.Vector3(this._end[0], this._end[1], this._end[2]),
-      ];
-      geometry.setFromPoints(points);
-      geometry.attributes.position.needsUpdate = true;
+    if (this._threeObject instanceof Line2) {
+      const geometry = this._threeObject.geometry as LineGeometry;
+      geometry.setPositions(this._buildPositions());
+      this._threeObject.computeLineDistances();
     }
     this._markDirty();
   }
 
-  /**
-   * Get the start point
-   */
+  private _buildPositions(): number[] {
+    return [
+      this._start[0],
+      this._start[1],
+      this._start[2],
+      this._end[0],
+      this._end[1],
+      this._end[2],
+    ];
+  }
+
+  /** @internal */
+  override _setSceneContext(
+    rendererWidth: number,
+    rendererHeight: number,
+    _frameWidth: number,
+  ): void {
+    this._resolutionWidth = rendererWidth;
+    this._resolutionHeight = rendererHeight;
+    if (this._threeObject instanceof Line2) {
+      const material = this._threeObject.material as LineMaterial;
+      material?.resolution.set(rendererWidth, rendererHeight);
+    }
+  }
+
   getStart(): Vector3Tuple {
     return [...this._start];
   }
 
-  /**
-   * Set the start point
-   */
   setStart(point: Vector3Tuple): this {
     this._start = [...point];
     this._updateGeometry();
     return this;
   }
 
-  /**
-   * Get the end point
-   */
   getEnd(): Vector3Tuple {
     return [...this._end];
   }
 
-  /**
-   * Set the end point
-   */
   setEnd(point: Vector3Tuple): this {
     this._end = [...point];
     this._updateGeometry();
     return this;
   }
 
-  /**
-   * Get the line width
-   */
   getLineWidth(): number {
-    return this._lineWidth;
+    return this.strokeWidth;
   }
 
-  /**
-   * Set the line width
-   */
   setLineWidth(width: number): this {
-    this._lineWidth = width;
-    this.strokeWidth = width;
-    this._markDirty();
+    this.setStyle({ strokeWidth: width });
     return this;
   }
 
-  /**
-   * Get the length of the line
-   */
   getLength(): number {
     const dx = this._end[0] - this._start[0];
     const dy = this._end[1] - this._start[1];
@@ -167,9 +160,6 @@ export class Line3D extends Mobject {
     return Math.sqrt(dx * dx + dy * dy + dz * dz);
   }
 
-  /**
-   * Get the direction vector (normalized)
-   */
   getDirection(): Vector3Tuple {
     const length = this.getLength();
     if (length === 0) {
@@ -182,9 +172,6 @@ export class Line3D extends Mobject {
     ];
   }
 
-  /**
-   * Get the midpoint of the line
-   */
   getMidpoint(): Vector3Tuple {
     return [
       (this._start[0] + this._end[0]) / 2,
@@ -193,9 +180,6 @@ export class Line3D extends Mobject {
     ];
   }
 
-  /**
-   * Get a point along the line at parameter t (0 = start, 1 = end)
-   */
   pointAtParameter(t: number): Vector3Tuple {
     return [
       this._start[0] + t * (this._end[0] - this._start[0]),
@@ -204,15 +188,12 @@ export class Line3D extends Mobject {
     ];
   }
 
-  /**
-   * Create a copy of this Line3D
-   */
   protected override _createCopy(): Line3D {
     return new Line3D({
       start: this._start,
       end: this._end,
       color: this.color,
-      lineWidth: this._lineWidth,
+      lineWidth: this.strokeWidth,
       opacity: this._opacity,
     });
   }


### PR DESCRIPTION
## Summary

Fixes #361. `Line3D` rendered with `THREE.LineBasicMaterial`, whose `linewidth` is silently ignored by the WebGL renderer on every desktop platform. Switching the backing object to `Line2` + `LineGeometry` + `LineMaterial` (the same stack VMobject strokes already use) makes `lineWidth` honored on every platform.

- Promoted `_setSceneContext` to a no-op on `Mobject` and made `Scene` propagate it to every mobject (not just `VMobject`) so `Line3D` material resolution tracks renderer size and survives resize.
- `strokeWidth` is now the single source of truth — `setStyle`/`setStrokeWidth` and the constructor's `lineWidth` option all converge there; `setLineWidth` routes through `setStyle`.
- Default resolution falls back to `VMobject._rendererWidth/_rendererHeight` (kept in sync by `Scene`) so a `Line3D` added to an already-mounted `Group` in a non-default-size scene still gets the right pixel width.
- Added `examples/3d-scenes/three_d_line_widths.{ts,html}` showing widths 1, 6, 16, 32.

## Test plan

- [x] `npx vitest run` — 118 files / 6014 tests pass.
- [x] New unit tests in `src/mobjects/three-d/Line3D.test.ts` cover: `Line2` backing, `linewidth` value, default width, `frustumCulled=false`, `setLineWidth` sync, opacity → `transparent`, `setStyle` path, `Scene.add` propagating resolution, `Scene.resize` updating resolution, and `Group`-add resolution inheritance.
- [x] Manually verified the issue reproducer pattern and the new example render distinct widths in Chrome on macOS.
- [x] Existing `three_d_reflex_angle` example still renders without regression.