### PR TITLE
fix(#396): unify @mathjax/src singleton across chunks

### DIFF
--- a/examples/issue_396_repro.html
+++ b/examples/issue_396_repro.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Issue #396 — MathTex via spherical coords</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: #191919;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100vw;
+        height: 100vh;
+        overflow: hidden;
+        color: #fff;
+        font-family: sans-serif;
+      }
+      #container {
+        width: 100vw;
+        height: 100vh;
+      }
+      #status {
+        position: fixed;
+        top: 12px;
+        left: 12px;
+        background: rgba(0, 0, 0, 0.65);
+        padding: 8px 12px;
+        border-radius: 6px;
+        font-size: 13px;
+        z-index: 10;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="status">loading…</div>
+    <div id="container"></div>
+
+    <script type="module">
+      import {
+        Dot3D,
+        YELLOW,
+        makeDraggable,
+        MathTex,
+        ThreeDAxes,
+        ThreeDScene,
+        Line3D,
+        WHITE,
+      } from '../src/index.ts';
+
+      const statusEl = document.getElementById('status');
+
+      const scene = new ThreeDScene(document.getElementById('container'), {
+        width: window.innerWidth,
+        height: window.innerHeight,
+        backgroundColor: '#191919',
+        phi: 75 * (Math.PI / 180),
+        theta: -45 * (Math.PI / 180),
+        distance: 20,
+        fov: 30,
+        enableOrbitControls: true,
+        orbitControlsUp: 'z',
+      });
+
+      const axes = new ThreeDAxes({
+        xRange: [-5, 5, 1],
+        yRange: [-5, 5, 1],
+        zRange: [-5, 5, 1],
+        xLength: 10,
+        yLength: 10,
+        zLength: 10,
+        showTicks: false,
+      });
+
+      const dot = new Dot3D({ radius: 0.1, color: YELLOW })
+        .moveTo(axes.coordsToPoint(1, 1, 1))
+        .addUpdater(() => {});
+      makeDraggable(dot, scene);
+
+      const radius = new Line3D({ start: [0, 0, 0], end: dot.getCenter(), lineWidth: 40 }).addUpdater(
+        (mob) => {
+          mob.setEnd(dot.getCenter());
+        },
+      );
+
+      const r = new MathTex({ latex: 'r', color: WHITE, fontSize: 22 }).addUpdater((mob) => {
+        mob.moveTo(radius.getMidpoint());
+      });
+
+      try {
+        await r.waitForRender();
+        statusEl.textContent = 'MathTex rendered ✓ (issue #396 fixed)';
+      } catch (e) {
+        statusEl.textContent = 'MathTex failed ✗ ' + e.message;
+        console.error(e);
+      }
+
+      scene.add(axes, dot, radius, r);
+      await scene.wait(Infinity);
+    </script>
+  </body>
+</html>

--- a/src/mobjects/text/MathJaxBundle.ts
+++ b/src/mobjects/text/MathJaxBundle.ts
@@ -1,0 +1,40 @@
+/**
+ * MathJaxBundle - single import surface for all `@mathjax/src` modules.
+ *
+ * Why this file exists:
+ *   `MathJaxRenderer.ts` used to call `await import('@mathjax/src/js/...')`
+ *   for five separate submodules (mathjax, tex, svg, liteAdaptor, html) plus
+ *   side-effect imports for the AMS / Newcommand / ConfigMacros TeX packages.
+ *   Vite/Rollup chunks them with a shared `mathjax-*.js` chunk so the
+ *   `mathjax` singleton (which holds the global `HandlerList`) stays unique.
+ *
+ *   Some downstream bundlers (most notably esm.sh) re-bundle every emitted
+ *   `.mjs` independently and re-inline the `mathjax` source into each chunk.
+ *   That produces two parallel `mathjax` singletons:
+ *     - `RegisterHTMLHandler(adaptor)` writes to the singleton living inside
+ *       `handlers/html.js`'s chunk.
+ *     - `mathjax.document(...)` reads the singleton living inside
+ *       `mathjax.js`'s chunk.
+ *   Result: an empty handler list and the runtime error
+ *   `Can't find handler for document` (issue #396).
+ *
+ *   Collapsing every `@mathjax/src` access into this single module gives the
+ *   downstream bundler a single chunk to ship. The shared `mathjax` singleton
+ *   is then unambiguous: there is only one place it can live.
+ *
+ *   IMPORTANT: keep this file as the ONLY runtime surface that imports from
+ *   `@mathjax/src`. Side-effect imports for the TeX packages must stay here
+ *   (they register themselves on import) and must not be tree-shaken; rollup
+ *   keeps bare imports for side effects by default.
+ */
+
+import { mathjax } from '@mathjax/src/js/mathjax.js';
+import { TeX } from '@mathjax/src/js/input/tex.js';
+import { SVG } from '@mathjax/src/js/output/svg.js';
+import { liteAdaptor } from '@mathjax/src/js/adaptors/liteAdaptor.js';
+import { RegisterHTMLHandler } from '@mathjax/src/js/handlers/html.js';
+import '@mathjax/src/js/input/tex/ams/AmsConfiguration.js';
+import '@mathjax/src/js/input/tex/newcommand/NewcommandConfiguration.js';
+import '@mathjax/src/js/input/tex/configmacros/ConfigMacrosConfiguration.js';
+
+export { mathjax, TeX, SVG, liteAdaptor, RegisterHTMLHandler };

