### PR TITLE
fix: restore textured-mobject scale/rotation and VGroup arrange centering after #417 normalize

### DIFF
--- a/src/core/TexturedMobject.ts
+++ b/src/core/TexturedMobject.ts
@@ -37,6 +37,109 @@ export abstract class TexturedMobject extends Mobject {
   abstract applyContentFrom(other: TexturedMobject): void;
 
   /**
+   * Return this mobject's current persistent visual size `[width, height]` in
+   * world units, or `null` if it has no own bakeable geometry right now (e.g. a
+   * multi-part container whose parts are children, or content not yet rendered).
+   *
+   * Used by `_bakeOwnGeometry` to fold `scaleVector` into the display mesh size.
+   * Default: `null` (no own geometry).
+   */
+  protected _currentVisualSize(): [number, number] | null {
+    return null;
+  }
+
+  /**
+   * Whether this mobject owns the display mesh(es) returned by
+   * `getDisplayMeshes()` directly (vs. delegating to child mobjects, e.g. a
+   * multi-part container). Containers must return `false` so that scale/rotation
+   * baking is left to the children (which are normalized recursively) rather
+   * than double-applied here. Default: `true`.
+   */
+  protected _ownsDisplayMesh(): boolean {
+    return true;
+  }
+
+  /**
+   * Bake this textured leaf's own `scaleVector` and Z-`rotation` into the
+   * display mesh so the rendered mesh and `getBounds()` stay unchanged after
+   * `_propagateTransformDownward` resets `scaleVector`/`rotation` to identity.
+   *
+   * Why this is needed: a TexturedMobject's geometry is a textured display mesh,
+   * not `_points3D`. The base `_bakeOwnGeometry` is a no-op, so before this
+   * override the scale/rotation accumulated on a textured leaf was silently
+   * dropped by #417's normalization (tiny logo M; stray rotated axis labels).
+   *
+   * - Scale: folded into the persistent visual size via `applyVisualSize`, which
+   *   rebuilds the plane geometry — so bounds reflect the baked size at scale=1.
+   * - Rotation: only the in-plane Z component is folded into each display mesh's
+   *   local rotation (the flat +Z quad cannot meaningfully bake X/Y rotation).
+   *
+   * Idempotent: the caller (`_propagateTransformDownward`) resets `scaleVector`
+   * to (1,1,1) and `rotation` to (0,0,0) immediately after this returns, so a
+   * second normalize reads identity and does nothing.
+   *
+   * ORDER ASSUMPTION (uniform scale): folding scale into the size and then adding
+   * `rz` to the mesh's local rotation is only equivalent to three.js's
+   * parent-scale-then-child-rotation when the scale is uniform (`sx === sy`).
+   * A non-uniform scale and a non-zero `rz` do not commute: baking the scale into
+   * the size shears the rendered quad in the wrong frame. For that case (and for
+   * the pre-render case where there is no bakeable size yet) we delegate to
+   * `_bakeFallbackScale`, which subclasses make DURABLE by persisting the factor
+   * (see `ImageMobject`/`Text`) so a later async load / canvas re-render composes
+   * with it rather than clobbering it. `getBounds()` stays correct either way (it
+   * reads the actual world matrices). The common uniform-scale path is unchanged.
+   */
+  protected override _bakeOwnGeometry(): void {
+    if (!this._ownsDisplayMesh()) return;
+
+    const sx = this.scaleVector.x;
+    const sy = this.scaleVector.y;
+    const rz = this.rotation.z;
+
+    if (sx !== 1 || sy !== 1) {
+      const size = this._currentVisualSize();
+      const nonUniformWhileRotated = rz !== 0 && sx !== sy;
+      if (size && !nonUniformWhileRotated) {
+        this.applyVisualSize(size[0] * sx, size[1] * sy);
+      } else {
+        // No bakeable size yet (content not rendered) OR non-uniform scale on a
+        // Z-rotated mesh: delegate to the durable fallback so the factor survives
+        // the caller's scaleVector→1 reset, a later load/re-render, and bounds.
+        this._bakeFallbackScale(sx, sy);
+      }
+    }
+
+    if (rz !== 0) {
+      for (const mesh of this.getDisplayMeshes()) {
+        mesh.rotation.z += rz;
+      }
+    }
+  }
+
+  /**
+   * Durably bake a scale factor for the cases `_bakeOwnGeometry` cannot fold into
+   * the persistent visual size: content not yet rendered/loaded, or a non-uniform
+   * scale on a Z-rotated mesh.
+   *
+   * The base implementation writes the factor into the display mesh's local scale.
+   * This is correct for the world-matrix `getBounds()` and composes in the right
+   * order with the mesh-local rotation, BUT it is non-durable for subtypes whose
+   * later async load / canvas re-render rewrites `mesh.scale` from scratch, or
+   * whose `getBoundingBox()` ignores `mesh.scale`. Such subtypes (ImageMobject,
+   * Text) override this to persist the factor in their own size state so it is
+   * honored by later rebuilds and by `getBoundingBox()`.
+   *
+   * Idempotent across repeated normalizes: the caller resets `scaleVector`→1 right
+   * after this returns, so a second normalize reads identity and does nothing.
+   */
+  protected _bakeFallbackScale(sx: number, sy: number): void {
+    for (const mesh of this.getDisplayMeshes()) {
+      mesh.scale.x *= sx;
+      mesh.scale.y *= sy;
+    }
+  }
+
+  /**
    * Sets material.map, marks material dirty, and disposes previous texture when replaced.
    */
   protected _handoffTextureMap(

--- a/src/core/VGroup.ts
+++ b/src/core/VGroup.ts
@@ -275,11 +275,58 @@ export class VGroup extends VMobject {
     }
 
     if (originalCenter) {
-      this.moveTo(originalCenter);
+      this._recenterChildrenTo(originalCenter);
     }
 
     this._markDirty();
     return this;
+  }
+
+  /**
+   * Recenter the arrangement by shifting the CHILDREN so the group's bbox
+   * center returns to `originalCenter`, leaving the container's own `position`
+   * untouched.
+   *
+   * Background: #417 removed VGroup's `moveTo`/`shift` child-shifting overrides,
+   * so `this.moveTo(...)` now moves only the container's `position` and leaves
+   * children in place. Arrange used `moveTo` to recenter, which silently became
+   * a no-op on the children — breaking callers that add the children directly
+   * (e.g. opening_manim) or rely on the children being physically centered.
+   * Shifting the children restores the pre-#417 arrange contract.
+   *
+   * Frame note: `getCenter()` returns WORLD coordinates, but `child.shift()`
+   * applies its delta in the child's PARENT-local frame — which is this VGroup's
+   * own local frame. We therefore map both world endpoints into that frame (via a
+   * child's world→parent-local conversion, which all children share) before
+   * taking the difference. For an identity, parentless VGroup the conversion is
+   * the identity, so this matches the previous world-delta behavior; for a
+   * transformed/nested VGroup it stays correct (the delta is no longer scaled or
+   * rotated by the group's transform).
+   */
+  private _recenterChildrenTo(originalCenter: Vector3Tuple): void {
+    const cur = this.getCenter();
+    const worldDelta: Vector3Tuple = [
+      originalCenter[0] - cur[0],
+      originalCenter[1] - cur[1],
+      originalCenter[2] - cur[2],
+    ];
+    if (worldDelta[0] === 0 && worldDelta[1] === 0 && worldDelta[2] === 0) return;
+
+    // The children's parent-local frame IS this group's local frame, so this
+    // group's world matrix maps child-local → world. Invert it and apply to both
+    // world endpoints, then difference them: the translation parts cancel,
+    // leaving the world delta mapped through this group's inverse linear
+    // transform. For an identity, parentless group the inverse is identity, so
+    // this reduces to the world delta (matching the prior behavior).
+    const invWorld = this._computeWorldMatrix().clone().invert();
+    const originalLocal = new THREE.Vector3(...originalCenter).applyMatrix4(invWorld);
+    const curLocal = new THREE.Vector3(...cur).applyMatrix4(invWorld);
+    const delta: Vector3Tuple = [
+      originalLocal.x - curLocal.x,
+      originalLocal.y - curLocal.y,
+      originalLocal.z - curLocal.z,
+    ];
+    for (const child of this.children) child.shift(delta);
   }
 
   /**
@@ -334,8 +381,8 @@ export class VGroup extends VMobject {
       child.moveTo([x, y, child.position.z]);
     }
 
-    // Recenter to original position
-    this.moveTo(originalCenter);
+    // Recenter to original position by shifting children (not the container).
+    this._recenterChildrenTo(originalCenter);
 
     this._markDirty();
     return this;

--- a/src/core/vgroup.test.ts
+++ b/src/core/vgroup.test.ts
@@ -786,4 +786,79 @@ describe('VGroup - extended coverage', () => {
     const obj = vg.getThreeObject();
     expect(obj).toBeDefined();
   });
+
+  // Regression for #417: arrange/arrangeInGrid must recenter by shifting the
+  // CHILDREN (not the container) so adding the children directly stays centered.
+  describe('arrange recenters children, not the container (#417 regression)', () => {
+    const makeDot = () => new Dot({ position: [0, 0, 0] });
+
+    it('arrange shifts children so their combined center returns to origin', () => {
+      const a = makeDot();
+      const b = makeDot();
+      const c = makeDot();
+      const vg = new VGroup(a, b, c);
+      vg.arrange(RIGHT, 0.5);
+
+      // Container position stays at origin — the offset lives on the children.
+      expect(vg.position.x).toBeCloseTo(0, 6);
+      expect(vg.position.y).toBeCloseTo(0, 6);
+
+      // Children are physically centered around the group origin.
+      const centerX = (a.getCenter()[0] + c.getCenter()[0]) / 2;
+      expect(centerX).toBeCloseTo(0, 6);
+      // Outer children are symmetric about origin.
+      expect(a.getCenter()[0]).toBeCloseTo(-c.getCenter()[0], 6);
+    });
+
+    it('arrange(DOWN) keeps the pair vertically centered on the children', () => {
+      const a = makeDot();
+      const b = makeDot();
+      const vg = new VGroup(a, b);
+      vg.arrange([0, -1, 0], 0.5);
+      expect(vg.position.y).toBeCloseTo(0, 6);
+      const midY = (a.getCenter()[1] + b.getCenter()[1]) / 2;
+      expect(midY).toBeCloseTo(0, 6);
+    });
+
+    it('arrangeInGrid recenters children around the group origin', () => {
+      const items = Array.from({ length: 4 }, makeDot);
+      const vg = new VGroup(...items);
+      vg.arrangeInGrid(2, 2, 0.5, 0.5);
+
+      expect(vg.position.x).toBeCloseTo(0, 6);
+      expect(vg.position.y).toBeCloseTo(0, 6);
+
+      const xs = items.map((m) => m.getCenter()[0]);
+      const ys = items.map((m) => m.getCenter()[1]);
+      const meanX = xs.reduce((s, v) => s + v, 0) / xs.length;
+      const meanY = ys.reduce((s, v) => s + v, 0) / ys.length;
+      expect(meanX).toBeCloseTo(0, 6);
+      expect(meanY).toBeCloseTo(0, 6);
+    });
+
+    // Issue 3: the recenter delta must be converted into the children's
+    // parent-local frame. On a VGroup with a non-identity (scaled) transform a
+    // raw world delta would be divided by the group scale when applied via
+    // child.shift(), pulling the arrangement off-center. The frame conversion
+    // keeps the WORLD-space center fixed.
+    it('arrange stays world-centered on a scaled VGroup (non-identity frame)', () => {
+      const a = makeDot();
+      const b = makeDot();
+      const c = makeDot();
+      const vg = new VGroup(a, b, c);
+      // Apply a non-identity linear transform to the group BEFORE arranging so
+      // world frame != children's parent-local frame.
+      vg.scale(2);
+
+      const before = vg.getCenter();
+      vg.arrange(RIGHT, 0.5);
+      const after = vg.getCenter();
+
+      // World-space center is preserved across arrange despite the group scale.
+      expect(after[0]).toBeCloseTo(before[0], 6);
+      expect(after[1]).toBeCloseTo(before[1], 6);
+      // Symmetric about the world center.
+      expect(a.getCenter()[0] + c.getCenter()[0]).toBeCloseTo(2 * after[0], 6);
+    });
+  });
 });

--- a/src/mobjects/graphing/Axes.ts
+++ b/src/mobjects/graphing/Axes.ts
@@ -137,6 +137,13 @@ export class Axes extends Group {
     };
     this.yAxis = new NumberLine(yConfig);
     this.yAxis.rotate(Math.PI / 2);
+    // Bake the +90° rotation into the line geometry and the label child positions
+    // now (eager), so the label-repositioning loop below reads already-rotated
+    // positions. #417 made rotation deferred; without this normalize the rotation
+    // would otherwise linger on the live transform (never re-normalized in the
+    // render path) and the labels — authored against the pre-#417 eager-rotation
+    // contract — would render as a stray horizontal row instead of a column.
+    this.yAxis.normalizeTransform();
 
     // Counter-rotate y-axis number labels so text stays horizontal,
     // and reposition them to the left of the axis

--- a/src/mobjects/graphing/graphing.test.ts
+++ b/src/mobjects/graphing/graphing.test.ts
@@ -275,6 +275,33 @@ describe('Axes', () => {
       expect(axes.xAxis).toBeDefined();
       expect(axes.yAxis).toBeDefined();
     });
+
+    // Regression for #417: the y-axis number labels are counter-rotated and must
+    // sit in a single vertical column to the left of the axis — not a stray
+    // horizontal row near the origin (which happened when the +90° rotation was
+    // left deferred and never baked into the labels' positions).
+    it('y-axis number labels form a vertical column, not a horizontal row', () => {
+      const axes = new Axes({
+        xRange: [0, 40, 5],
+        yRange: [-8, 32, 5],
+        xLength: 9,
+        yLength: 6,
+        yAxisConfig: { numbersToInclude: [-5, 0, 5, 10, 15, 20, 25, 30] },
+        tips: false,
+      });
+      const labels = axes.yAxis.getNumberLabels();
+      expect(labels.length).toBeGreaterThan(2);
+
+      const xs = labels.map((l) => l.getCenter()[0]);
+      const ys = labels.map((l) => l.getCenter()[1]);
+
+      // All labels share (near-)identical x — a vertical column.
+      const xSpread = Math.max(...xs) - Math.min(...xs);
+      expect(xSpread).toBeLessThan(0.05);
+      // Labels are spread out vertically.
+      const ySpread = Math.max(...ys) - Math.min(...ys);
+      expect(ySpread).toBeGreaterThan(1);
+    });
   });
 
   describe('coordinate transformations', () => {

--- a/src/mobjects/image/image-bounds.test.ts
+++ b/src/mobjects/image/image-bounds.test.ts
@@ -60,4 +60,70 @@ describe('ImageMobject bounds after scale', () => {
       createElementSpy.mockRestore();
     }
   });
+
+  // Issue 1 regression: a scaled ImageMobject must survive normalizeTransform().
+  // Before the fix, normalize reset scaleVector to 1 without baking the scale
+  // into the persistent display size, so the image shrank back to its unscaled
+  // dimensions (visible inside a VGroup, which normalizes on construction).
+  it('scaled ImageMobject survives normalizeTransform (bounds preserved, scaleVector=1)', async () => {
+    const mockCtx = {
+      imageSmoothingEnabled: false,
+      imageSmoothingQuality: 'low' as const,
+      createImageData: (width: number, height: number) => ({
+        data: new Uint8ClampedArray(width * height * 4),
+        width,
+        height,
+      }),
+      putImageData: () => {},
+      drawImage: () => {},
+      getImageData: (x: number, y: number, width: number, height: number) => ({
+        data: new Uint8ClampedArray(width * height * 4),
+        width,
+        height,
+      }),
+    };
+    const originalCreateElement = document.createElement.bind(document);
+    const spy = vi
+      .spyOn(document, 'createElement')
+      .mockImplementation((tagName: string): HTMLElement => {
+        const el = originalCreateElement(tagName);
+        if (tagName.toLowerCase() === 'canvas') {
+          (el as HTMLCanvasElement).getContext = ((contextType: string) =>
+            contextType === '2d' ? mockCtx : null) as HTMLCanvasElement['getContext'];
+        }
+        return el;
+      });
+
+    try {
+      const image = new ImageMobject({
+        pixelData: [
+          [0, 255],
+          [255, 0],
+        ],
+        height: 2,
+      });
+      await image.waitForLoad();
+
+      image.scale(2);
+      const before = image.getBounds();
+      const wBefore = before.max.x - before.min.x;
+      const hBefore = before.max.y - before.min.y;
+
+      image.normalizeTransform();
+
+      // Scale was folded into the persistent size; the transform is now identity.
+      expect(image.scaleVector.x).toBeCloseTo(1, 6);
+      expect(image.scaleVector.y).toBeCloseTo(1, 6);
+
+      const after = image.getBounds();
+      const wAfter = after.max.x - after.min.x;
+      const hAfter = after.max.y - after.min.y;
+
+      // Bounds must NOT change across normalize — no shrink.
+      expect(wAfter).toBeCloseTo(wBefore, 5);
+      expect(hAfter).toBeCloseTo(hBefore, 5);
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });

--- a/src/mobjects/image/image-prescale-normalize.test.ts
+++ b/src/mobjects/image/image-prescale-normalize.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+import * as THREE from 'three';
+import { describe, expect, it, vi } from 'vitest';
+import { ImageMobject } from './index';
+
+/**
+ * Regression tests for the DURABLE fallback bake in TexturedMobject._bakeFallbackScale,
+ * as overridden by ImageMobject. Covers the case the size-bake path cannot handle:
+ * scaling + normalizing an ImageMobject BEFORE its texture has loaded.
+ *
+ * Before the fix, the scale went into mesh.scale and was clobbered when the async
+ * load ran _updateGeometry() (mesh.scale.set(dims...)), and getBoundingBox() ignored
+ * mesh.scale entirely. Now the factor persists in _calculateDimensions().
+ */
+describe('ImageMobject pre-load scale survives load + normalize', () => {
+  // Mock 2D canvas context so pixelData decoding works headlessly.
+  const mockCtx = {
+    imageSmoothingEnabled: false,
+    imageSmoothingQuality: 'low' as const,
+    createImageData: (width: number, height: number) => ({
+      data: new Uint8ClampedArray(width * height * 4),
+      width,
+      height,
+    }),
+    putImageData: () => {},
+    drawImage: () => {},
+    getImageData: (_x: number, _y: number, width: number, height: number) => ({
+      data: new Uint8ClampedArray(width * height * 4),
+      width,
+      height,
+    }),
+  };
+
+  function withCanvasMock<T>(fn: () => T): T {
+    const originalCreateElement = document.createElement.bind(document);
+    const spy = vi
+      .spyOn(document, 'createElement')
+      .mockImplementation((tagName: string): HTMLElement => {
+        const el = originalCreateElement(tagName);
+        if (tagName.toLowerCase() === 'canvas') {
+          (el as HTMLCanvasElement).getContext = ((contextType: string) =>
+            contextType === '2d' ? mockCtx : null) as HTMLCanvasElement['getContext'];
+        }
+        return el;
+      });
+    try {
+      return fn();
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  it('scale before texture load is preserved after async load completes', async () => {
+    // Drive the TextureLoader manually so we can scale+normalize BEFORE onLoad.
+    let fireLoad: (() => void) | null = null;
+    const loadSpy = vi
+      .spyOn(THREE.TextureLoader.prototype, 'load')
+      .mockImplementation((_url: string, onLoad?: any) => {
+        const texture = new THREE.Texture();
+        // 4x2 natural pixels -> aspect ratio 2.
+        (texture as any).image = { width: 4, height: 2 };
+        fireLoad = () => onLoad?.(texture);
+        return texture;
+      });
+
+    try {
+      withCanvasMock(() => {
+        const image = new ImageMobject({ source: 'https://example.com/x.png', width: 2 });
+
+        // Not loaded yet: _currentVisualSize() is null, so this hits the durable fallback.
+        expect(image.isLoaded()).toBe(false);
+        image.scale(3);
+        image.normalizeTransform();
+
+        // Transform folded to identity.
+        expect(image.scaleVector.x).toBeCloseTo(1, 6);
+        expect(image.scaleVector.y).toBeCloseTo(1, 6);
+
+        // Complete the async load.
+        fireLoad!();
+        expect(image.isLoaded()).toBe(true);
+
+        // width:2 with aspect 2 -> base 2x1; baked 3x -> 6x3. getBoundingBox honors it.
+        const bb = image.getBoundingBox();
+        expect(bb.width).toBeCloseTo(6, 4);
+        expect(bb.height).toBeCloseTo(3, 4);
+
+        // getBounds (world matrices) must agree.
+        const b = image.getBounds();
+        expect(b.max.x - b.min.x).toBeCloseTo(6, 3);
+        expect(b.max.y - b.min.y).toBeCloseTo(3, 3);
+      });
+    } finally {
+      loadSpy.mockRestore();
+    }
+  });
+
+  it('a later applyVisualSize composes (overrides) rather than double-applying the fallback', async () => {
+    let fireLoad: (() => void) | null = null;
+    const loadSpy = vi
+      .spyOn(THREE.TextureLoader.prototype, 'load')
+      .mockImplementation((_url: string, onLoad?: any) => {
+        const texture = new THREE.Texture();
+        (texture as any).image = { width: 4, height: 2 };
+        fireLoad = () => onLoad?.(texture);
+        return texture;
+      });
+
+    try {
+      withCanvasMock(() => {
+        const image = new ImageMobject({ source: 'https://example.com/x.png', width: 2 });
+        image.scale(3); // -> baked fallback factor 3
+        image.normalizeTransform();
+        fireLoad!();
+
+        // applyVisualSize sets an explicit size and must DROP the baked factor.
+        image.applyVisualSize(5, 5);
+        const bb = image.getBoundingBox();
+        expect(bb.width).toBeCloseTo(5, 4);
+        expect(bb.height).toBeCloseTo(5, 4);
+
+        // A subsequent normalize is a no-op (identity scale) and must not shrink.
+        image.normalizeTransform();
+        const bb2 = image.getBoundingBox();
+        expect(bb2.width).toBeCloseTo(5, 4);
+        expect(bb2.height).toBeCloseTo(5, 4);
+      });
+    } finally {
+      loadSpy.mockRestore();
+    }
+  });
+});

--- a/src/mobjects/image/index.ts
+++ b/src/mobjects/image/index.ts
@@ -88,6 +88,15 @@ export class ImageMobject extends TexturedMobject {
   protected _naturalHeight: number = 1;
   private _mesh: THREE.Mesh | null = null;
 
+  // Persistent scale factors baked by `_bakeFallbackScale` for the pre-load
+  // (and non-uniform-while-rotated) cases, where `_calculateDimensions()` cannot
+  // yet be trusted. Multiplied into the final display dimensions so the factor
+  // survives the async load (which re-runs `_updateGeometry`/`_calculateDimensions`)
+  // and is honored by `getBoundingBox()`. Reset to 1 once an explicit size is
+  // baked via `applyVisualSize` (the size then carries the scale directly).
+  private _bakedScaleX: number = 1;
+  private _bakedScaleY: number = 1;
+
   // Promise that resolves when image is loaded
   private _loadPromise: Promise<void>;
   private _loadResolve: (() => void) | null = null;
@@ -268,6 +277,19 @@ export class ImageMobject extends TexturedMobject {
    * Calculate the display dimensions based on options and natural size
    */
   private _calculateDimensions(): { width: number; height: number } {
+    const dims = this._calculateBaseDimensions();
+    // Fold in any durably-baked fallback scale (pre-load / non-uniform-rotated).
+    return {
+      width: dims.width * this._bakedScaleX,
+      height: dims.height * this._bakedScaleY,
+    };
+  }
+
+  /**
+   * Display dimensions from width/height options and natural size, BEFORE the
+   * persistent `_bakedScale{X,Y}` fallback factors are applied.
+   */
+  private _calculateBaseDimensions(): { width: number; height: number } {
     const aspectRatio = this._naturalWidth / this._naturalHeight;
 
     if (this._width !== undefined && this._height !== undefined) {
@@ -465,10 +487,44 @@ export class ImageMobject extends TexturedMobject {
     this._texture = nextTexture;
   }
 
+  /**
+   * Current persistent visual size for scale-baking. Returns the same display
+   * dimensions used by `getBoundingBox()` (`_calculateDimensions()`), so folding
+   * `scaleVector` into them via `applyVisualSize` keeps bounds unchanged after the
+   * base normalize resets `scaleVector` to 1: bounds go from `dims*scale` (scale
+   * on the group) to `dims*scale` baked into `_width/_height` with scale=1.
+   * Null before the texture loaded (dimensions derive from natural size of 1×1),
+   * so a pre-load scale falls back to `mesh.scale` baking — see `_bakeOwnGeometry`.
+   */
+  protected override _currentVisualSize(): [number, number] | null {
+    if (!this._imageLoaded) return null;
+    const dims = this._calculateDimensions();
+    if (!dims.width || !dims.height) return null;
+    return [dims.width, dims.height];
+  }
+
   applyVisualSize(width: number, height: number): void {
     this._width = width;
     this._height = height;
     this._scaleToFit = false;
+    // The explicit size now carries the full scale; drop any earlier fallback
+    // factor so `_calculateDimensions()` does not double-apply it.
+    this._bakedScaleX = 1;
+    this._bakedScaleY = 1;
+    this._updateGeometry();
+  }
+
+  /**
+   * Durable fallback bake (overrides `TexturedMobject`): persist the scale factor
+   * into `_bakedScale{X,Y}` instead of `mesh.scale`. Multiplied into
+   * `_calculateDimensions()`, so it survives a later async texture load (which
+   * re-runs `_updateGeometry`) and is honored by `getBoundingBox()`. Idempotent:
+   * the caller resets `scaleVector`→1 after this returns; repeated normalizes with
+   * an identity scale multiply by 1.
+   */
+  protected override _bakeFallbackScale(sx: number, sy: number): void {
+    this._bakedScaleX *= sx;
+    this._bakedScaleY *= sy;
     this._updateGeometry();
   }
 
@@ -712,6 +768,8 @@ export class ImageMobject extends TexturedMobject {
     copy._imageLoaded = this._imageLoaded;
     copy._naturalWidth = this._naturalWidth;
     copy._naturalHeight = this._naturalHeight;
+    copy._bakedScaleX = this._bakedScaleX;
+    copy._bakedScaleY = this._bakedScaleY;
     if (this._texture) {
       copy._texture = this._texture.clone();
       copy._markDirty();

--- a/src/mobjects/text/MarkupText.ts
+++ b/src/mobjects/text/MarkupText.ts
@@ -872,6 +872,12 @@ export class MarkupText extends Text {
     const lines: StyledTextSegment[][] = [[]];
     let lineIdx = 0;
 
+    // `_styledSegments` is undefined while the base `Text` constructor runs
+    // `_renderToCanvas` (subclass field initializers run after `super()`), and the
+    // copy path forces an early render before `_parseMarkup` populates it. Treat an
+    // unpopulated list as empty so an early render is a harmless no-op.
+    if (!this._styledSegments) return lines;
+
     for (const seg of this._styledSegments) {
       const parts = seg.text.split('\n');
       for (let i = 0; i < parts.length; i++) {
@@ -1107,6 +1113,7 @@ export class MarkupText extends Text {
       textAlign: this._textAlign,
     });
     copy._codeFontFamily = this._codeFontFamily;
+    this._carryVisualSizeTo(copy);
     return copy;
   }
 }

--- a/src/mobjects/text/MathTexImage.ts
+++ b/src/mobjects/text/MathTexImage.ts
@@ -105,6 +105,17 @@ interface RenderState {
  * // Wait for rendering to complete before animating
  * await integral.waitForRender();
  * ```
+ *
+ * @note Scale a MathTexImage only AFTER `waitForRender()`. Scaling after render
+ * takes the DURABLE size-bake path: `normalizeTransform()` folds the scale into
+ * `_renderState.width/height` via `applyVisualSize` (mesh.scale reset to 1), so
+ * the size survives a later `setRevealProgress()`/`applyVisualSize`. Scaling
+ * BEFORE render (no measured size yet) instead relies on the inherited
+ * `_bakeFallbackScale` writing into `mesh.scale` — a NON-DURABLE path that a
+ * later reveal or `applyVisualSize` may reset. A non-uniform scale of a
+ * Z-rotated MathTexImage is likewise unsupported (it also takes the
+ * non-durable `mesh.scale` fallback). These edge cases are out of scope; all
+ * real usage (including the manim_ce_logo) scales after render.
  */
 export class MathTexImage extends TexturedMobject {
   protected _latex: string;
@@ -123,6 +134,16 @@ export class MathTexImage extends TexturedMobject {
   protected _arrangePromise: Promise<void> | null = null;
   /** Padding in pixels around rendered content */
   protected _padding: number;
+  /**
+   * Absolute visual size `[width, height]` (world units) that a `copy()` of an
+   * already-sized MathTexImage must reproduce, overriding the natural size the
+   * copy's fresh async re-render measures. Set by `_createCopy` from the source's
+   * current `_renderState` size (which, after a scale+normalize, carries the baked
+   * scale via `applyVisualSize`); applied once in `_startRender`'s post-render
+   * callback and then cleared. Null for normal (non-copy) instances, so the
+   * standard render/reveal path is untouched.
+   */
+  protected _visualSizeOverride: [number, number] | null = null;
 
   constructor(options: MathTexImageOptions) {
     super();
@@ -420,6 +441,14 @@ export class MathTexImage extends TexturedMobject {
     this._renderState.renderPromise = this._renderLatex()
       .then(() => {
         this._renderState.isRendering = false;
+        // A copy of an already-sized instance must keep that size: the fresh
+        // re-render above measured the UNSCALED natural size, so re-apply the
+        // carried absolute size (which carries any baked scale) and clear it.
+        if (this._visualSizeOverride) {
+          const [w, h] = this._visualSizeOverride;
+          this._visualSizeOverride = null;
+          this.applyVisualSize(w, h);
+        }
         this._markDirty();
       })
       .catch((error) => {
@@ -1067,6 +1096,24 @@ export class MathTexImage extends TexturedMobject {
     this._renderState.texture = nextTexture;
   }
 
+  /**
+   * Own display mesh only in single-part mode; multi-part delegates to child parts.
+   */
+  protected override _ownsDisplayMesh(): boolean {
+    return !this._isMultiPart;
+  }
+
+  /**
+   * Current persistent visual size for scale-baking. Null when multi-part (parts
+   * bake their own size) or before the first render produced dimensions.
+   */
+  protected override _currentVisualSize(): [number, number] | null {
+    if (this._isMultiPart) return null;
+    const { width, height } = this._renderState;
+    if (!width || !height) return null;
+    return [width, height];
+  }
+
   applyVisualSize(width: number, height: number): void {
     if (this._isMultiPart) {
       throw new Error('MathTexImage.applyVisualSize requires single-part MathTexImage');
@@ -1115,7 +1162,7 @@ export class MathTexImage extends TexturedMobject {
    */
   protected override _createCopy(): MathTexImage {
     const latexValue = this._isMultiPart ? this._parts.map((p) => p._latex) : this._latex;
-    return new MathTexImage({
+    const copy = new MathTexImage({
       latex: latexValue,
       color: this.color,
       fontSize: this._fontSize,
@@ -1123,6 +1170,20 @@ export class MathTexImage extends TexturedMobject {
       position: [this.position.x, this.position.y, this.position.z],
       renderer: this._renderer,
     });
+    // Preserve the normalized visual size. After a scale+normalize, a single-part
+    // MathTexImage folds its scale into `_renderState.width/height` via
+    // `applyVisualSize` (mesh.scale reset to 1). The copy kicks off a fresh async
+    // render that measures the UNSCALED natural size, so without this it would
+    // shrink. Carry the current absolute size as an override applied once the
+    // copy's re-render settles (multi-part parts carry their own size when copied
+    // recursively by `Mobject.copy()`). Also apply it eagerly so a synchronous
+    // bounds read before the render settles already reflects the size.
+    if (!this._isMultiPart && this._renderState.width && this._renderState.height) {
+      copy._visualSizeOverride = [this._renderState.width, this._renderState.height];
+      copy.getThreeObject();
+      copy.applyVisualSize(this._renderState.width, this._renderState.height);
+    }
+    return copy;
   }
 
   /**

--- a/src/mobjects/text/Paragraph.ts
+++ b/src/mobjects/text/Paragraph.ts
@@ -331,7 +331,7 @@ export class Paragraph extends Text {
    * Create a copy of this Paragraph mobject
    */
   protected override _createCopy(): Paragraph {
-    return new Paragraph({
+    const copy = new Paragraph({
       text: this._text,
       fontSize: this._fontSize,
       fontFamily: this._fontFamily,
@@ -345,5 +345,7 @@ export class Paragraph extends Text {
       width: this._maxWidth,
       alignment: this._alignment,
     });
+    this._carryVisualSizeTo(copy);
+    return copy;
   }
 }

--- a/src/mobjects/text/Text.ts
+++ b/src/mobjects/text/Text.ts
@@ -150,6 +150,17 @@ export class Text extends TexturedMobject {
   protected _worldWidth: number = 0;
   protected _worldHeight: number = 0;
 
+  /**
+   * Persistent scale factors baked by `_bakeFallbackScale` for the cases the
+   * size-bake path cannot handle: scaled before the canvas produced dimensions
+   * (headless/no-DOM), or a non-uniform scale on a Z-rotated mesh. Applied to the
+   * PlaneGeometry size so the factor survives a later canvas re-render (which
+   * recomputes `_worldWidth`/`_worldHeight`) and a later `applyVisualSize`. Reset
+   * to 1 by `applyVisualSize`, whose explicit size already carries the scale.
+   */
+  protected _bakedScaleX: number = 1;
+  protected _bakedScaleY: number = 1;
+
   constructor(options: TextOptions) {
     super();
 
@@ -465,8 +476,10 @@ export class Text extends TexturedMobject {
     this._mesh.geometry.dispose();
 
     // Create new geometry with updated dimensions
-    const geometry = new THREE.PlaneGeometry(this._worldWidth, this._worldHeight);
-    this._mesh.geometry = geometry;
+    this._mesh.geometry = new THREE.PlaneGeometry(
+      this._worldWidth * this._bakedScaleX,
+      this._worldHeight * this._bakedScaleY,
+    );
   }
 
   /**
@@ -496,8 +509,11 @@ export class Text extends TexturedMobject {
       depthWrite: false,
     });
 
-    // Create plane geometry sized to match text
-    const geometry = new THREE.PlaneGeometry(this._worldWidth, this._worldHeight);
+    // Create plane geometry sized to match text (folding in any baked fallback scale)
+    const geometry = new THREE.PlaneGeometry(
+      this._worldWidth * this._bakedScaleX,
+      this._worldHeight * this._bakedScaleY,
+    );
 
     // Create mesh
     this._mesh = new THREE.Mesh(geometry, material);
@@ -557,13 +573,58 @@ export class Text extends TexturedMobject {
     this._canvasDirty = false;
   }
 
+  /**
+   * Current persistent visual size for scale-baking. The plane geometry is sized
+   * to `[_worldWidth, _worldHeight]`, so returning those keeps `getBounds()`
+   * consistent after `_bakeOwnGeometry` folds `scaleVector` into them and the
+   * base normalize resets `scaleVector` to 1. Null before the canvas produced
+   * dimensions (headless/no-DOM) so a pre-render scale is not silently lost via
+   * a 0×0 bake — see `_bakeOwnGeometry`'s mesh.scale fallback.
+   */
+  protected override _currentVisualSize(): [number, number] | null {
+    // Force lazy Three.js construction first. `_createThreeObject` re-runs
+    // `_renderToCanvas`, which RECOMPUTES `_worldWidth`/`_worldHeight` from the
+    // canvas. If we read the size before the mesh exists, `applyVisualSize`
+    // would bake a scaled size that the later mesh build immediately clobbers,
+    // silently dropping the scale. Building the mesh now makes the recompute
+    // happen before we read the size, so the bake sticks.
+    this.getThreeObject();
+    if (!this._worldWidth || !this._worldHeight) return null;
+    // Report the actual geometry size, folding in any durable fallback factor so
+    // a subsequent size-bake composes with (not ignores) the prior fallback bake.
+    return [this._worldWidth * this._bakedScaleX, this._worldHeight * this._bakedScaleY];
+  }
+
   applyVisualSize(width: number, height: number): void {
     this._worldWidth = width;
     this._worldHeight = height;
+    // The explicit size now carries the full scale; drop any earlier fallback
+    // factor so geometry/_currentVisualSize do not double-apply it.
+    this._bakedScaleX = 1;
+    this._bakedScaleY = 1;
     this._updateMesh();
     if (this._mesh) {
       this._mesh.scale.set(1, 1, 1);
     }
+    // The baked `_worldWidth`/`_worldHeight` are now authoritative. Clear any
+    // pending canvas-dirty flag so a later `_syncMaterialToThree` does not
+    // re-render and RECOMPUTE the size from the unscaled canvas, silently
+    // dropping the just-baked scale (e.g. a `getBounds()` after a scale+normalize
+    // on a subclass whose normalize left `_canvasDirty` set, such as Paragraph).
+    this._canvasDirty = false;
+  }
+
+  /**
+   * Durable fallback bake (overrides `TexturedMobject`): persist the scale factor
+   * into `_bakedScale{X,Y}` instead of `mesh.scale`. Applied to the PlaneGeometry
+   * size, so it survives a later canvas re-render (which recomputes
+   * `_worldWidth`/`_worldHeight`) and a later `applyVisualSize`. Idempotent: the
+   * caller resets `scaleVector`→1 after this returns.
+   */
+  protected override _bakeFallbackScale(sx: number, sy: number): void {
+    this._bakedScaleX *= sx;
+    this._bakedScaleY *= sy;
+    this._updateMesh();
   }
 
   /**
@@ -651,7 +712,7 @@ export class Text extends TexturedMobject {
    * Create a copy of this Text mobject
    */
   protected override _createCopy(): Text {
-    return new Text({
+    const copy = new Text({
       text: this._text,
       fontSize: this._fontSize,
       fontFamily: this._fontFamily,
@@ -665,6 +726,37 @@ export class Text extends TexturedMobject {
       textAlign: this._textAlign,
       fontUrl: this._fontUrl,
     });
+    this._carryVisualSizeTo(copy);
+    return copy;
+  }
+
+  /**
+   * Copy this Text's normalized visual-size state onto a freshly-constructed copy.
+   *
+   * After `normalizeTransform()`, a scaled Text has `scaleVector` reset to 1 and
+   * its scale folded into `_worldWidth`/`_worldHeight` (and `_bakedScale{X,Y}` for
+   * the non-durable edge cases). A subclass `_createCopy` rebuilds the copy from
+   * `text`+`fontSize`, so its constructor re-measures to the UNSCALED size — the
+   * copy would shrink back. This builds the copy's mesh first (so
+   * `_createThreeObject`'s canvas re-render recomputes the size before we overwrite
+   * it), then applies the source's persistent size to the geometry.
+   *
+   * Robust whether or not the source was normalized: for an unscaled, unnormalized
+   * Text this just re-copies the already-equal size, a no-op. Shared by
+   * `MarkupText`/`Paragraph`, which override `_createCopy` without calling super.
+   */
+  protected _carryVisualSizeTo(copy: Text): void {
+    copy.getThreeObject();
+    copy._worldWidth = this._worldWidth;
+    copy._worldHeight = this._worldHeight;
+    copy._bakedScaleX = this._bakedScaleX;
+    copy._bakedScaleY = this._bakedScaleY;
+    copy._updateMesh();
+    // The copy's canvas was just rendered by `getThreeObject()`; clear the dirty
+    // flag so a later `_syncMaterialToThree` does not re-render and RECOMPUTE
+    // `_worldWidth`/`_worldHeight` from the unscaled canvas, clobbering the size
+    // we just carried over.
+    copy._canvasDirty = false;
   }
 
   /**

--- a/src/mobjects/text/copy-visual-size.test.ts
+++ b/src/mobjects/text/copy-visual-size.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment happy-dom
+/**
+ * Regression: `copy()` of a scaled+normalized textured mobject must retain its
+ * visual size (no shrink).
+ *
+ * `Mobject.copy()` only copies `scaleVector`, while the textured `_createCopy`
+ * rebuilds from text/latex+fontSize. After `normalizeTransform()` a scaled
+ * mobject has `scaleVector` reset to 1 and its scale folded into the persistent
+ * size (`_worldWidth/_worldHeight` for Text; `_renderState.width/height` for
+ * MathTexImage). Without carrying that size the copy re-measures to the UNSCALED
+ * size and shrinks — visible when `copy()` is used by animation snapshot /
+ * Transform / saveState-restore infra.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as THREE from 'three';
+import { Text } from './Text';
+import { MarkupText } from './MarkupText';
+import { Paragraph } from './Paragraph';
+import { MathTexImage } from './MathTexImage';
+
+function createMockCtx(): CanvasRenderingContext2D {
+  return {
+    font: '',
+    textBaseline: 'top',
+    textAlign: 'center',
+    fillStyle: '',
+    strokeStyle: '',
+    globalAlpha: 1,
+    lineWidth: 1,
+    measureText: vi.fn((_text: string) => ({
+      width: _text.length * 10,
+      actualBoundingBoxAscent: 10,
+      actualBoundingBoxDescent: 2,
+      fontBoundingBoxAscent: 12,
+      fontBoundingBoxDescent: 3,
+      actualBoundingBoxLeft: 0,
+      actualBoundingBoxRight: _text.length * 10,
+    })),
+    fillText: vi.fn(),
+    strokeText: vi.fn(),
+    clearRect: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    fillRect: vi.fn(),
+  } as unknown as CanvasRenderingContext2D;
+}
+
+const widthOf = (m: { getBounds(): { min: THREE.Vector3; max: THREE.Vector3 } }): number => {
+  const b = m.getBounds();
+  return b.max.x - b.min.x;
+};
+const heightOf = (m: { getBounds(): { min: THREE.Vector3; max: THREE.Vector3 } }): number => {
+  const b = m.getBounds();
+  return b.max.y - b.min.y;
+};
+
+describe('copy() retains visual size after scale + normalize', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation((id: string) =>
+      id === '2d' ? createMockCtx() : null,
+    );
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('Text copy keeps width/height (no shrink)', () => {
+    const t = new Text({ text: 'Hello' });
+    t.scale(2);
+    t.normalizeTransform();
+    const wBefore = widthOf(t);
+    const hBefore = heightOf(t);
+
+    const copy = t.copy() as Text;
+    expect(widthOf(copy)).toBeCloseTo(wBefore, 5);
+    expect(heightOf(copy)).toBeCloseTo(hBefore, 5);
+  });
+
+  it('Text copy of an UNSCALED Text is unchanged (robust regardless of normalize)', () => {
+    const t = new Text({ text: 'Plain' });
+    const wBefore = widthOf(t);
+    const copy = t.copy() as Text;
+    expect(widthOf(copy)).toBeCloseTo(wBefore, 5);
+  });
+
+  it('MarkupText copy keeps width', () => {
+    const t = new MarkupText({ text: 'Hi' });
+    t.scale(3);
+    t.normalizeTransform();
+    const wBefore = widthOf(t);
+    const copy = t.copy() as MarkupText;
+    expect(widthOf(copy)).toBeCloseTo(wBefore, 5);
+  });
+
+  it('Paragraph copy keeps width', () => {
+    const t = new Paragraph({ text: 'a\nb' });
+    t.scale(2.5);
+    t.normalizeTransform();
+    const wBefore = widthOf(t);
+    const copy = t.copy() as Paragraph;
+    expect(widthOf(copy)).toBeCloseTo(wBefore, 5);
+  });
+});
+
+describe('MathTexImage copy retains visual size after scale + normalize', () => {
+  beforeEach(() => {
+    // happy-dom has no 2D canvas; stub the async render so `_renderState` size is
+    // not overwritten by a real render. We drive size explicitly to mimic a
+    // post-`waitForRender()` scaled+normalized instance.
+    vi.spyOn(
+      MathTexImage.prototype as unknown as { _renderLatex(): Promise<void> },
+      '_renderLatex',
+    ).mockResolvedValue(undefined);
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  const makeSized = (w: number, h: number): MathTexImage => {
+    const tex = new MathTexImage({ latex: 'M' });
+    const rs = (tex as unknown as { _renderState: { width: number; height: number } })._renderState;
+    rs.width = w;
+    rs.height = h;
+    tex.getThreeObject();
+    tex.applyVisualSize(w, h);
+    return tex;
+  };
+  const planeSize = (tex: MathTexImage): { w: number; h: number } => {
+    const mesh = tex.getDisplayMeshes()[0];
+    const p = (mesh.geometry as THREE.PlaneGeometry).parameters;
+    return { w: p.width, h: p.height };
+  };
+
+  it('single-part copy keeps the baked size (no shrink)', async () => {
+    const tex = makeSized(1, 0.5);
+    tex.scale(7);
+    tex.normalizeTransform();
+    const before = planeSize(tex);
+    expect(before.w).toBeCloseTo(7, 4); // sanity: scale was baked
+
+    const copy = tex.copy() as MathTexImage;
+    // Eager apply: size correct before the async re-render settles.
+    expect(planeSize(copy).w).toBeCloseTo(before.w, 4);
+    expect(planeSize(copy).h).toBeCloseTo(before.h, 4);
+
+    // After the (stubbed) re-render settles, the override re-applies the size and
+    // is cleared — still no shrink.
+    await copy.waitForRender();
+    expect(planeSize(copy).w).toBeCloseTo(before.w, 4);
+    expect(planeSize(copy).h).toBeCloseTo(before.h, 4);
+  });
+
+  it('override is consumed once (cleared after render settles)', async () => {
+    const tex = makeSized(1, 0.5);
+    tex.scale(4);
+    tex.normalizeTransform();
+    const copy = tex.copy() as MathTexImage;
+    await copy.waitForRender();
+    const override = (copy as unknown as { _visualSizeOverride: unknown })._visualSizeOverride;
+    expect(override).toBeNull();
+  });
+});

--- a/src/mobjects/text/mathtex-normalize.test.ts
+++ b/src/mobjects/text/mathtex-normalize.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as THREE from 'three';
+import { MathTexImage } from './MathTexImage';
+import { VGroup } from '../../core/VGroup';
+
+// happy-dom has no 2D canvas context, so the background LaTeX render rejects.
+// These tests only exercise the transform-baking math, not rendering, so we
+// stub the async render to a no-op to keep the suite's console.error guard quiet.
+beforeEach(() => {
+  vi.spyOn(
+    MathTexImage.prototype as unknown as { _renderLatex(): Promise<void> },
+    '_renderLatex',
+  ).mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * Regression coverage for #417: a TexturedMobject (MathTexImage) must absorb its
+ * own scale + in-plane (Z) rotation into the display mesh during
+ * normalizeTransform, so the rendered mesh survives `scaleVector`/`rotation`
+ * being reset to identity. Without this the logo M rendered tiny and rotated
+ * axis labels rendered in a stray row (Bugs B and C).
+ */
+describe('MathTexImage survives normalizeTransform (#417)', () => {
+  // Build a single-part MathTexImage with a known render size, with its mesh
+  // created, without depending on async LaTeX rendering.
+  const makeSized = (w: number, h: number): MathTexImage => {
+    const tex = new MathTexImage({ latex: 'M' });
+    const rs = (tex as unknown as { _renderState: { width: number; height: number } })._renderState;
+    rs.width = w;
+    rs.height = h;
+    tex.getThreeObject(); // create the mesh
+    tex.applyVisualSize(w, h); // rebuild geometry to match
+    return tex;
+  };
+
+  const planeSize = (tex: MathTexImage): { w: number; h: number } => {
+    const mesh = tex.getDisplayMeshes()[0];
+    const params = (mesh.geometry as THREE.PlaneGeometry).parameters;
+    return { w: params.width, h: params.height };
+  };
+
+  it('bakes scale into the mesh geometry so size persists after scaleVector→1', () => {
+    const tex = makeSized(1, 0.5);
+    tex.scale(7);
+    expect(tex.scaleVector.x).toBeCloseTo(7, 6);
+
+    tex.normalizeTransform();
+
+    // scaleVector is reset to identity...
+    expect(tex.scaleVector.x).toBeCloseTo(1, 6);
+    expect(tex.scaleVector.y).toBeCloseTo(1, 6);
+    // ...but the mesh geometry now reflects the baked 7x size.
+    const { w, h } = planeSize(tex);
+    expect(w).toBeCloseTo(7, 4);
+    expect(h).toBeCloseTo(3.5, 4);
+  });
+
+  it('scale baking is idempotent (second normalize does not double-apply)', () => {
+    const tex = makeSized(1, 0.5);
+    tex.scale(7);
+    tex.normalizeTransform();
+    const first = planeSize(tex);
+    tex.normalizeTransform();
+    const second = planeSize(tex);
+    expect(second.w).toBeCloseTo(first.w, 6);
+    expect(second.h).toBeCloseTo(first.h, 6);
+  });
+
+  it('a scaled MathTexImage inside a VGroup keeps its baked size after group normalize', () => {
+    const tex = makeSized(1, 0.5);
+    tex.scale(3);
+    const vg = new VGroup(tex); // constructor normalizes
+    vg.normalizeTransform();
+    expect(tex.scaleVector.x).toBeCloseTo(1, 6);
+    const { w } = planeSize(tex);
+    expect(w).toBeCloseTo(3, 4);
+  });
+
+  it('a Z-rotated MathTexImage in a group bakes net rotation into the mesh', () => {
+    // Group rotated +90°, child counter-rotated -90° => net 0 visual orientation,
+    // mirroring the heat-diagram y-axis labels.
+    const label = makeSized(0.4, 0.4);
+    label.rotate(-Math.PI / 2); // own counter-rotation
+    const group = new VGroup(label);
+    group.rotate(Math.PI / 2); // container rotation
+    group.normalizeTransform();
+
+    // Everything resolves to identity transforms with the orientation baked.
+    expect(group.rotation.z).toBeCloseTo(0, 6);
+    expect(label.rotation.z).toBeCloseTo(0, 6);
+
+    // Net mesh world rotation is flat (0): the +90 and -90 cancel.
+    const mesh = label.getDisplayMeshes()[0];
+    group._syncToThree();
+    mesh.updateWorldMatrix(true, true);
+    const e = new THREE.Euler().setFromQuaternion(mesh.getWorldQuaternion(new THREE.Quaternion()));
+    expect(Math.abs(e.z) % Math.PI).toBeCloseTo(0, 4);
+  });
+});

--- a/src/mobjects/text/text-normalize.test.ts
+++ b/src/mobjects/text/text-normalize.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+/**
+ * Issue 1 regression: a scaled `Text` must survive `normalizeTransform()`.
+ *
+ * Before the fix, `Text` inherited `TexturedMobject`'s default
+ * `_currentVisualSize() => null`, so `_bakeOwnGeometry` skipped scale-baking
+ * while the base `normalizeTransform` still reset `scaleVector` to 1 — a scaled
+ * Text shrank back to its unscaled size (visible inside a VGroup, which
+ * normalizes on construction). The fix folds the scale into the persistent
+ * `_worldWidth`/`_worldHeight` (used by the plane geometry) so `getBounds()`
+ * stays unchanged across normalize.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Text } from './Text';
+
+/** Mock 2D context — happy-dom has no canvas 2d support. */
+function createMockCtx(): CanvasRenderingContext2D {
+  return {
+    font: '',
+    textBaseline: 'top',
+    textAlign: 'center',
+    fillStyle: '',
+    strokeStyle: '',
+    globalAlpha: 1,
+    lineWidth: 1,
+    measureText: vi.fn((_text: string) => ({
+      width: _text.length * 10,
+      actualBoundingBoxAscent: 10,
+      actualBoundingBoxDescent: 2,
+      fontBoundingBoxAscent: 12,
+      fontBoundingBoxDescent: 3,
+      actualBoundingBoxLeft: 0,
+      actualBoundingBoxRight: _text.length * 10,
+    })),
+    fillText: vi.fn(),
+    strokeText: vi.fn(),
+    clearRect: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    fillRect: vi.fn(),
+  } as unknown as CanvasRenderingContext2D;
+}
+
+beforeEach(() => {
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation((contextId: string) => {
+    if (contextId === '2d') return createMockCtx();
+    return null;
+  });
+});
+
+describe('Text scale survives normalizeTransform (Issue 1)', () => {
+  it('folds scale into the persistent size so bounds are unchanged across normalize', () => {
+    const t = new Text({ text: 'Hello' });
+
+    t.scale(2);
+    const before = t.getBounds();
+    const wBefore = before.max.x - before.min.x;
+    const hBefore = before.max.y - before.min.y;
+
+    t.normalizeTransform();
+
+    // Transform is now identity; the scale lives in the geometry size.
+    expect(t.scaleVector.x).toBeCloseTo(1, 6);
+    expect(t.scaleVector.y).toBeCloseTo(1, 6);
+
+    const after = t.getBounds();
+    const wAfter = after.max.x - after.min.x;
+    const hAfter = after.max.y - after.min.y;
+
+    // No shrink: bounds must be preserved.
+    expect(wAfter).toBeCloseTo(wBefore, 5);
+    expect(hAfter).toBeCloseTo(hBefore, 5);
+  });
+
+  it('mesh is not shrunk — its local scale stays at 1 after baking', () => {
+    const t = new Text({ text: 'World' });
+    t.scale(3);
+    t.normalizeTransform();
+
+    const mesh = t.getDisplayMeshes()[0];
+    expect(mesh.scale.x).toBeCloseTo(1, 6);
+    expect(mesh.scale.y).toBeCloseTo(1, 6);
+  });
+
+  it('baked size matches the original scaled bounds (no double-application)', () => {
+    const a = new Text({ text: 'Same' });
+    const b = new Text({ text: 'Same' });
+
+    const baseline = a.getBounds();
+    const wBaseline = baseline.max.x - baseline.min.x;
+
+    b.scale(2);
+    b.normalizeTransform();
+    const baked = b.getBounds();
+    const wBaked = baked.max.x - baked.min.x;
+
+    expect(wBaked).toBeCloseTo(wBaseline * 2, 5);
+  });
+});

--- a/src/mobjects/text/text-prerender-normalize.test.ts
+++ b/src/mobjects/text/text-prerender-normalize.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+/**
+ * Regression tests for the DURABLE fallback bake in TexturedMobject._bakeFallbackScale,
+ * as overridden by Text. Covers the cases the size-bake path cannot handle:
+ *  - scaling + normalizing BEFORE the canvas produced dimensions (no 2D context yet)
+ *  - a later applyVisualSize must compose with / override the fallback, not lose it
+ *
+ * Before the fix, the pre-render scale went into mesh.scale and was lost when a
+ * later applyVisualSize() reset mesh.scale to 1 (the MEDIUM finding).
+ */
+import * as THREE from 'three';
+import { describe, it, expect, vi } from 'vitest';
+import { Text } from './Text';
+
+function createMockCtx(): CanvasRenderingContext2D {
+  return {
+    font: '',
+    textBaseline: 'top',
+    textAlign: 'center',
+    fillStyle: '',
+    strokeStyle: '',
+    globalAlpha: 1,
+    lineWidth: 1,
+    measureText: vi.fn((_text: string) => ({
+      width: _text.length * 10,
+      actualBoundingBoxAscent: 10,
+      actualBoundingBoxDescent: 2,
+      fontBoundingBoxAscent: 12,
+      fontBoundingBoxDescent: 3,
+      actualBoundingBoxLeft: 0,
+      actualBoundingBoxRight: _text.length * 10,
+    })),
+    fillText: vi.fn(),
+    strokeText: vi.fn(),
+    clearRect: vi.fn(),
+  } as unknown as CanvasRenderingContext2D;
+}
+
+describe('Text pre-render scale survives via durable fallback', () => {
+  it('scale before canvas dims (size unmeasured) is preserved once the canvas renders', () => {
+    const ctxSpy = vi
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation((contextId: string) => (contextId === '2d' ? createMockCtx() : null));
+
+    try {
+      const t = new Text({ text: 'Hello' });
+
+      // Simulate the headless / not-yet-measured state: no world dims yet, so
+      // _currentVisualSize() returns null and the durable fallback path is taken.
+      const tt = t as unknown as {
+        _worldWidth: number;
+        _worldHeight: number;
+        _currentVisualSize(): unknown;
+        _canvasDirty: boolean;
+        _renderToCanvas(): void;
+        _updateMesh(): void;
+      };
+      tt._worldWidth = 0;
+      tt._worldHeight = 0;
+      // _currentVisualSize() calls getThreeObject() which re-renders; null only if
+      // measurement yields 0. With a real ctx it remeasures, so assert the bake
+      // path directly by stubbing the size getter to null for this scale.
+      const sizeSpy = vi.spyOn(tt, '_currentVisualSize').mockReturnValue(null);
+
+      t.scale(2);
+      t.normalizeTransform();
+      expect(t.scaleVector.x).toBeCloseTo(1, 6);
+      sizeSpy.mockRestore();
+
+      // Now the canvas re-renders (recomputing _worldWidth/Height) and rebuilds.
+      tt._canvasDirty = true;
+      tt._renderToCanvas();
+      tt._updateMesh();
+
+      const geom = t.getDisplayMeshes()[0].geometry as THREE.PlaneGeometry;
+      const baseW = tt._worldWidth;
+      const baseH = tt._worldHeight;
+
+      // Geometry must reflect the baked 2x factor over the freshly measured size,
+      // i.e. the pre-render scale was NOT lost by the re-render.
+      expect(baseW).toBeGreaterThan(0);
+      expect(geom.parameters.width).toBeCloseTo(baseW * 2, 4);
+      expect(geom.parameters.height).toBeCloseTo(baseH * 2, 4);
+    } finally {
+      ctxSpy.mockRestore();
+    }
+  });
+
+  it('a later applyVisualSize overrides the fallback factor (no double-apply, no loss)', () => {
+    const ctxSpy = vi
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation((contextId: string) => (contextId === '2d' ? createMockCtx() : null));
+
+    try {
+      const t = new Text({ text: 'World' });
+      // Force the fallback even though dims exist, by calling it directly with a
+      // factor (simulates the non-uniform-rotated unsupported path).
+      (t as unknown as { _bakeFallbackScale(x: number, y: number): void })._bakeFallbackScale(2, 2);
+
+      const geomBefore = t.getDisplayMeshes()[0].geometry as THREE.PlaneGeometry;
+      const baseW = (t as unknown as { _worldWidth: number })._worldWidth;
+      expect(geomBefore.parameters.width).toBeCloseTo(baseW * 2, 4);
+
+      // Explicit size carries the full scale; the fallback factor must be dropped.
+      t.applyVisualSize(4, 3);
+      const geomAfter = t.getDisplayMeshes()[0].geometry as THREE.PlaneGeometry;
+      expect(geomAfter.parameters.width).toBeCloseTo(4, 4);
+      expect(geomAfter.parameters.height).toBeCloseTo(3, 4);
+      expect(t.getDisplayMeshes()[0].scale.x).toBeCloseTo(1, 6);
+    } finally {
+      ctxSpy.mockRestore();
+    }
+  });
+
+  it('the supported post-render uniform-scale path still bakes into size (unchanged)', () => {
+    const ctxSpy = vi
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation((contextId: string) => (contextId === '2d' ? createMockCtx() : null));
+
+    try {
+      const t = new Text({ text: 'Same' });
+      const baseline = t.getBounds();
+      const w0 = baseline.max.x - baseline.min.x;
+
+      t.scale(2);
+      t.normalizeTransform();
+      const after = t.getBounds();
+      expect(after.max.x - after.min.x).toBeCloseTo(w0 * 2, 5);
+      // Uniform post-render path uses the size bake, leaving the fallback factor at 1.
+      expect((t as unknown as { _bakedScaleX: number })._bakedScaleX).toBeCloseTo(1, 6);
+    } finally {
+      ctxSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Merge #417 (\"Normalize transform\") made base \`Mobject.normalizeTransform\` active (bakes scale+rotation into geometry, then resets \`scaleVector\`/\`rotation\` to identity) and removed \`VGroup\`'s \`moveTo\`/\`shift\` child-shifting. This regressed three doc examples:

| Example | Symptom | Root cause |
|---|---|---|
| `opening_manim` | title+equation ~55px below center | `arrange()` recentered via `this.moveTo(originalCenter)`, now a no-op on children that are added directly |
| `manim_ce_logo` | `M` rendered tiny | `MathTexImage` (a `TexturedMobject`) had no `_bakeOwnGeometry`, so `scale(7)` was dropped when normalize zeroed `scaleVector` |
| `heat_diagram_plot` | stray duplicate y-axis number row near center | deferred +90° y-axis rotation never re-normalized in the render path; labels (authored against the old eager-rotation contract) ended up as a horizontal row |

## Fix

- **`VGroup.arrange` / `arrangeInGrid`**: recenter by shifting the **children** (in the group's parent-local frame) instead of moving the container, restoring the pre-#417 arrange contract. Does not reintroduce the removed `moveTo`/`shift` overrides.
- **`TexturedMobject._bakeOwnGeometry`**: fold the leaf's own scale into its persistent display size and its in-plane **Z**-rotation into the display mesh, so the rendered mesh and `getBounds()` are unchanged after normalize resets `scaleVector`/`rotation`. Idempotent.
- **`Text` / `MarkupText` / `Paragraph` / `ImageMobject`**: persistent baked-scale factor folded into each subtype's size source so a scaled instance survives `normalizeTransform()` **and** `copy()` with consistent bounds.
- **`Axes`**: eagerly normalize the rotated y-axis before repositioning labels.
- **`MathTexImage`**: documents that scaling must happen after `waitForRender()` (the only real-usage path; the pre-render `mesh.scale` fallback and non-uniform-scale-of-rotated cases are out of scope and documented).

## Verification

- Full test suite green: **6109 passing, 0 failures** (started from a 6085 baseline; only additions, zero regressions). Adds regression tests for arrange/arrangeInGrid centering, scaled/rotated textured mobjects surviving normalize, and `copy()` preserving baked size.
- `npm run build` succeeds.
- All three examples confirmed rendering correctly in the browser (incl. running `opening_manim`'s full Transform/FadeOut animation).
- Reviewed across multiple adversarial passes (Claude subagents + codex `gpt-5.5`); each finding addressed or explicitly documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)