### PR TITLE
fix(camera): read live camera position in Camera3D orbit angles (#425)

### DIFF
--- a/src/core/Camera.ts
+++ b/src/core/Camera.ts
@@ -68,9 +68,12 @@ export class Camera3D {
 
   /**
    * Get the camera position.
+   *
+   * Reads the live Three.js camera position so external drivers (e.g.
+   * OrbitControls, which mutate the camera directly) are reflected.
    */
   get position(): THREE.Vector3 {
-    return this._position.clone();
+    return this._camera.position.clone();
   }
 
   /**
@@ -152,7 +155,9 @@ export class Camera3D {
    * @returns this for chaining
    */
   orbit(phi: number, theta: number, distance?: number, gamma: number = 0): this {
-    const dist = distance ?? this._position.distanceTo(this._lookAt);
+    // Default to the *live* camera distance so a re-orient after an external
+    // zoom (OrbitControls dolly) doesn't snap back to a stale radius.
+    const dist = distance ?? this._camera.position.distanceTo(this._lookAt);
 
     // Store theta for gimbal lock recovery in getOrbitAngles()
     this._lastTheta = theta;
@@ -184,17 +189,33 @@ export class Camera3D {
    * @returns Object with phi (polar), theta (azimuthal), and distance
    */
   getOrbitAngles(): { phi: number; theta: number; distance: number } {
-    const dx = this._position.x - this._lookAt.x;
-    const dy = this._position.y - this._lookAt.y;
-    const dz = this._position.z - this._lookAt.z;
+    // Read from the live Three.js camera, not the cached this._position.
+    // External drivers (OrbitControls) move the camera directly and never
+    // touch this._position, so the cache goes stale during a drag (issue #425).
+    const dx = this._camera.position.x - this._lookAt.x;
+    const dy = this._camera.position.y - this._lookAt.y;
+    const dz = this._camera.position.z - this._lookAt.z;
     const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+    // Camera coincident with the look-at point: angles are undefined. Avoid
+    // dividing by zero (which would yield NaN) and keep the last azimuth.
+    if (distance < 1e-9) {
+      return { phi: 0, theta: this._lastTheta, distance: 0 };
+    }
 
     const phi = Math.acos(dz / distance);
 
     // At poles (sin(phi) ≈ 0), atan2(0,0) returns 0, losing azimuth.
     // Preserve the last known theta to avoid gimbal lock artifacts.
     const sinPhi = Math.sin(phi);
-    const theta = Math.abs(sinPhi) < 1e-6 ? this._lastTheta : Math.atan2(dy, dx);
+    if (Math.abs(sinPhi) < 1e-6) {
+      return { phi, theta: this._lastTheta, distance };
+    }
+
+    // Remember the live azimuth so a subsequent drag to the pole can fall
+    // back to it rather than to a stale programmatic theta.
+    const theta = Math.atan2(dy, dx);
+    this._lastTheta = theta;
 
     return { phi, theta, distance };
   }

--- a/src/core/camera.test.ts
+++ b/src/core/camera.test.ts
@@ -1023,3 +1023,86 @@ describe('MultiCamera', () => {
     });
   });
 });
