### PR TITLE
fix(#360): auto-resize canvas on container/window changes

### DIFF
--- a/examples/responsive_canvas.html
+++ b/examples/responsive_canvas.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ManimWeb - Responsive Canvas (issue #360)</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { height: 100%; }
+    body {
+      background: #1a1a2e;
+      font-family: system-ui, sans-serif;
+      color: white;
+      display: flex;
+      flex-direction: column;
+    }
+    header {
+      padding: 12px 16px;
+      background: #0f0f1e;
+      border-bottom: 1px solid #2a2a3e;
+    }
+    header h1 { font-size: 16px; font-weight: 600; }
+    header p  { font-size: 12px; opacity: 0.7; margin-top: 4px; }
+    /* The container fills the viewport. Rotating a mobile device, dragging
+       the browser window, or DevTools resizing all change its size and the
+       canvas should follow. */
+    #container {
+      flex: 1;
+      width: 100%;
+      min-height: 0;
+      background: #1C1C1C;
+    }
+    .badge {
+      position: fixed;
+      bottom: 12px;
+      right: 12px;
+      padding: 6px 10px;
+      font-family: ui-monospace, monospace;
+      font-size: 11px;
+      background: rgba(0,0,0,0.6);
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Responsive canvas demo (issue #360)</h1>
+    <p>Resize the window or rotate your device. The canvas should follow without a reload.</p>
+  </header>
+  <div id="container"></div>
+  <div id="badge" class="badge">–</div>
+
+  <script type="module">
+    import { Scene, Circle, Square, Create, FadeIn } from '../src/index.ts';
+
+    const container = document.getElementById('container');
+    const badge = document.getElementById('badge');
+
+    // No explicit width/height — Scene auto-installs ResizeObserver +
+    // window/orientationchange fallback.
+    const scene = new Scene(container, {
+      backgroundColor: '#1C1C1C',
+    });
+
+    const circle = new Circle({ radius: 1.5, color: '#e94560' });
+    const square = new Square({ sideLength: 2, color: '#5cdb95' }).shift([3, 0, 0]);
+
+    await scene.play(new Create(circle));
+    await scene.play(new FadeIn(square));
+
+    const report = () => {
+      const c = scene.renderer.getCanvas();
+      badge.textContent = `canvas: ${c.width}x${c.height}  css: ${c.clientWidth}x${c.clientHeight}`;
+    };
+    report();
+    window.addEventListener('resize', report);
+    window.addEventListener('orientationchange', report);
+    new ResizeObserver(report).observe(container);
+  </script>
+</body>
+</html>

--- a/src/core/Renderer.test.ts
+++ b/src/core/Renderer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as THREE from 'three';
 import { Renderer } from './Renderer';
 
@@ -127,5 +127,47 @@ describe('Renderer backgroundOpacity', () => {
 
     renderer.backgroundColor = '#ff0000';
     expect(mockRenderer.setClearColor).toHaveBeenCalledWith(expect.any(THREE.Color), 0.4);
+  });
+});
+
+describe('Renderer.resize() pixel-ratio handling (issue #360)', () => {
+  // Node env has no `window`; stub one so the resize DPR refresh runs.
+  const originalWindow = (globalThis as { window?: unknown }).window;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as { window?: { devicePixelRatio: number } }).window = {
+      devicePixelRatio: 2,
+    };
+  });
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      (globalThis as { window?: unknown }).window = originalWindow;
+    }
+  });
+
+  it('refreshes devicePixelRatio on resize when no explicit pixelRatio was set', () => {
+    const renderer = new Renderer(createContainer());
+    const mock = (renderer as any)._renderer;
+    mock.setPixelRatio.mockClear();
+
+    renderer.resize(1000, 600);
+
+    expect(mock.setPixelRatio).toHaveBeenCalledTimes(1);
+    expect(mock.setSize).toHaveBeenCalledWith(1000, 600);
+  });
+
+  it('does NOT overwrite an explicit pixelRatio on resize', () => {
+    const renderer = new Renderer(createContainer(), { pixelRatio: 1 });
+    const mock = (renderer as any)._renderer;
+    mock.setPixelRatio.mockClear();
+
+    renderer.resize(1000, 600);
+
+    expect(mock.setPixelRatio).not.toHaveBeenCalled();
+    expect(mock.setSize).toHaveBeenCalledWith(1000, 600);
   });
 });

