### PR TITLE
feat(#380): add onLog callback for subscribing to log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,26 @@ Have existing Manim scripts? Convert them:
 node tools/py2ts.cjs input.py -o output.ts
 ```
 
+## Logging
+
+manim-web logs through a small structured logger. Subscribe to log messages
+with `onLog` — useful for surfacing errors in your UI or forwarding them to a
+server (handy for AI agents that write and debug scenes):
+
+```ts
+import { onLog } from 'manim-web';
+
+const unsubscribe = onLog((entry) => {
+  // entry = { level, message, timestamp } — always JSON-serializable
+  fetch('/__log', { method: 'POST', body: JSON.stringify(entry) });
+});
+
+unsubscribe(); // stop receiving log messages
+```
+
+Forwarded messages are sanitized (tokens, keys, and emails are redacted) and
+respect the `LOG_LEVEL` environment variable (`debug` | `info` | `warn` | `error`).
+
 ## Contributing
 
 ```bash

--- a/examples/log_callback.html
+++ b/examples/log_callback.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ManimWeb - Log Callback (onLog)</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #1a1a2e;
+      display: flex;
+      gap: 16px;
+      justify-content: center;
+      align-items: flex-start;
+      min-height: 100vh;
+      padding: 24px;
+      font-family: system-ui, sans-serif;
+      color: #eee;
+    }
+    #container {
+      border: 2px solid #333;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    #panel {
+      width: 360px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    h1 { font-size: 16px; font-weight: 600; }
+    p { font-size: 12px; color: #aaa; line-height: 1.5; }
+    #log {
+      flex: 1;
+      min-height: 360px;
+      background: #11111c;
+      border: 1px solid #333;
+      border-radius: 6px;
+      padding: 10px;
+      font-family: ui-monospace, monospace;
+      font-size: 11px;
+      overflow-y: auto;
+      white-space: pre-wrap;
+    }
+    .entry { padding: 2px 0; border-bottom: 1px solid #222; }
+    .debug { color: #6c7a89; }
+    .info  { color: #4aa3df; }
+    .warn  { color: #f5c542; }
+    .error { color: #e94560; }
+    button {
+      padding: 10px 16px;
+      background: #e94560;
+      border: none;
+      border-radius: 4px;
+      color: white;
+      cursor: pointer;
+      font-size: 13px;
+    }
+    button:hover { background: #ff6b6b; }
+  </style>
+</head>
+<body>
+  <div id="container"></div>
+
+  <div id="panel">
+    <h1>onLog() — log message callback</h1>
+    <p>
+      Every <code>logger</code> call is forwarded to listeners registered with
+      <code>onLog()</code>. Entries are sanitized and JSON-serializable, so they
+      can be POSTed to a server — handy for AI agents that need to read errors.
+    </p>
+    <button id="runBtn">Run animation &amp; emit logs</button>
+    <div id="log"></div>
+  </div>
+
+  <script type="module">
+    import { Scene, Circle, Create, logger, onLog } from '../src/index.ts';
+
+    const container = document.getElementById('container');
+    const logEl = document.getElementById('log');
+
+    const scene = new Scene(container, {
+      width: 520,
+      height: 400,
+      backgroundColor: '#1a1a2e',
+    });
+
+    // --- Subscribe to log messages -----------------------------------------
+    // entry = { level, message, timestamp } — fully JSON-serializable.
+    const unsubscribe = onLog((entry) => {
+      const line = document.createElement('div');
+      line.className = `entry ${entry.level}`;
+      const time = new Date(entry.timestamp).toLocaleTimeString();
+      line.textContent = `[${time}] ${entry.level.toUpperCase()} ${entry.message}`;
+      logEl.appendChild(line);
+      logEl.scrollTop = logEl.scrollHeight;
+
+      // For AI agents / remote collection, forward it instead:
+      // fetch('/__log', { method: 'POST', body: JSON.stringify(entry) });
+    });
+
+    // Stop receiving entries when the page unloads.
+    window.addEventListener('beforeunload', unsubscribe);
+
+    document.getElementById('runBtn').addEventListener('click', async () => {
+      scene.clear();
+      logEl.textContent = '';
+
+      logger.info('starting animation');
+      logger.debug('debug lines are filtered out unless LOG_LEVEL=debug');
+
+      const c = new Circle({ radius: 1.2, color: '#e94560', strokeWidth: 4 });
+      scene.add(c);
+      await scene.play(new Create(c));
+
+      logger.warn('animation finished, scene still has', 1, 'mobject');
+      logger.error(new Error('example error so agents can see stack capture'));
+    });
+  </script>
+</body>
+</html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -991,3 +991,6 @@ export {
   resetFeatureFlags,
   getFeatureFlags,
 } from './utils/featureFlags';
+
+// Logging
+export { logger, onLog, type LogEntry, type LogLevel, type LogListener } from './utils/logger';

--- a/src/utils/logger-callback.test.ts
+++ b/src/utils/logger-callback.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { logger, onLog, clearLogListeners, type LogEntry } from './logger';
+
+// ---------------------------------------------------------------------------
+// onLog — log-message callback subscription (issue #380)
+// ---------------------------------------------------------------------------
+
+describe('onLog', () => {
+  beforeEach(() => {
+    // Silence console so test output stays pristine.
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    clearLogListeners();
+    vi.restoreAllMocks();
+  });
+
+  it('delivers a structured entry to a registered listener', () => {
+    const entries: LogEntry[] = [];
+    onLog((entry) => entries.push(entry));
+
+    logger.info('hello world');
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].level).toBe('info');
+    expect(entries[0].message).toBe('hello world');
+    expect(typeof entries[0].timestamp).toBe('number');
+    expect(entries[0].timestamp).toBeGreaterThan(0);
+  });
+
+  it('joins multiple arguments into the message', () => {
+    const entries: LogEntry[] = [];
+    onLog((entry) => entries.push(entry));
+
+    logger.warn('count is', 42, { ok: true });
+
+    expect(entries[0].level).toBe('warn');
+    expect(entries[0].message).toBe('count is 42 {"ok":true}');
+  });
+
+  it('stops delivering after unsubscribe', () => {
+    const entries: LogEntry[] = [];
+    const unsubscribe = onLog((entry) => entries.push(entry));
+
+    logger.info('first');
+    unsubscribe();
+    logger.info('second');
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].message).toBe('first');
+  });
+
+  it('notifies every registered listener', () => {
+    const a: LogEntry[] = [];
+    const b: LogEntry[] = [];
+    onLog((entry) => a.push(entry));
+    onLog((entry) => b.push(entry));
+
+    logger.error('boom');
+
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+  });
+
+  it('isolates a throwing listener so others still fire and logging survives', () => {
+    const received: LogEntry[] = [];
+    onLog(() => {
+      throw new Error('listener exploded');
+    });
+    onLog((entry) => received.push(entry));
+
+    expect(() => logger.info('still works')).not.toThrow();
+    expect(received).toHaveLength(1);
+    expect(received[0].message).toBe('still works');
+  });
+
+  it('sanitizes sensitive data in the forwarded message', () => {
+    const entries: LogEntry[] = [];
+    onLog((entry) => entries.push(entry));
+
+    logger.info('Auth: ' + 'Bearer ' + 'abc123XYZtoken456');
+
+    expect(entries[0].message).toContain('[REDACTED]');
+    expect(entries[0].message).not.toContain('abc123XYZtoken456');
+  });
+
+  it('respects the log-level filter (debug suppressed at default level)', () => {
+    const entries: LogEntry[] = [];
+    onLog((entry) => entries.push(entry));
+
+    logger.debug('verbose detail');
+
+    expect(entries).toHaveLength(0);
+  });
+
+  it('serializes Error arguments with a useful message', () => {
+    const entries: LogEntry[] = [];
+    onLog((entry) => entries.push(entry));
+
+    logger.error(new Error('something failed'));
+
+    expect(entries[0].message).toContain('something failed');
+  });
+
+  it('emits to listeners only after writing to the console', () => {
+    let consoleCalledWhenListenerFired = false;
+    onLog(() => {
+      consoleCalledWhenListenerFired =
+        (console.info as ReturnType<typeof vi.fn>).mock.calls.length > 0;
+    });
+
+    logger.info('ordering check');
+
+    expect(consoleCalledWhenListenerFired).toBe(true);
+  });
+
+  it('does not recurse when a listener calls the logger', () => {
+    let calls = 0;
+    onLog(() => {
+      calls += 1;
+      if (calls < 5) logger.info('re-entrant call');
+    });
+
+    expect(() => logger.info('start')).not.toThrow();
+    expect(calls).toBe(1);
+  });
+
+  it('handles circular objects without throwing', () => {
+    const entries: LogEntry[] = [];
+    onLog((entry) => entries.push(entry));
+
+    const circular: Record<string, unknown> = { name: 'loop' };
+    circular.self = circular;
+
+    expect(() => logger.info('cycle:', circular)).not.toThrow();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].message).toContain('cycle:');
+  });
+
+  it('redacts object values stored under sensitive keys', () => {
+    const entries: LogEntry[] = [];
+    onLog((entry) => entries.push(entry));
+
+    logger.info({ api_key: 'secretvalue123', label: 'safe-to-show' });
+
+    expect(entries[0].message).not.toContain('secretvalue123');
+    expect(entries[0].message).toContain('[REDACTED]');
+    expect(entries[0].message).toContain('safe-to-show');
+  });
+
+  it('renders shared (non-circular) references without a false [Circular]', () => {
+    const entries: LogEntry[] = [];
+    onLog((entry) => entries.push(entry));
+
+    const shared = { value: 7 };
+    logger.info({ a: shared, b: shared });
+
+    expect(entries[0].message).not.toContain('[Circular]');
+    // Both occurrences of the shared object should be rendered.
+    expect(entries[0].message.match(/7/g)).toHaveLength(2);
+  });
+
+  it('sanitizes secrets when reporting a thrown listener error', () => {
+    const errorSpy = console.error as unknown as ReturnType<typeof vi.fn>;
+    onLog(() => {
+      throw new Error('listener leak: ' + 'Bearer ' + 'abc123XYZtoken456');
+    });
+
+    logger.info('trigger');
+
+    const reported = errorSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join(' ');
+    expect(reported).toContain('[REDACTED]');
+    expect(reported).not.toContain('abc123XYZtoken456');
+  });
+
+  it('redacts structured secrets in a non-Error thrown listener value', () => {
+    const errorSpy = console.error as unknown as ReturnType<typeof vi.fn>;
+    onLog(() => {
+      throw { apiKey: 'hunter2plaintext' };
+    });
+
+    logger.info('trigger');
+
+    const reported = errorSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join(' ');
+    expect(reported).not.toContain('hunter2plaintext');
+    expect(reported).toContain('[REDACTED]');
+  });
+
+  it('clearLogListeners removes all listeners', () => {
+    const entries: LogEntry[] = [];
+    onLog((entry) => entries.push(entry));
+
+    clearLogListeners();
+    logger.info('after clear');
+
+    expect(entries).toHaveLength(0);
+  });
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -4,7 +4,8 @@
  * Includes log sanitization to redact sensitive data (tokens, keys, emails).
  */
 
-type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+/** Severity of a log message. */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 interface Logger {
   debug: (...args: unknown[]) => void;
@@ -12,6 +13,22 @@ interface Logger {
   warn: (...args: unknown[]) => void;
   error: (...args: unknown[]) => void;
 }
+
+/**
+ * A single log event delivered to {@link onLog} listeners. Every field is a
+ * primitive, so an entry is always safe to `JSON.stringify`.
+ */
+export interface LogEntry {
+  /** Severity of the log call. */
+  level: LogLevel;
+  /** Sanitized, human-readable message built from all log arguments. */
+  message: string;
+  /** Unix epoch milliseconds (`Date.now()`) when the log call happened. */
+  timestamp: number;
+}
+
+/** Callback invoked for every log message that passes the level filter. */
+export type LogListener = (entry: LogEntry) => void;
 
 const LOG_LEVELS: Record<LogLevel, number> = {
   debug: 0,
@@ -67,6 +84,17 @@ const SENSITIVE_PATTERNS: RegExp[] = [
 ];
 
 /**
+ * Object keys whose values are redacted regardless of the value's format.
+ *
+ * The {@link SENSITIVE_PATTERNS} above only catch secrets that *look* like
+ * secrets (token prefixes, `key=value` assignments). A secret stored as a bare
+ * object value — `{ apiKey: 'hunter2' }` — has no recognizable shape, so it is
+ * caught here by the name of the key holding it.
+ */
+const SENSITIVE_KEY_PATTERN =
+  /pass(?:word|wd)|secret|token|authorization|api[_-]?key|access[_-]?key|private[_-]?key|credential/i;
+
+/**
  * Sanitize a single string by replacing all sensitive patterns with a
  * redaction placeholder.
  */
@@ -83,24 +111,42 @@ function sanitizeString(value: string): string {
 /**
  * Recursively sanitize a single log argument.
  *  - Strings are scrubbed directly.
- *  - Plain objects and arrays are shallow-cloned with their string values scrubbed.
+ *  - Plain objects and arrays are cloned with their string values scrubbed,
+ *    and values under {@link SENSITIVE_KEY_PATTERN} keys fully redacted.
+ *  - Circular references are replaced with `[Circular]`.
  *  - All other types are returned as-is.
+ *
+ * @param seen Objects on the *current* recursion path; used to detect cycles.
+ *   Entries are removed on unwind so a value referenced twice (a diamond, not
+ *   a cycle) is not mistaken for a circular reference.
  */
-function sanitizeArg(arg: unknown): unknown {
+function sanitizeArg(arg: unknown, seen: WeakSet<object> = new WeakSet()): unknown {
   if (typeof arg === 'string') {
     return sanitizeString(arg);
   }
 
   if (Array.isArray(arg)) {
-    return arg.map(sanitizeArg);
+    if (seen.has(arg)) return '[Circular]';
+    seen.add(arg);
+    try {
+      return arg.map((value) => sanitizeArg(value, seen));
+    } finally {
+      seen.delete(arg);
+    }
   }
 
   if (arg !== null && typeof arg === 'object') {
-    const sanitized: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(arg as Record<string, unknown>)) {
-      sanitized[key] = sanitizeArg(value);
+    if (seen.has(arg)) return '[Circular]';
+    seen.add(arg);
+    try {
+      const sanitized: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(arg as Record<string, unknown>)) {
+        sanitized[key] = SENSITIVE_KEY_PATTERN.test(key) ? REDACTED : sanitizeArg(value, seen);
+      }
+      return sanitized;
+    } finally {
+      seen.delete(arg);
     }
-    return sanitized;
   }
 
   return arg;
@@ -108,24 +154,139 @@ function sanitizeArg(arg: unknown): unknown {
 
 /** Sanitize an entire list of log arguments. */
 function sanitizeArgs(args: unknown[]): unknown[] {
-  return args.map(sanitizeArg);
+  return args.map((arg) => sanitizeArg(arg));
+}
+
+// ---------------------------------------------------------------------------
+// Log-message callbacks  (issue #380)
+// ---------------------------------------------------------------------------
+
+const logListeners = new Set<LogListener>();
+
+/**
+ * Whether a listener notification is currently in flight. Guards against a
+ * listener that itself calls `logger.*` triggering unbounded recursion.
+ */
+let notifying = false;
+
+/**
+ * Stringify a value without throwing on circular references or `BigInt`
+ * values. The result is scrubbed by {@link buildMessage} before it reaches a
+ * listener, so this only needs to be crash-safe, not redacted.
+ */
+function safeStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+  try {
+    const json = JSON.stringify(value, (_key, val: unknown) => {
+      if (typeof val === 'bigint') return val.toString();
+      if (typeof val === 'object' && val !== null) {
+        if (seen.has(val)) return '[Circular]';
+        seen.add(val);
+      }
+      return val;
+    });
+    return json ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/** Render one raw log argument as a string for {@link LogEntry.message}. */
+function formatArg(arg: unknown): string {
+  if (typeof arg === 'string') return arg;
+  // Errors carry their useful data (message/stack) in non-enumerable fields,
+  // so a generic object walk would yield "{}". Handle them explicitly.
+  if (arg instanceof Error) return arg.stack ?? `${arg.name}: ${arg.message}`;
+  if (arg !== null && typeof arg === 'object') return safeStringify(arg);
+  return String(arg);
+}
+
+/**
+ * Build a single sanitized message string from a list of log arguments.
+ *
+ * Non-`Error` arguments are run through {@link sanitizeArg} first so that
+ * key-aware redaction applies to structured data; `Error` arguments keep their
+ * stack via {@link formatArg}. The joined result is scrubbed once more so any
+ * secret revealed by stringification is caught.
+ */
+function buildMessage(args: unknown[]): string {
+  const parts = args.map((arg) =>
+    arg instanceof Error ? formatArg(arg) : formatArg(sanitizeArg(arg)),
+  );
+  return sanitizeString(parts.join(' '));
+}
+
+/**
+ * Register a callback that receives every log message (at or above the active
+ * `LOG_LEVEL`). The forwarded {@link LogEntry} is sanitized, so secrets are
+ * never leaked to a remote endpoint.
+ *
+ * @returns An unsubscribe function that removes the listener.
+ *
+ * @example
+ * ```ts
+ * import { onLog } from 'manim-web';
+ *
+ * const stop = onLog((entry) =>
+ *   fetch('/__log', { method: 'POST', body: JSON.stringify(entry) }),
+ * );
+ * // ...later
+ * stop();
+ * ```
+ */
+export function onLog(listener: LogListener): () => void {
+  logListeners.add(listener);
+  return () => {
+    logListeners.delete(listener);
+  };
+}
+
+/** Remove all registered {@link onLog} listeners. */
+export function clearLogListeners(): void {
+  logListeners.clear();
+}
+
+/** Deliver a log entry to every listener, isolating failures and recursion. */
+function notifyListeners(level: LogLevel, args: unknown[]): void {
+  if (logListeners.size === 0 || notifying) return;
+  notifying = true;
+  const entry: LogEntry = {
+    level,
+    message: buildMessage(args),
+    timestamp: Date.now(),
+  };
+  try {
+    for (const listener of logListeners) {
+      try {
+        listener(entry);
+      } catch (err) {
+        // Report directly via console — never via `logger`, which would
+        // recurse back into this function. Route the thrown value through the
+        // same key-aware sanitize pipeline as a normal log argument: it may
+        // carry secrets and this path skips the standard one.
+        console.error('[manim-web] log listener threw:', buildMessage([err]));
+      }
+    }
+  } finally {
+    notifying = false;
+  }
 }
 
 // ---------------------------------------------------------------------------
 // Public logger
 // ---------------------------------------------------------------------------
 
+/** Write to the console (if the level passes) then notify {@link onLog} listeners. */
+function emit(level: LogLevel, args: unknown[]): void {
+  if (!shouldLog(level)) return;
+  // Look up the console method dynamically so test spies are honored.
+  console[level]('[manim-web]', ...sanitizeArgs(args));
+  notifyListeners(level, args);
+}
+
 export const logger: Logger = {
-  debug: (...args: unknown[]) => {
-    if (shouldLog('debug')) console.debug('[manim-web]', ...sanitizeArgs(args));
-  },
-  info: (...args: unknown[]) => {
-    if (shouldLog('info')) console.info('[manim-web]', ...sanitizeArgs(args));
-  },
-  warn: (...args: unknown[]) => {
-    if (shouldLog('warn')) console.warn('[manim-web]', ...sanitizeArgs(args));
-  },
-  error: (...args: unknown[]) => {
-    if (shouldLog('error')) console.error('[manim-web]', ...sanitizeArgs(args));
-  },
+  debug: (...args: unknown[]) => emit('debug', args),
+  info: (...args: unknown[]) => emit('info', args),
+  warn: (...args: unknown[]) => emit('warn', args),
+  error: (...args: unknown[]) => emit('error', args),
 };


### PR DESCRIPTION
## Summary

Closes #380.

Adds an `onLog` callback so consumers can subscribe to manim-web log messages and process/forward them — e.g. `POST` to a server. Useful for AI agents that write scenes and need to read errors quickly.

```ts
import { onLog } from 'manim-web';

const unsubscribe = onLog((entry) => {
  // entry = { level, message, timestamp } — always JSON-serializable
  fetch('/__log', { method: 'POST', body: JSON.stringify(entry) });
});

unsubscribe(); // stop receiving
```

## Changes

- **`src/utils/logger.ts`** — listener registry behind `onLog(listener)` (returns an unsubscribe fn). Each `logger.*` call emits a sanitized, JSON-serializable `LogEntry { level, message, timestamp }` after writing to the console, gated by the same `LOG_LEVEL` filter. Listener failures are isolated (one throwing listener can't break logging) and a reentrancy guard prevents infinite recursion if a listener itself logs.
- **Security hardening** — added key-aware redaction (`SENSITIVE_KEY_PATTERN`) so secrets stored as bare object values (`{ apiKey: '...' }`) are scrubbed before reaching a listener, not just secrets that *look* like tokens. `sanitizeArg` now uses path-unwind cycle detection so shared (diamond) references aren't misreported as `[Circular]`.
- **`src/index.ts`** — exports `logger`, `onLog`, and the `LogEntry` / `LogLevel` / `LogListener` types. `clearLogListeners` is intentionally **not** exported (global mutation; test-only).
- **`examples/log_callback.html`** — runnable demo showing the callback live.
- **`README.md`** — new Logging section.

## Testing

- New `src/utils/logger-callback.test.ts` — 16 tests (TDD): delivery, unsubscribe, multiple listeners, throwing-listener isolation, sanitization, level gating, `Error` serialization, emit ordering, reentrancy, circular objects, key-aware redaction, shared-reference handling.
- Full suite: **6044 passing**. Typecheck + lint clean.
- Example verified end-to-end in a browser — `onLog` captures info/warn/error entries (with stack), debug correctly filtered.

## Notes

Non-breaking — additive only. The `logger` util was not previously exported from the package root; it is now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