+
+// ============================================================
+// Camera3D — live orbit-angle sync (issue #425)
+// ============================================================
+// OrbitControls mutates the live Three.js camera position directly. getOrbitAngles()
+// (and the public position getter / orbit() default distance) must reflect that live
+// position, not a stale internal cache.
+describe('Camera3D orbit angle sync (#425)', () => {
+  // Place the live camera at given spherical coords relative to lookAt, the way
+  // OrbitControls would by writing straight to camera.position.
+  const setLivePosition = (
+    cam: Camera3D,
+    phi: number,
+    theta: number,
+    distance: number,
+    lookAt: [number, number, number] = [0, 0, 0],
+  ): void => {
+    cam
+      .getCamera()
+      .position.set(
+        lookAt[0] + distance * Math.sin(phi) * Math.cos(theta),
+        lookAt[1] + distance * Math.sin(phi) * Math.sin(theta),
+        lookAt[2] + distance * Math.cos(phi),
+      );
+  };
+
+  it('getOrbitAngles reflects live camera position after external mutation', () => {
+    const cam = new Camera3D();
+    // Simulate OrbitControls dragging the live camera to new angles.
+    setLivePosition(cam, Math.PI / 2, Math.PI / 6, 5);
+
+    const o = cam.getOrbitAngles();
+    expect(o.phi).toBeCloseTo(Math.PI / 2);
+    expect(o.theta).toBeCloseTo(Math.PI / 6);
+    expect(o.distance).toBeCloseTo(5);
+  });
+
+  it('position getter reflects live camera position', () => {
+    const cam = new Camera3D();
+    cam.getCamera().position.set(1, 2, 3);
+    const p = cam.position;
+    expect(p.x).toBeCloseTo(1);
+    expect(p.y).toBeCloseTo(2);
+    expect(p.z).toBeCloseTo(3);
+  });
+
+  it('orbit() without explicit distance preserves live (zoomed) distance', () => {
+    const cam = new Camera3D(16 / 9, { position: [0, 0, 10] });
+    // OrbitControls zooms in to distance 4.
+    setLivePosition(cam, Math.PI / 2, 0, 4);
+    // Programmatic re-orient with no distance should keep the live radius, not jump to 10.
+    cam.orbit(Math.PI / 2, Math.PI / 2);
+    expect(cam.getOrbitAngles().distance).toBeCloseTo(4);
+  });
+
+  it('gimbal fallback preserves the last live (non-pole) theta', () => {
+    const cam = new Camera3D();
+    // A normal (non-pole) drag establishes theta.
+    setLivePosition(cam, Math.PI / 2, Math.PI / 3, 6);
+    expect(cam.getOrbitAngles().theta).toBeCloseTo(Math.PI / 3);
+    // Drag straight to the pole (sin(phi) ~ 0): theta is undefined, fall back to last live theta.
+    setLivePosition(cam, 0, 0, 6);
+    expect(cam.getOrbitAngles().theta).toBeCloseTo(Math.PI / 3);
+  });
+
+  it('returns finite values when camera coincides with lookAt (distance 0)', () => {
+    const cam = new Camera3D();
+    cam.getCamera().position.set(0, 0, 0); // exactly at the origin lookAt
+    const o = cam.getOrbitAngles();
+    expect(Number.isNaN(o.phi)).toBe(false);
+    expect(Number.isNaN(o.theta)).toBe(false);
+    expect(o.distance).toBe(0);
+  });
+
+  it('works with a non-origin lookAt target', () => {
+    const cam = new Camera3D(16 / 9, { lookAt: [1, 2, 3] });
+    setLivePosition(cam, Math.PI / 2, Math.PI / 4, 7, [1, 2, 3]);
+    const o = cam.getOrbitAngles();
+    expect(o.phi).toBeCloseTo(Math.PI / 2);
+    expect(o.theta).toBeCloseTo(Math.PI / 4);
+    expect(o.distance).toBeCloseTo(7);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #425 — `getCameraOrientation()` returned stale angles while dragging with OrbitControls.

`Camera3D.getOrbitAngles()` (and the `position` getter and `orbit()`'s default distance) computed values from the cached `this._position` vector. OrbitControls drives the **live** three.js camera (`this._camera.position`) directly during a drag and never touches `this._position`, so the readback froze at the last programmatic value — exactly the reported stale `{ phi: 1.047, theta: -0.785, distance: 8 }`.

## Changes (`src/core/Camera.ts`)

- `getOrbitAngles()` now reads `this._camera.position` (relative to `this._lookAt`).
- `position` getter reads the live camera position.
- `orbit()` default distance derives from the live camera, so a re-orient after an OrbitControls zoom doesn't snap back to a stale radius.
- `_lastTheta` is refreshed from the live azimuth on non-pole reads, so the gimbal-lock fallback uses the latest real theta.
- Guard `distance === 0` to avoid a NaN `phi` divide-by-zero.

## Verification

- 6 new regression tests in `src/core/camera.test.ts` (live angle sync, live position getter, live default distance, pole theta fallback, distance-0, non-origin lookAt). Full `camera.test.ts` 120/120; orbit-related suites (`fixed-orientation`, `Headless`, `circle-rotate-3d`, `core-camera`, `interaction`) all pass. Lint + build clean.
- Reproduced the issue's example in a browser against the local build: before drag → stale `{phi:1.0472, theta:-0.7854, distance:8}`; after a drag moving the camera to (2,3,6) → `{phi:0.5411, theta:0.9828, distance:7}` (distance=√49=7, phi=acos(6/7)=0.541, theta=atan2(3,2)=0.983). The `change` listener now reports live values.

## Scope note

Pan is not covered: OrbitControls maintains its own target separate from `Camera3D._lookAt`, and `Camera3D` doesn't track it. Rotate and zoom (the reported cases) are fixed. Syncing the pan target would couple `Camera3D` to OrbitControls — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