--- a/src/core/Renderer.ts
+++ b/src/core/Renderer.ts
@@ -55,6 +55,10 @@ export class Renderer implements IRenderer {
   private _backgroundOpacity: number;
   private _alpha: boolean;
   private _contextLost: boolean = false;
+  // True when pixelRatio was auto-derived from window.devicePixelRatio.
+  // When false the caller pinned a specific ratio (e.g. 1 for export); we
+  // must not override it on resize.
+  private _autoPixelRatio: boolean;
 
   /**
    * Create a new Renderer and append it to the container.
@@ -76,6 +80,7 @@ export class Renderer implements IRenderer {
       preserveDrawingBuffer = true, // Needed for video/image export
       canvas,
     } = options;
+    this._autoPixelRatio = options.pixelRatio == null;
 
     this._backgroundOpacity = Math.max(0, Math.min(1, backgroundOpacity));
     // Enable alpha channel if background is semi-transparent or explicitly requested
@@ -188,12 +193,19 @@ export class Renderer implements IRenderer {
 
   /**
    * Handle resize events.
+   * Re-applies the device pixel ratio so DPR changes (e.g. screen rotation
+   * moving the canvas between displays) do not leave a blurry buffer.
    * @param width - New width in pixels
    * @param height - New height in pixels
    */
   resize(width: number, height: number): void {
     this._width = width;
     this._height = height;
+    // Only re-derive devicePixelRatio when no explicit pixelRatio was pinned.
+    // Otherwise rotation could clobber a caller-forced ratio (e.g. 1 for export).
+    if (this._autoPixelRatio && typeof window !== 'undefined') {
+      this._renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    }
     this._renderer.setSize(width, height);
   }
 

--- a/src/core/Scene-auto-resize.test.ts
+++ b/src/core/Scene-auto-resize.test.ts
@@ -1,0 +1,229 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as THREE from 'three';
+
+// Mock three's WebGLRenderer so Scene can be constructed without real WebGL.
+vi.mock('three', async () => {
+  const actual = await vi.importActual<typeof THREE>('three');
+  const MockWebGLRenderer = vi.fn().mockImplementation(function () {
+    const canvas = document.createElement('canvas');
+    return {
+      setSize: vi.fn(),
+      setPixelRatio: vi.fn(),
+      setClearColor: vi.fn(),
+      domElement: canvas,
+      dispose: vi.fn(),
+      render: vi.fn(),
+    };
+  });
+  return { ...actual, WebGLRenderer: MockWebGLRenderer };
+});
+
+import { Scene } from './Scene';
+
+/**
+ * Regression tests for issue #360:
+ * Canvas must resize on container/window changes (mobile rotation, browser
+ * resize) instead of staying frozen at construction-time dimensions.
+ */
+
+// Capturable ResizeObserver so tests can fire observations on demand.
+type ROCallback = (entries: ResizeObserverEntry[], observer: ResizeObserver) => void;
+let lastObserver: { cb: ROCallback; targets: Element[]; disconnect: () => void } | null = null;
+
+class MockResizeObserver {
+  private _cb: ROCallback;
+  private _targets: Element[] = [];
+  constructor(cb: ROCallback) {
+    this._cb = cb;
+    lastObserver = {
+      cb,
+      targets: this._targets,
+      disconnect: () => this.disconnect(),
+    };
+  }
+  observe(el: Element) {
+    this._targets.push(el);
+  }
+  unobserve(el: Element) {
+    this._targets = this._targets.filter((t) => t !== el);
+  }
+  disconnect() {
+    this._targets.length = 0;
+  }
+}
+
+function fireResize() {
+  if (!lastObserver) throw new Error('No ResizeObserver was installed');
+  lastObserver.cb([], {} as ResizeObserver);
+}
+
+function flushRaf(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+function makeContainer(w: number, h: number): HTMLElement {
+  const el = document.createElement('div');
+  Object.defineProperty(el, 'clientWidth', { value: w, configurable: true });
+  Object.defineProperty(el, 'clientHeight', { value: h, configurable: true });
+  document.body.appendChild(el);
+  return el;
+}
+
+function setSize(el: HTMLElement, w: number, h: number) {
+  Object.defineProperty(el, 'clientWidth', { value: w, configurable: true });
+  Object.defineProperty(el, 'clientHeight', { value: h, configurable: true });
+}
+
+const originalRO = globalThis.ResizeObserver;
+
+describe('Scene auto-resize (issue #360)', () => {
+  beforeEach(() => {
+    lastObserver = null;
+    (globalThis as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+      MockResizeObserver as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    (globalThis as { ResizeObserver: typeof ResizeObserver }).ResizeObserver = originalRO;
+    document.body.innerHTML = '';
+  });
+
+  it('installs ResizeObserver on container when no explicit dimensions are passed', () => {
+    const container = makeContainer(800, 450);
+    const scene = new Scene(container);
+    expect(lastObserver).not.toBeNull();
+    expect(lastObserver!.targets).toContain(container);
+    scene.dispose();
+  });
+
+  it('does not install ResizeObserver when width and height are pinned', () => {
+    const container = makeContainer(800, 450);
+    const scene = new Scene(container, { width: 800, height: 450 });
+    expect(lastObserver).toBeNull();
+    scene.dispose();
+  });
+
+  it('does not install ResizeObserver when only width is pinned', () => {
+    const container = makeContainer(800, 450);
+    const scene = new Scene(container, { width: 800 });
+    expect(lastObserver).toBeNull();
+    scene.dispose();
+  });
+
+  it('does not install ResizeObserver when only height is pinned', () => {
+    const container = makeContainer(800, 450);
+    const scene = new Scene(container, { height: 450 });
+    expect(lastObserver).toBeNull();
+    scene.dispose();
+  });
+
+  it('does not install ResizeObserver when autoResize is false', () => {
+    const container = makeContainer(800, 450);
+    const scene = new Scene(container, { autoResize: false });
+    expect(lastObserver).toBeNull();
+    scene.dispose();
+  });
+
+  it('resizes renderer + camera when the container changes size', async () => {
+    const container = makeContainer(800, 450);
+    const scene = new Scene(container);
+    const resizeSpy = vi.spyOn(scene, 'resize');
+    const aspectSpy = vi.spyOn(scene.camera, 'setAspectRatio');
+
+    setSize(container, 1200, 700);
+    fireResize();
+    await flushRaf();
+
+    expect(resizeSpy).toHaveBeenCalledWith(1200, 700);
+    expect(aspectSpy).toHaveBeenLastCalledWith(1200 / 700);
+
+    scene.dispose();
+  });
+
+  it('coalesces rapid resize events into a single resize per frame', async () => {
+    const container = makeContainer(800, 450);
+    const scene = new Scene(container);
+    const resizeSpy = vi.spyOn(scene, 'resize');
+
+    setSize(container, 1000, 500);
+    fireResize();
+    fireResize();
+    fireResize();
+    await flushRaf();
+
+    expect(resizeSpy).toHaveBeenCalledTimes(1);
+    scene.dispose();
+  });
+
+  it('skips resize when container reports zero size (detached / hidden)', async () => {
+    const container = makeContainer(800, 450);
+    const scene = new Scene(container);
+    const resizeSpy = vi.spyOn(scene, 'resize');
+
+    setSize(container, 0, 0);
+    fireResize();
+    await flushRaf();
+
+    expect(resizeSpy).not.toHaveBeenCalled();
+    scene.dispose();
+  });
+
+  it('skips resize when dimensions are unchanged', async () => {
+    const container = makeContainer(800, 450);
+    const scene = new Scene(container);
+    const resizeSpy = vi.spyOn(scene, 'resize');
+
+    // Same size as construction.
+    fireResize();
+    await flushRaf();
+
+    expect(resizeSpy).not.toHaveBeenCalled();
+    scene.dispose();
+  });
+
+  it('responds to window resize as a fallback (no-RO browsers / orientation)', async () => {
+    const container = makeContainer(800, 450);
+    const scene = new Scene(container);
+    const resizeSpy = vi.spyOn(scene, 'resize');
+
+    setSize(container, 600, 800);
+    window.dispatchEvent(new Event('resize'));
+    await flushRaf();
+
+    expect(resizeSpy).toHaveBeenCalledWith(600, 800);
+    scene.dispose();
+  });
+
+  it('responds to orientationchange as a mobile fallback', async () => {
+    const container = makeContainer(800, 450);
+    const scene = new Scene(container);
+    const resizeSpy = vi.spyOn(scene, 'resize');
+
+    setSize(container, 480, 800);
+    window.dispatchEvent(new Event('orientationchange'));
+    await flushRaf();
+
+    expect(resizeSpy).toHaveBeenCalledWith(480, 800);
+    scene.dispose();
+  });
+
+  it('detaches observer + listeners on dispose', async () => {
+    const container = makeContainer(800, 450);
+    const scene = new Scene(container);
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const resizeSpy = vi.spyOn(scene, 'resize');
+
+    scene.dispose();
+
+    expect(removeSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith('orientationchange', expect.any(Function));
+
+    // Post-dispose events must not throw or trigger resize.
+    setSize(container, 100, 100);
+    window.dispatchEvent(new Event('resize'));
+    fireResize();
+    await flushRaf();
+    expect(resizeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -70,6 +70,13 @@ export interface SceneOptions {
   backgroundOpacity?: number;
   /** Enable headless mode (no WebGL renderer). Useful for testing scene logic without a DOM. */
   headless?: boolean;
+  /**
+   * Automatically resize the canvas when its container (or the window, on
+   * mobile rotation) changes size. Only active when both `width` and `height`
+   * are omitted — passing either dimension is treated as a request for a
+   * pinned canvas size, so auto-resize stays off. Defaults to true.
+   */
+  autoResize?: boolean;
 }
 
 /**
@@ -129,11 +136,21 @@ export class Scene {
   // for API compatibility and as a fallback when this is cleared.
   private _multiCamera: MultiCamera | null = null;
 
+  // Auto-resize: ResizeObserver on container + window listeners (orientationchange
+  // fallback for mobile browsers where ResizeObserver lags behind rotation).
+  // Listeners are coalesced via requestAnimationFrame to fire at most once per
+  // frame. Detached in `dispose()`.
+  private _container: HTMLElement | null = null;
+  private _resizeObserver: ResizeObserver | null = null;
+  private _resizeRafId: number | null = null;
+  private _onWindowResize: (() => void) | null = null;
+
   /**
    * Create a new Scene.
    * @param container - DOM element to render into, or null for headless mode
    * @param options - Scene configuration options
    */
+  // eslint-disable-next-line complexity
   constructor(container: HTMLElement | null, options: SceneOptions = {}) {
     const {
       width,
@@ -146,6 +163,7 @@ export class Scene {
       autoRender = true,
       backgroundOpacity = 1,
       headless = false,
+      autoResize = true,
     } = options;
 
     // Initialize performance options
@@ -179,6 +197,7 @@ export class Scene {
         antialias: true,
       };
       this._renderer = new Renderer(container, rendererOptions);
+      this._container = container;
     }
 
     // Create camera with Manim-style frame dimensions
@@ -206,6 +225,12 @@ export class Scene {
 
     // Initial render
     this._render();
+
+    // Install auto-resize observer. Only when neither width nor height was
+    // pinned by the caller — explicit dimensions are treated as a fixed canvas.
+    if (autoResize && !headless && this._container && width == null && height == null) {
+      this._installAutoResize();
+    }
   }
 
   /**
@@ -1195,6 +1220,60 @@ export class Scene {
   }
 
   /**
+   * Install ResizeObserver on the container and a window resize/orientation
+   * fallback. All triggers funnel through a single rAF-debounced measurement
+   * so a rotation that fires multiple events resizes once per frame.
+   */
+  private _installAutoResize(): void {
+    if (typeof window === 'undefined' || !this._container) return;
+
+    const measure = () => {
+      this._resizeRafId = null;
+      if (this._disposed || !this._container) return;
+      const w = Math.round(this._container.clientWidth);
+      const h = Math.round(this._container.clientHeight);
+      // Guard against zero-sized (detached / display:none) containers and
+      // skip when dimensions did not actually change to avoid render churn.
+      if (w <= 0 || h <= 0) return;
+      if (w === this._renderer.width && h === this._renderer.height) return;
+      this.resize(w, h);
+    };
+
+    const schedule = () => {
+      if (this._resizeRafId !== null) return;
+      this._resizeRafId = requestAnimationFrame(measure);
+    };
+
+    if (typeof ResizeObserver !== 'undefined') {
+      this._resizeObserver = new ResizeObserver(schedule);
+      this._resizeObserver.observe(this._container);
+    }
+
+    // Window resize covers browsers without ResizeObserver; orientationchange
+    // is a belt-and-suspenders trigger for older mobile browsers where the
+    // observer can lag behind device rotation.
+    this._onWindowResize = schedule;
+    window.addEventListener('resize', this._onWindowResize);
+    window.addEventListener('orientationchange', this._onWindowResize);
+  }
+
+  private _disposeAutoResize(): void {
+    if (this._resizeRafId !== null) {
+      cancelAnimationFrame(this._resizeRafId);
+      this._resizeRafId = null;
+    }
+    if (this._resizeObserver) {
+      this._resizeObserver.disconnect();
+      this._resizeObserver = null;
+    }
+    if (this._onWindowResize && typeof window !== 'undefined') {
+      window.removeEventListener('resize', this._onWindowResize);
+      window.removeEventListener('orientationchange', this._onWindowResize);
+    }
+    this._onWindowResize = null;
+  }
+
+  /**
    * Get the canvas element.
    * @returns The HTMLCanvasElement used for rendering
    */
@@ -1427,6 +1506,9 @@ export class Scene {
   dispose(): void {
     if (this._disposed) return;
     this._disposed = true;
+
+    // Detach auto-resize observer/listeners
+    this._disposeAutoResize();
 
     // Stop playback
     this._stopRenderLoop();

--- a/src/player/Player.test.ts
+++ b/src/player/Player.test.ts
@@ -68,7 +68,22 @@ describe('Player', () => {
     expect(player.isPlaying).toBe(false);
   });
 
-  it('stores original dimensions from scene', () => {
+  it('captures original dimensions when toggleFullscreen is called (issue #360)', () => {
+    // Pre-toggle: _orig stays at construction default (0) — captured lazily
+    // so any auto-resize before fullscreen is not snapshotted.
+    expect((player as any)._origWidth).toBe(0);
+    expect((player as any)._origHeight).toBe(0);
+
+    // happy-dom does not implement requestFullscreen; stub it to a no-op so
+    // toggleFullscreen() runs to completion.
+    (container as any).requestFullscreen = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(document, 'fullscreenElement', {
+      value: null,
+      configurable: true,
+    });
+
+    player.toggleFullscreen();
+
     expect((player as any)._origWidth).toBe(800);
     expect((player as any)._origHeight).toBe(450);
   });
@@ -568,6 +583,15 @@ describe('Player', () => {
 
     const resizeSpy = vi.spyOn(player.scene, 'resize');
     const renderSpy = vi.spyOn(player.scene, 'render');
+
+    // toggleFullscreen() snapshots the pre-fullscreen size before the request.
+    Object.defineProperty(document, 'fullscreenElement', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+    (container as any).requestFullscreen = vi.fn().mockResolvedValue(undefined);
+    player.toggleFullscreen();
 
     // Simulate entering fullscreen
     Object.defineProperty(document, 'fullscreenElement', {

--- a/src/player/Player.ts
+++ b/src/player/Player.ts
@@ -115,17 +115,14 @@ export class Player {
       getDuration: () => this._masterTimeline.getDuration(),
     });
 
-    // Track original dimensions for fullscreen restore
-    this._origWidth = this._scene.getWidth();
-    this._origHeight = this._scene.getHeight();
-
-    // Resize scene when entering/leaving fullscreen
+    // Resize scene when entering/leaving fullscreen. Restore dimensions are
+    // captured synchronously in `toggleFullscreen()` before `requestFullscreen`
+    // — capturing here would race with auto-resize and could snapshot the
+    // post-fullscreen layout as the "original".
     this._onFullscreenChange = () => {
       if (document.fullscreenElement === this._container) {
-        const w = window.innerWidth;
-        const h = window.innerHeight;
-        this._scene.resize(w, h);
-      } else {
+        this._scene.resize(window.innerWidth, window.innerHeight);
+      } else if (this._origWidth > 0 && this._origHeight > 0) {
         this._scene.resize(this._origWidth, this._origHeight);
       }
       this._scene.render();
@@ -419,8 +416,17 @@ export class Player {
     if (document.fullscreenElement === this._container) {
       document.exitFullscreen();
     } else {
+      // Capture restore dimensions synchronously, before requesting
+      // fullscreen. Doing it inside the fullscreenchange handler would race
+      // with auto-resize observers that may already see the fullscreen
+      // layout by the time the event fires.
+      this._origWidth = this._scene.getWidth();
+      this._origHeight = this._scene.getHeight();
       this._container.requestFullscreen().catch(() => {
-        // Fullscreen may be blocked by browser policy
+        // Fullscreen may be blocked by browser policy; discard the snapshot
+        // so a subsequent toggle does not restore to a stale size.
+        this._origWidth = 0;
+        this._origHeight = 0;
       });
     }
   }


### PR DESCRIPTION
Fixes #360.

## Summary
- `Scene` now installs a `ResizeObserver` on the container plus `window` `resize` / `orientationchange` listeners (rAF-debounced). Mobile rotation and viewport changes update the canvas and camera aspect without a reload.
- Auto-resize is gated on implicit dimensions (passing either `width` or `height` pins the canvas). Opt-out with `{ autoResize: false }`. All observers/listeners are detached in `Scene.dispose()`.
- `Renderer.resize()` re-applies `devicePixelRatio` so DPR changes on rotation don't leave a blurry buffer, while preserving an explicitly pinned `pixelRatio` (e.g. `1` for export).
- `Player` snapshots fullscreen restore dimensions synchronously inside `toggleFullscreen()` (instead of inside `fullscreenchange`) to avoid racing the new observer and snapshotting fullscreen size as the "original".
- Added `examples/responsive_canvas.html` as a manual demo of the fluid-canvas behavior.

## Test plan
- [x] `npm test` — 6028 tests pass, including 12 new tests in `Scene-auto-resize.test.ts` and `Renderer.test.ts` covering: observer install, gating on explicit width/height, rAF coalescing, zero-size/no-change skip, window resize + orientationchange fallbacks, dispose teardown, and DPR refresh behavior (auto vs pinned).
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Manual: open `examples/responsive_canvas.html` on a mobile device, rotate — canvas fills container without reload.