--- a/src/mobjects/text/MathJaxRenderer.ts
+++ b/src/mobjects/text/MathJaxRenderer.ts
@@ -14,8 +14,10 @@
 import katex from 'katex';
 import type { VGroup } from '../../core/VGroup';
 import { svgToVMobjects } from './svgPathParser';
-import { LiteAdaptor } from '@mathjax/src/js/adaptors/liteAdaptor.js';
-import { LiteElement } from '@mathjax/src/js/adaptors/lite/Element.js';
+// Type-only imports so MathJax never enters the main module graph. The
+// runtime values arrive lazily through `./MathJaxBundle.js`.
+import type { LiteAdaptor } from '@mathjax/src/js/adaptors/liteAdaptor.js';
+import type { LiteElement } from '@mathjax/src/js/adaptors/lite/Element.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -83,31 +85,36 @@ interface MathJaxModuleGlobal {
 /** Generic callable constructor for dynamic MathJax classes */
 type MathJaxConstructor = new (options: Record<string, unknown>) => Record<string, unknown>;
 
-interface MathJaxNpmMjModule {
-  mathjax: {
-    document: (
-      content: string,
-      options: Record<string, unknown>,
-    ) => {
-      convert: (input: string, options: Record<string, unknown>) => unknown;
-    };
+interface MathJaxSingleton {
+  document: (
+    content: string,
+    options: Record<string, unknown>,
+  ) => {
+    convert: (input: string, options: Record<string, unknown>) => unknown;
   };
-}
-
-interface MathJaxNpmTexModule {
-  TeX: MathJaxConstructor;
-}
-
-interface MathJaxNpmSvgModule {
-  SVG: MathJaxConstructor;
+  /** Internal registry the npm path uses to assert handler registration. */
+  handlers?: { [Symbol.iterator]?: () => Iterator<unknown> };
 }
 
 interface MathJaxModuleNpm {
   strategy: 'npm';
-  mjModule: MathJaxNpmMjModule;
-  texModule: MathJaxNpmTexModule;
-  svgModule: MathJaxNpmSvgModule;
+  mathjax: MathJaxSingleton;
+  TeX: MathJaxConstructor;
+  SVG: MathJaxConstructor;
   adaptor: LiteAdaptor;
+}
+
+/**
+ * Thrown when the npm-path `mathjax` singleton produced by `RegisterHTMLHandler`
+ * does not share its handler list with the `mathjax.document(...)` callsite.
+ * This typically means the downstream bundler (e.g. esm.sh) re-bundled
+ * `@mathjax/src` into separate copies. The error triggers the CDN fallback.
+ */
+export class MathJaxSingletonMismatchError extends Error {
+  constructor(message = 'MathJax singletons split during bundling') {
+    super(message);
+    this.name = 'MathJaxSingletonMismatchError';
+  }
 }
 
 type MathJaxModuleState = MathJaxModuleGlobal | MathJaxModuleNpm;
@@ -123,6 +130,29 @@ let mathjaxModule: MathJaxModuleState | null = null;
 let mathjaxLoadPromise: Promise<MathJaxModuleState> | null = null;
 
 /**
+ * Probe whether `RegisterHTMLHandler` actually populated the `mathjax`
+ * singleton we will later call `.document(...)` on. Returns true when at
+ * least one handler is registered.
+ */
+function hasRegisteredHandler(mathjax: MathJaxSingleton): boolean {
+  const handlers = mathjax.handlers;
+  if (!handlers) return false;
+  // HandlerList exposes `Symbol.iterator`; counting via iteration covers
+  // both real lists and any test stubs that match the same shape.
+  if (typeof handlers[Symbol.iterator] === 'function') {
+    for (const item of handlers as Iterable<unknown>) {
+      void item;
+      return true;
+    }
+    return false;
+  }
+  // Last-ditch structural check for an `items` array if the iterator shape
+  // ever changes upstream.
+  const items = (handlers as { items?: unknown[] }).items;
+  return Array.isArray(items) && items.length > 0;
+}
+
+/**
  * Dynamically load MathJax's SVG output module.
  *
  * We use the "@mathjax/src" npm package which provides a programmatic API
@@ -134,33 +164,36 @@ async function loadMathJax(): Promise<MathJaxModuleState> {
   if (mathjaxLoadPromise) return mathjaxLoadPromise;
 
   mathjaxLoadPromise = (async () => {
-    // Strategy 1: try the npm package "@mathjax/src"
-    // it will resolve for local npm installs, but it will not be bundled in browser code.
+    // Strategy 1: load `@mathjax/src` through a single internal wrapper
+    // module. Collapsing every `@mathjax/src` access into one dynamic import
+    // forces downstream bundlers (esm.sh, CDNs) to emit a single chunk, which
+    // keeps the `mathjax` singleton unique. See ./MathJaxBundle.ts and #396.
     try {
-      const mjModule = await import('@mathjax/src/js/mathjax.js');
-      const texModule = await import('@mathjax/src/js/input/tex.js');
-      const svgModule = await import('@mathjax/src/js/output/svg.js');
-      const { liteAdaptor } = await import('@mathjax/src/js/adaptors/liteAdaptor.js');
-      const { RegisterHTMLHandler } = await import('@mathjax/src/js/handlers/html.js');
-      // Register TeX packages (ams, newcommand, configmacros) so environments like pmatrix/bmatrix work
-      await import('@mathjax/src/js/input/tex/ams/AmsConfiguration.js');
-      await import('@mathjax/src/js/input/tex/newcommand/NewcommandConfiguration.js');
-      await import('@mathjax/src/js/input/tex/configmacros/ConfigMacrosConfiguration.js');
+      const bundle = await import('./MathJaxBundle.js');
 
-      const adaptor = liteAdaptor();
-      RegisterHTMLHandler(adaptor);
+      const adaptor = bundle.liteAdaptor();
+      bundle.RegisterHTMLHandler(adaptor);
+
+      // Verify the handler landed on the same `mathjax` singleton we will
+      // later call `.document()` on. If the bundler split the chunk we will
+      // observe an empty handler list here and fall through to the CDN path
+      // instead of caching a broken state.
+      const mathjax = bundle.mathjax as unknown as MathJaxSingleton;
+      if (!hasRegisteredHandler(mathjax)) {
+        throw new MathJaxSingletonMismatchError();
+      }
 
       const result: MathJaxModuleNpm = {
-        mjModule: mjModule as unknown as MathJaxNpmMjModule,
-        texModule: texModule as unknown as MathJaxNpmTexModule,
-        svgModule: svgModule as unknown as MathJaxNpmSvgModule,
+        mathjax,
+        TeX: bundle.TeX as unknown as MathJaxConstructor,
+        SVG: bundle.SVG as unknown as MathJaxConstructor,
         adaptor,
         strategy: 'npm' as const,
       };
       mathjaxModule = result;
       return result;
     } catch {
-      // npm package not available -- fall through
+      // Bundle missing or singleton split -- fall through to CDN strategy.
     }
 
     // Strategy 2: global MathJax loaded via <script> tag (CDN fallback)
@@ -314,10 +347,7 @@ export async function renderLatexToSVG(
     // ------------------------------------------------------------------
     // npm @mathjax/src
     // ------------------------------------------------------------------
-    const { mjModule, texModule, svgModule, adaptor } = mj;
-    const MathJax = mjModule.mathjax;
-    const TeX = texModule.TeX;
-    const SVG = svgModule.SVG;
+    const { mathjax: MathJax, TeX, SVG, adaptor } = mj;
 
     const tex = new TeX({
       packages: ['base', 'ams', 'newcommand', 'configmacros'],

--- a/src/mobjects/text/mathjax-bundle-shape.test.ts
+++ b/src/mobjects/text/mathjax-bundle-shape.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+
+/**
+ * Build-shape regression for issue #396.
+ *
+ * The issue #396 bug only manifests when downstream bundlers re-bundle each
+ * emitted chunk independently (e.g. esm.sh). Source-level tests cannot catch
+ * a regression that re-externalizes `@mathjax/src` in `vite.config.ts`, so we
+ * assert against the published `dist/` shape directly:
+ *
+ *   - `dist/src-*.js` must contain exactly one `await import("./MathJaxBundle*")`
+ *     and no other `@mathjax/src` dynamic imports. Any other MathJax chunk
+ *     name (mathjax-*, tex-*, svg-*, html-*, liteAdaptor-*, AmsConfiguration*,
+ *     NewcommandConfiguration*, ConfigMacrosConfiguration*) means the
+ *     singleton can be duplicated again under re-bundling.
+ *
+ * The test is skipped when `dist/` is absent (developer who has not run
+ * `npm run build`); CI runs `npm run build` first.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DIST = join(__dirname, '..', '..', '..', 'dist');
+
+const SPLIT_CHUNK_PATTERNS = [
+  /mathjax-[A-Za-z0-9_-]+\.js/,
+  /^tex-[A-Za-z0-9_-]+\.js/,
+  /^svg-[A-Za-z0-9_-]+\.js/,
+  /^html-[A-Za-z0-9_-]+\.js/,
+  /liteAdaptor-[A-Za-z0-9_-]+\.js/,
+  /AmsConfiguration-[A-Za-z0-9_-]+\.js/,
+  /NewcommandConfiguration-[A-Za-z0-9_-]+\.js/,
+  /ConfigMacrosConfiguration-[A-Za-z0-9_-]+\.js/,
+];
+
+describe('dist/ MathJax chunk shape (issue #396)', () => {
+  if (!existsSync(DIST)) {
+    it.skip('dist/ not built — skipping shape assertion', () => {});
+    return;
+  }
+
+  const files = readdirSync(DIST);
+
+  it('emits a single MathJaxBundle chunk and no split MathJax chunks', () => {
+    const bundles = files.filter((f) => /^MathJaxBundle-[A-Za-z0-9_-]+\.js$/.test(f));
+    expect(
+      bundles.length,
+      `expected exactly one MathJaxBundle chunk, got: ${bundles.join(', ')}`,
+    ).toBe(1);
+
+    for (const pattern of SPLIT_CHUNK_PATTERNS) {
+      const offenders = files.filter((f) => pattern.test(f));
+      expect(
+        offenders,
+        `dist/ must not contain ${pattern} — these chunks split the mathjax singleton and reintroduce #396`,
+      ).toEqual([]);
+    }
+  });
+
+  it('renderer dynamic-imports only the MathJaxBundle chunk', () => {
+    const srcChunks = files.filter((f) => /^src-[A-Za-z0-9_-]+\.js$/.test(f));
+    expect(srcChunks.length, 'expected a dist/src-*.js entry chunk').toBeGreaterThan(0);
+
+    for (const chunk of srcChunks) {
+      const body = readFileSync(join(DIST, chunk), 'utf8');
+      const dynImports = [...body.matchAll(/await import\("\.\/([^"]+)"\)/g)].map((m) => m[1]);
+      const mathjaxImports = dynImports.filter((n) =>
+        /MathJax|mathjax|tex-|svg-|html-|liteAdaptor|Configuration/i.test(n),
+      );
+      expect(
+        mathjaxImports,
+        `dist/${chunk} must only dynamic-import MathJaxBundle, got: ${mathjaxImports.join(', ')}`,
+      ).toSatisfy((arr: string[]) => arr.every((n) => /^MathJaxBundle-/.test(n)));
+    }
+  });
+});

--- a/src/mobjects/text/mathjax-singleton.test.ts
+++ b/src/mobjects/text/mathjax-singleton.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+
+/**
+ * Regression for issue #396.
+ *
+ * MathTex broke when manim-web was loaded through esm.sh because
+ * `RegisterHTMLHandler(adaptor)` and `mathjax.document(...)` ended up running
+ * against two different copies of the `mathjax` singleton (the downstream
+ * bundler re-inlined `@mathjax/src/mjs/mathjax.js` into multiple chunks).
+ *
+ * The fix collapses every `@mathjax/src` access into `./MathJaxBundle.ts`.
+ * These tests verify the invariant that callers can rely on:
+ *
+ *   1. `renderLatexToSVG` succeeds — confirming no "Can't find handler for
+ *      document" leak when MathJax is consumed through the wrapper.
+ *   2. After bundle load the `mathjax` singleton has the HTML handler that
+ *      `RegisterHTMLHandler` returned, i.e. the renderer is talking to the
+ *      same object that holds the handler list.
+ *
+ * Order matters: the render test runs first so it cannot be falsely greened
+ * by handler registration performed inside another test in this file.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderLatexToSVG, MathJaxSingletonMismatchError } from './MathJaxRenderer';
+
+describe('MathJax singleton (issue #396)', () => {
+  it('renders LaTeX without throwing "Can\'t find handler for document"', async () => {
+    // First test in the file: if `loadMathJax` ever stops calling
+    // RegisterHTMLHandler internally, the singleton stays empty and this
+    // call throws the issue #396 error before any other test can prime it.
+    const result = await renderLatexToSVG('x');
+    expect(result.vmobjectGroup.children.length).toBeGreaterThan(0);
+  });
+
+  it('points renderer and RegisterHTMLHandler at the same singleton', async () => {
+    const bundle = await import('./MathJaxBundle');
+    const adaptor = bundle.liteAdaptor();
+    const registered = bundle.RegisterHTMLHandler(adaptor) as unknown;
+
+    const mathjax = bundle.mathjax as unknown as {
+      handlers: Iterable<unknown>;
+    };
+
+    // The exact handler RegisterHTMLHandler returned must be reachable from
+    // mathjax.handlers; this proves both sides share state, which is what
+    // breaks under esm.sh's chunk duplication. PrioritizedList wraps each
+    // entry as { item, priority }, so unwrap before checking.
+    const items = Array.from(mathjax.handlers).map((entry) => (entry as { item: unknown }).item);
+    expect(items).toContain(registered);
+  });
+
+  it('exports a typed mismatch error so the CDN fallback can catch it', () => {
+    const err = new MathJaxSingletonMismatchError();
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('MathJaxSingletonMismatchError');
+  });
+});

--- a/tests/integration/mathtex.spec.ts
+++ b/tests/integration/mathtex.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Browser regression for issue #396.
+ *
+ * When manim-web was loaded through esm.sh, `MathTex` failed with
+ * `Can't find handler for document` because the `@mathjax/src` singleton was
+ * duplicated across chunks. The fix collapses every MathJax import behind
+ * `MathJaxBundle.ts`, so a single dynamic import chunk owns the singleton.
+ *
+ * This test reuses the user-supplied reproduction (radius label `r`) and
+ * confirms MathTex actually renders without a render error in the browser.
+ */
+
+test('issue #396 — MathTex renders inside a ThreeDScene', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on('pageerror', (err) => consoleErrors.push(err.message));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+
+  await page.goto('/examples/issue_396_repro.html');
+
+  await expect(page.locator('#status')).toHaveText(/MathTex rendered/, { timeout: 20_000 });
+
+  // The exact runtime error from the issue must not appear.
+  const handlerError = consoleErrors.find((m) => /Can't find handler for document/.test(m));
+  expect(handlerError, `unexpected MathJax handler error: ${handlerError}`).toBeUndefined();
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,13 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['three', 'react', 'react/jsx-runtime', 'vue', '@mathjax/src'],
+      // NOTE: `@mathjax/src` MUST be bundled (not externalized). Splitting the
+      // five submodules it exposes (mathjax, tex, svg, liteAdaptor, html) over
+      // separate dynamic-import targets makes downstream re-bundlers (e.g.
+      // esm.sh) duplicate the `mathjax` singleton and breaks MathTex (#396).
+      // `./mobjects/text/MathJaxBundle.ts` concentrates the imports so Vite
+      // emits a single MathJax chunk.
+      external: ['three', 'react', 'react/jsx-runtime', 'vue'],
       output: {
         globals: {
           three: 'THREE',


### PR DESCRIPTION
## Summary
`MathTex` failed with `Can't find handler for document` when `manim-web` was consumed through `https://esm.sh/manim-web@...`. The renderer split `@mathjax/src` across five separate dynamic imports, and esm.sh re-bundles each emitted chunk independently — which duplicates the `mathjax` singleton (`RegisterHTMLHandler` writes to one copy, `mathjax.document(...)` reads another).

The fix collapses every `@mathjax/src` access into a single internal module (`MathJaxBundle.ts`) so there is only one possible chunk for downstream bundlers to ship. A runtime probe and typed `MathJaxSingletonMismatchError` keep the existing CDN fallback as a safety net.

## Changes
- New `src/mobjects/text/MathJaxBundle.ts` — single import surface for `mathjax`, `TeX`, `SVG`, `liteAdaptor`, `RegisterHTMLHandler`, and the AMS / Newcommand / ConfigMacros TeX package side-effect imports.
- `src/mobjects/text/MathJaxRenderer.ts`
  - Five dynamic imports → one `await import('./MathJaxBundle.js')`.
  - Type-only imports for `LiteAdaptor` / `LiteElement` so MathJax never enters the main module graph.
  - New `hasRegisteredHandler` probe verifies the handler list of the same `mathjax` we will later call `.document(...)` on.
  - New exported `MathJaxSingletonMismatchError`; npm-path failures fall through to the CDN script-tag strategy and never cache broken state.
  - Flattened the `MathJaxModuleNpm` shape (`{ mathjax, TeX, SVG, adaptor }`) accordingly.
- `vite.config.ts` — stop externalizing `@mathjax/src`. Inline comment explains why splitting the chunk re-introduces #396.
- `src/mobjects/text/mathjax-singleton.test.ts` — runtime regression. Render assertion runs first (cannot be false-greened by handler registration in another test); a second test asserts the handler returned by `RegisterHTMLHandler` is reachable from the same `mathjax.handlers` the renderer reads.
- `src/mobjects/text/mathjax-bundle-shape.test.ts` — build-shape regression. Asserts `dist/` contains exactly one `MathJaxBundle-*.js` chunk, no split `mathjax-*` / `tex-*` / `svg-*` / `html-*` / `liteAdaptor-*` / `*Configuration-*` chunks, and the `src-*.js` entry only dynamic-imports `MathJaxBundle-*`. Skips when `dist/` is absent.
- `examples/issue_396_repro.html` — user-reported reproduction, used by the Playwright e2e and runnable manually via `npm run dev`.
- `tests/integration/mathtex.spec.ts` — Playwright e2e that loads the reproduction and asserts the on-page status reaches `"MathTex rendered ✓"` with no console error.

## Root cause (one-paragraph)
Locally Vite emits a shared `mathjax-*.js` chunk that `html-*.js` imports — singleton is unique. On esm.sh, the served `html-DU38zqaN.mjs` inlines its own `var yt = { handlers: new he(), ... }`, while `mathjax-7LgaTjtj.mjs` keeps a separate `var d = { handlers: new f(), ... }`. esm.sh runs each emitted `.mjs` through its own bundler and loses Rollup's shared-chunk identity, so `RegisterHTMLHandler(adaptor)` and `mathjax.document(...)` end up acting on different `handlers` lists. Consolidating into one dynamic-import chunk removes the shared edge that downstream bundlers can break.

## Testing
- [x] Tests pass (`npm test`) — `122 passed → 123 passed`, `6063 → 6065` tests (added singleton regression + dist shape regression).
- [x] Lint passes (`npm run lint`).
- [x] Types check (`npm run typecheck`).
- [x] `npm run build` emits a single `dist/MathJaxBundle-*.js` chunk; no `mathjax-*`/`tex-*`/`svg-*`/`html-*`/`liteAdaptor-*`/`*Configuration-*` chunks remain.
- [x] Playwright loads the user's exact reproduction (`examples/issue_396_repro.html`) — `#status` reaches `"MathTex rendered ✓"` and no `Can't find handler for document` error fires.

## Related Issues
Closes #396
