### PR TITLE
Fix/arrow

### DIFF
--- a/examples/arrow-dance.html
+++ b/examples/arrow-dance.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Arrow Dance</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #0b0f14;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+    }
+    #container {
+      border: 2px solid #253041;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .controls {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      gap: 10px;
+    }
+    button {
+      padding: 10px 20px;
+      background: #2563eb;
+      border: none;
+      border-radius: 6px;
+      color: white;
+      cursor: pointer;
+      font-size: 14px;
+    }
+    button:hover { background: #3b82f6; }
+  </style>
+</head>
+<body>
+  <div id="container"></div>
+  <div class="controls">
+    <button id="playBtn">Play Arrow Dance</button>
+    <button id="resetBtn">Reset</button>
+  </div>
+
+  <script type="module" src="./arrow-dance.ts"></script>
+</body>
+</html>

--- a/examples/arrow-dance.ts
+++ b/examples/arrow-dance.ts
@@ -1,0 +1,126 @@
+import {
+  Scene,
+  Arrow,
+  GrowArrow,
+  Transform,
+  VMobject,
+  AnimationGroup,
+  Rotate,
+} from '../src/index.ts';
+
+const container = document.getElementById('container')!;
+const scene = new Scene(container, {
+  width: 800,
+  height: 450,
+  backgroundColor: '#101319',
+});
+
+let isAnimating = false;
+
+function makeArrowTo(radius: number, angle: number): Arrow {
+  return new Arrow({
+    start: [0, 0, 0],
+    end: [radius * Math.cos(angle), radius * Math.sin(angle), 0],
+    color: '#7dd3fc',
+    strokeWidth: 3,
+    tipLength: 0.28,
+    tipWidth: 0.12,
+  });
+}
+
+document.getElementById('playBtn')!.addEventListener('click', async () => {
+  if (isAnimating) return;
+  isAnimating = true;
+
+  scene.clear();
+
+  const n = 12;
+  const radius = 2.6;
+  const arrows: Arrow[] = [];
+
+  for (let i = 0; i < n; i++) {
+    const angle = (2 * Math.PI * i) / n;
+    const arrow = makeArrowTo(radius, angle);
+    arrows.push(arrow);
+  }
+
+  // Grow one-by-one from center out to a 12-gon.
+  // Do not pre-add: GrowArrow/Create pipeline adds to scene.
+  for (const arrow of arrows) {
+    await scene.play(new GrowArrow(arrow, { duration: 0.32 }));
+  }
+
+  await scene.wait(0.25);
+
+  // Shift all arrows outward by +1 unit (together).
+  await scene.play(
+    ...arrows.map((arrow, i) => {
+      const angle = (2 * Math.PI * i) / n;
+      const target = arrow.copy() as Arrow;
+      target.putStartAndEndOn(
+        [Math.cos(angle), Math.sin(angle), 0],
+        [(radius + 1) * Math.cos(angle), (radius + 1) * Math.sin(angle), 0],
+      );
+      return new Transform(arrow, target, { duration: 1.2 });
+    }),
+  );
+
+  // Scale all arrows down to half (together).
+  await scene.play(...arrows.map((arrow) => arrow.animate.scale(0.5).withDuration(0.9)));
+
+  // Change tip color to yellow one after another (staggered).
+  const colorAnimations = arrows.map((arrow) => {
+    const tip = arrow.children[1] as VMobject;
+    return tip.animate.setColor('#ffeb3b').withDuration(0.15);
+  });
+  await scene.play(new AnimationGroup(colorAnimations, { lagRatio: 0.33 }));
+
+  // Rotate each arrow by 180° staggered.
+  const rotateAnimations = arrows.map(
+    (arrow) => new Rotate(arrow, { angle: Math.PI, duration: 0.5 }),
+  );
+  await scene.play(new AnimationGroup(rotateAnimations, { lagRatio: 0.33 }));
+
+  // Final: lay the arrows tangentially around the circle so they point
+  // counter-clockwise around the perimeter (a pinwheel), back in the base color.
+  const perimeterRadius = radius;
+  const arrowLen = 2 * perimeterRadius * Math.sin(Math.PI / n); // chord between neighbours
+  await scene.play(
+    ...arrows.map((arrow, i) => {
+      const angle = (2 * Math.PI * i) / n;
+      const cx = perimeterRadius * Math.cos(angle);
+      const cy = perimeterRadius * Math.sin(angle);
+      const tx = -Math.sin(angle); // unit tangent, counter-clockwise
+      const ty = Math.cos(angle);
+      const half = arrowLen / 2;
+      // Build a FRESH arrow rather than arrow.copy(): by this point each arrow
+      // carries a live group rotation (from the Rotate(π) step), and copy()
+      // inherits it. putStartAndEndOn lays the shaft/tip out in the group-local
+      // frame, so the inherited rotation would be re-applied on top and fling the
+      // shaft to the wrong side. A fresh Arrow has an identity group transform.
+      const target = new Arrow({
+        start: [cx - half * tx, cy - half * ty, 0],
+        end: [cx + half * tx, cy + half * ty, 0],
+        color: '#7dd3fc', // reset the yellow tips back to the base arrow color
+        strokeWidth: 3,
+        tipLength: 0.28,
+        tipWidth: 0.12,
+      });
+      return new Transform(arrow, target, { duration: 0.6 });
+    }),
+  );
+
+  isAnimating = false;
+});
+
+document.getElementById('resetBtn')!.addEventListener('click', () => {
+  scene.clear();
+});
+
+// Embed mode: hide controls and autoplay.
+if (new URLSearchParams(window.location.search).has('embed')) {
+  document
+    .querySelectorAll('.controls')
+    .forEach((el) => ((el as HTMLElement).style.display = 'none'));
+  setTimeout(() => document.getElementById('playBtn')?.click(), 300);
+}

--- a/src/animation/animation-growing.test.ts
+++ b/src/animation/animation-growing.test.ts
@@ -70,65 +70,64 @@ describe('GrowArrow', () => {
     });
   });
 
+  // GrowArrow grows the shaft/tip children, leaving the Arrow's own
+  // _start/_end (hence getStart/getEnd) untouched. Progress is therefore
+  // measured on the RENDERED geometry: getWidth() is the rendered length and
+  // getCenter() tracks the visual center from the start point to the midpoint.
   describe('begin()', () => {
-    it('sets scale to near-zero', () => {
+    it('collapses the arrow to near-zero size', () => {
       const arrow = makeArrow();
-      const anim = new GrowArrow(arrow);
-      anim.begin();
-      expect(arrow.scaleVector.x).toBeCloseTo(0.001, 5);
-      expect(arrow.scaleVector.y).toBeCloseTo(0.001, 5);
-      expect(arrow.scaleVector.z).toBeCloseTo(0.001, 5);
+      new GrowArrow(arrow).begin();
+      expect(arrow.getWidth()).toBeCloseTo(0, 1);
     });
 
-    it('moves position to start point', () => {
+    it('collapses onto the start point', () => {
       const arrow = new Arrow({ start: [1, 2, 0], end: [3, 4, 0] });
-      const anim = new GrowArrow(arrow);
-      anim.begin();
-      expect(arrow.position.x).toBeCloseTo(1, 5);
-      expect(arrow.position.y).toBeCloseTo(2, 5);
+      new GrowArrow(arrow).begin();
+      const c = arrow.getCenter();
+      expect(c[0]).toBeCloseTo(1, 1);
+      expect(c[1]).toBeCloseTo(2, 1);
     });
   });
 
   describe('interpolate()', () => {
-    it('at alpha=0.5 scales to roughly half', () => {
-      const arrow = makeArrow();
+    it('at alpha=0.5 is roughly half-grown', () => {
+      const arrow = makeArrow(); // full rendered width = 2
       const anim = new GrowArrow(arrow);
       anim.begin();
       anim.interpolate(0.5);
-      expect(arrow.scaleVector.x).toBeCloseTo(0.5, 2);
-      expect(arrow.scaleVector.y).toBeCloseTo(0.5, 2);
+      expect(arrow.getWidth()).toBeCloseTo(1, 1);
     });
 
-    it('at alpha=1 restores full scale', () => {
+    it('at alpha=1 reaches full size', () => {
       const arrow = makeArrow();
-      const origScaleX = arrow.scaleVector.x;
+      const full = arrow.getWidth();
       const anim = new GrowArrow(arrow);
       anim.begin();
       anim.interpolate(1);
-      expect(arrow.scaleVector.x).toBeCloseTo(origScaleX, 5);
+      expect(arrow.getWidth()).toBeCloseTo(full, 2);
     });
 
-    it('position interpolates from start toward center', () => {
+    it('center grows from the start point toward the midpoint', () => {
       const arrow = new Arrow({ start: [0, 0, 0], end: [4, 0, 0] });
       const anim = new GrowArrow(arrow);
       anim.begin();
       anim.interpolate(1);
-      // At alpha=1 position should be at midpoint (0+4)/2 = 2
-      expect(arrow.position.x).toBeCloseTo(2, 2);
+      // fully grown: visual center sits at the segment midpoint (0+4)/2 = 2
+      expect(arrow.getCenter()[0]).toBeCloseTo(2, 1);
     });
   });
 
   describe('finish()', () => {
-    it('restores original scale and sets position to midpoint', () => {
+    it('restores full size with center at the midpoint', () => {
       const arrow = new Arrow({ start: [0, 0, 0], end: [4, 0, 0] });
-      const origScale = arrow.scaleVector.clone();
+      const full = arrow.getWidth();
       const anim = new GrowArrow(arrow);
       anim.begin();
       anim.interpolate(0.3);
       anim.finish();
-      expect(arrow.scaleVector.x).toBeCloseTo(origScale.x, 5);
-      expect(arrow.scaleVector.y).toBeCloseTo(origScale.y, 5);
-      expect(arrow.position.x).toBeCloseTo(2, 2);
+      expect(arrow.getWidth()).toBeCloseTo(full, 2);
+      expect(arrow.getCenter()[0]).toBeCloseTo(2, 1);
     });
   });
 

--- a/src/animation/growing/growing-extra.test.ts
+++ b/src/animation/growing/growing-extra.test.ts
@@ -59,53 +59,45 @@ function trianglePoints(): number[][] {
 // ============================================================================
 
 describe('GrowArrow (extra)', () => {
+  // GrowArrow grows the shaft/tip children, so progress shows up in the
+  // rendered geometry: getWidth() is the rendered length and getCenter()
+  // tracks the visual center from the start point to the midpoint.
   describe('interpolate() progression', () => {
-    it('scale increases monotonically from 0 to 1', () => {
+    it('rendered size increases monotonically from 0 to full', () => {
       const arrow = makeArrow();
       const anim = new GrowArrow(arrow);
       anim.begin();
 
-      const scales: number[] = [];
+      const widths: number[] = [];
       for (let a = 0; a <= 1; a += 0.1) {
         anim.interpolate(a);
-        scales.push(arrow.scaleVector.x);
+        widths.push(arrow.getWidth());
       }
 
-      // Each scale should be >= previous
-      for (let i = 1; i < scales.length; i++) {
-        expect(scales[i]).toBeGreaterThanOrEqual(scales[i - 1] - 0.001);
+      for (let i = 1; i < widths.length; i++) {
+        expect(widths[i]).toBeGreaterThanOrEqual(widths[i - 1] - 1e-6);
       }
     });
 
-    it('at alpha=0, scale is clamped to 0.001 (not 0)', () => {
-      const arrow = makeArrow();
-      const anim = new GrowArrow(arrow);
-      anim.begin();
-      anim.interpolate(0);
-      expect(arrow.scaleVector.x).toBeCloseTo(0.001, 5);
-      expect(arrow.scaleVector.y).toBeCloseTo(0.001, 5);
-      expect(arrow.scaleVector.z).toBeCloseTo(0.001, 5);
-    });
-
-    it('position moves continuously from start to midpoint', () => {
+    it('center moves continuously from the start point to the midpoint', () => {
       const arrow = makeArrow([0, 0, 0], [6, 0, 0]);
       const anim = new GrowArrow(arrow);
       anim.begin();
 
       anim.interpolate(0);
-      expect(arrow.position.x).toBeCloseTo(0, 2);
+      expect(arrow.getCenter()[0]).toBeCloseTo(0, 2);
 
       anim.interpolate(0.25);
-      expect(arrow.position.x).toBeCloseTo(0.75, 2);
+      expect(arrow.getCenter()[0]).toBeCloseTo(0.75, 2);
 
       anim.interpolate(0.5);
-      expect(arrow.position.x).toBeCloseTo(1.5, 2);
+      expect(arrow.getCenter()[0]).toBeCloseTo(1.5, 2);
 
       anim.interpolate(0.75);
-      expect(arrow.position.x).toBeCloseTo(2.25, 2);
+      expect(arrow.getCenter()[0]).toBeCloseTo(2.25, 2);
 
       anim.interpolate(1);
-      expect(arrow.position.x).toBeCloseTo(3, 2); // midpoint
+      expect(arrow.getCenter()[0]).toBeCloseTo(3, 2); // midpoint
     });
 
     it('handles arrow with 3D coordinates', () => {
@@ -113,49 +105,33 @@ describe('GrowArrow (extra)', () => {
       const anim = new GrowArrow(arrow);
       anim.begin();
 
-      // Position should start at the start point
-      expect(arrow.position.x).toBeCloseTo(1, 2);
-      expect(arrow.position.y).toBeCloseTo(2, 2);
-      expect(arrow.position.z).toBeCloseTo(3, 2);
+      // collapsed onto the start point
+      const start = arrow.getCenter();
+      expect(start[0]).toBeCloseTo(1, 2);
+      expect(start[1]).toBeCloseTo(2, 2);
+      expect(start[2]).toBeCloseTo(3, 2);
 
       anim.interpolate(1);
-      // At alpha=1, position should be at midpoint
-      expect(arrow.position.x).toBeCloseTo(3, 2); // (1+5)/2
-      expect(arrow.position.y).toBeCloseTo(4, 2); // (2+6)/2
-      expect(arrow.position.z).toBeCloseTo(5, 2); // (3+7)/2
-    });
-  });
-
-  describe('begin() stores target correctly', () => {
-    it('preserves target scale for non-unit scaled arrow', () => {
-      const arrow = makeArrow();
-      arrow.scaleVector.set(2, 3, 4);
-      const anim = new GrowArrow(arrow);
-      anim.begin();
-
-      // Scale should be near-zero after begin
-      expect(arrow.scaleVector.x).toBeCloseTo(0.001, 5);
-
-      anim.interpolate(1);
-      expect(arrow.scaleVector.x).toBeCloseTo(2, 2);
-      expect(arrow.scaleVector.y).toBeCloseTo(3, 2);
-      expect(arrow.scaleVector.z).toBeCloseTo(4, 2);
+      // fully grown: center at the midpoint
+      const mid = arrow.getCenter();
+      expect(mid[0]).toBeCloseTo(3, 2); // (1+5)/2
+      expect(mid[1]).toBeCloseTo(4, 2); // (2+6)/2
+      expect(mid[2]).toBeCloseTo(5, 2); // (3+7)/2
     });
   });
 
   describe('finish() after partial interpolation', () => {
-    it('restores exact state regardless of last interpolation step', () => {
+    it('restores full rendered geometry regardless of last interpolation step', () => {
       const arrow = makeArrow([0, 0, 0], [4, 4, 0]);
-      const origScale = arrow.scaleVector.clone();
+      const full = arrow.getWidth();
       const anim = new GrowArrow(arrow);
       anim.begin();
       anim.interpolate(0.1); // barely started
       anim.finish();
-      expect(arrow.scaleVector.x).toBeCloseTo(origScale.x, 5);
-      expect(arrow.scaleVector.y).toBeCloseTo(origScale.y, 5);
-      expect(arrow.scaleVector.z).toBeCloseTo(origScale.z, 5);
-      expect(arrow.position.x).toBeCloseTo(2, 2); // midpoint x
-      expect(arrow.position.y).toBeCloseTo(2, 2); // midpoint y
+      expect(arrow.getWidth()).toBeCloseTo(full, 2);
+      const c = arrow.getCenter();
+      expect(c[0]).toBeCloseTo(2, 2); // midpoint x
+      expect(c[1]).toBeCloseTo(2, 2); // midpoint y
     });
   });
 

--- a/src/animation/growing/index.ts
+++ b/src/animation/growing/index.ts
@@ -16,13 +16,16 @@ export { GrowFromCenter, growFromCenter, type GrowFromCenterOptions } from '../m
 export type GrowArrowOptions = AnimationOptions;
 
 /**
- * GrowArrow animation - grows an arrow from its start point.
- * The arrow extends from start toward end, with the tip growing proportionally.
+ * GrowArrow animation - interpolate arrow from a start-growth state to end state.
  */
 export class GrowArrow extends Animation {
-  private _targetScale: THREE.Vector3 = new THREE.Vector3();
-  private _startPoint: Vector3Tuple = [0, 0, 0];
-  private _endPoint: Vector3Tuple = [0, 0, 0];
+  private _start = new THREE.Vector3();
+  private _endShaftPos = new THREE.Vector3();
+  private _endTipPos = new THREE.Vector3();
+  private _endShaftScale = new THREE.Vector3();
+  private _endTipScale = new THREE.Vector3();
+  private _endShaftCenter = new THREE.Vector3();
+  private _endTipCenter = new THREE.Vector3();
 
   constructor(mobject: Arrow, options: GrowArrowOptions = {}) {
     super(mobject, options);
@@ -32,58 +35,83 @@ export class GrowArrow extends Animation {
     super.begin();
 
     const arrow = this.mobject as Arrow;
+    const shaft = arrow.children[0];
+    const tip = arrow.children[1];
+    if (!shaft || !tip) throw new Error('GrowArrow requires Arrow to have shaft and tip children');
 
-    // Store the target state
-    this._targetScale.copy(arrow.scaleVector);
-    this._startPoint = arrow.getStart();
-    this._endPoint = arrow.getEnd();
+    const [sx, sy, sz] = arrow.getStart();
+    this._start.set(sx, sy, sz);
+    this._endShaftPos.copy(shaft.position);
+    this._endTipPos.copy(tip.position);
+    this._endShaftScale.copy(shaft.scaleVector);
+    this._endTipScale.copy(tip.scaleVector);
 
-    // Start at scale 0 (from the start point)
-    arrow.scaleVector.set(0.001, 0.001, 0.001); // Use small value to avoid division issues
+    {
+      const c = shaft.getCenter();
+      this._endShaftCenter.set(c[0], c[1], c[2]);
+    }
+    {
+      const c = tip.getCenter();
+      this._endTipCenter.set(c[0], c[1], c[2]);
+    }
 
-    // Position at start point
-    const start = this._startPoint;
-    arrow.position.set(start[0], start[1], start[2]);
+    this.interpolate(0);
   }
 
   interpolate(alpha: number): void {
     const arrow = this.mobject as Arrow;
+    const shaft = arrow.children[0];
+    const tip = arrow.children[1];
+    if (!shaft || !tip) throw new Error('GrowArrow requires Arrow to have shaft and tip children');
 
-    // Scale from 0 to target
-    const scale = Math.max(0.001, alpha);
-    arrow.scaleVector.set(
-      this._targetScale.x * scale,
-      this._targetScale.y * scale,
-      this._targetScale.z * scale,
+    const s = alpha;
+
+    shaft.scaleVector.set(
+      this._endShaftScale.x * s,
+      this._endShaftScale.y * s,
+      this._endShaftScale.z * s,
     );
+    tip.scaleVector.set(this._endTipScale.x * s, this._endTipScale.y * s, this._endTipScale.z * s);
 
-    // Interpolate position from start to proper position
-    const start = this._startPoint;
-    const end = this._endPoint;
-    const midX = (start[0] + end[0]) / 2;
-    const midY = (start[1] + end[1]) / 2;
-    const midZ = (start[2] + end[2]) / 2;
-
-    // Position interpolates from start to center
-    arrow.position.set(
-      start[0] + (midX - start[0]) * alpha,
-      start[1] + (midY - start[1]) * alpha,
-      start[2] + (midZ - start[2]) * alpha,
+    const shaftTargetCenter = new THREE.Vector3().lerpVectors(
+      this._start,
+      this._endShaftCenter,
+      alpha,
     );
+    {
+      const c = shaft.getCenter();
+      shaft.shift([
+        shaftTargetCenter.x - c[0],
+        shaftTargetCenter.y - c[1],
+        shaftTargetCenter.z - c[2],
+      ]);
+    }
 
-    arrow._markDirty();
+    const tipTargetCenter = new THREE.Vector3().lerpVectors(this._start, this._endTipCenter, alpha);
+    {
+      const c = tip.getCenter();
+      tip.shift([tipTargetCenter.x - c[0], tipTargetCenter.y - c[1], tipTargetCenter.z - c[2]]);
+    }
+
+    shaft._markDirty();
+    tip._markDirty();
+    this.mobject._markDirty();
   }
 
   override finish(): void {
     const arrow = this.mobject as Arrow;
-    arrow.scaleVector.copy(this._targetScale);
+    const shaft = arrow.children[0];
+    const tip = arrow.children[1];
+    if (!shaft || !tip) throw new Error('GrowArrow requires Arrow to have shaft and tip children');
 
-    // Restore proper position
-    const start = this._startPoint;
-    const end = this._endPoint;
-    arrow.position.set((start[0] + end[0]) / 2, (start[1] + end[1]) / 2, (start[2] + end[2]) / 2);
+    shaft.position.copy(this._endShaftPos);
+    tip.position.copy(this._endTipPos);
+    shaft.scaleVector.copy(this._endShaftScale);
+    tip.scaleVector.copy(this._endTipScale);
 
-    arrow._markDirty();
+    shaft._markDirty();
+    tip._markDirty();
+    this.mobject._markDirty();
     super.finish();
   }
 }

--- a/src/mobjects/geometry/Arrow.ts
+++ b/src/mobjects/geometry/Arrow.ts
@@ -1,7 +1,8 @@
-import { Group } from '../../core/Group';
+import { VGroup } from '../../core/VGroup';
 import { VMobject } from '../../core/VMobject';
 import { Vector3Tuple } from '../../core/Mobject';
 import { WHITE, DEFAULT_STROKE_WIDTH } from '../../constants';
+import { segmentLength, segmentDirection, segmentAngle } from './segment';
 
 /**
  * Options for creating an Arrow
@@ -25,26 +26,66 @@ export interface ArrowOptions {
  * ArrowShaft - The line part of an arrow (internal use)
  */
 class ArrowShaft extends VMobject {
-  constructor(start: number[], end: number[], color: string, strokeWidth: number) {
+  /**
+   * Build a straight shaft spanning `delta`, optionally trimmed by independent
+   * amounts at each end along the direction of travel.
+   *
+   * The geometry is laid out in a frame centered on the FULL `delta` (endpoints
+   * at ∓delta/2), then each end is pulled inward by its margin. Asymmetric
+   * margins therefore shift the line off its own geometric center, which is how
+   * Arrow keeps a tip-trimmed shaft (endMargin = tipLength) anchored at the true
+   * start while its carrier sits at the arrow center. See Arrow._generateParts.
+   *
+   * @pre startMargin >= 0 && endMargin >= 0
+   * @pre startMargin + endMargin <= |delta|
+   */
+  constructor(delta: number[], color: string, strokeWidth: number, startMargin = 0, endMargin = 0) {
     super();
     this.color = color;
     this.strokeWidth = strokeWidth;
     this.fillOpacity = 0;
 
-    const dx = end[0] - start[0];
-    const dy = end[1] - start[1];
-    const dz = end[2] - start[2];
+    const [dx, dy, dz] = delta;
+    const len = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+    if (len === 0) {
+      this.setPoints3D([
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+      ]);
+      return;
+    }
+
+    if (startMargin < 0 || endMargin < 0) {
+      throw new Error(`ArrowShaft margins must be >= 0, got (${startMargin}, ${endMargin})`);
+    }
+    if (startMargin + endMargin > len + 1e-9) {
+      throw new Error(`ArrowShaft margins ${startMargin}+${endMargin} exceed length ${len}`);
+    }
+
+    const dirX = dx / len;
+    const dirY = dy / len;
+    const dirZ = dz / len;
+
+    const sx = -dx / 2 + dirX * startMargin;
+    const sy = -dy / 2 + dirY * startMargin;
+    const sz = -dz / 2 + dirZ * startMargin;
+    const ex = dx / 2 - dirX * endMargin;
+    const ey = dy / 2 - dirY * endMargin;
+    const ez = dz / 2 - dirZ * endMargin;
 
     this.setPoints3D([
-      [...start],
-      [start[0] + dx / 3, start[1] + dy / 3, start[2] + dz / 3],
-      [start[0] + (2 * dx) / 3, start[1] + (2 * dy) / 3, start[2] + (2 * dz) / 3],
-      [...end],
+      [sx, sy, sz],
+      [sx + (ex - sx) / 3, sy + (ey - sy) / 3, sz + (ez - sz) / 3],
+      [sx + (2 * (ex - sx)) / 3, sy + (2 * (ey - sy)) / 3, sz + (2 * (ez - sz)) / 3],
+      [ex, ey, ez],
     ]);
   }
 
   override copy(): ArrowShaft {
-    const copy = new ArrowShaft([0, 0, 0], [1, 0, 0], this.color, this.strokeWidth);
+    const copy = new ArrowShaft([1, 0, 0], this.color, this.strokeWidth);
     this._copyBaseAttributesInto(copy, { copyChildren: false, copyPosition: false });
     return copy;
   }
@@ -54,22 +95,51 @@ class ArrowShaft extends VMobject {
  * ArrowTip - The triangular tip of an arrow (internal use)
  */
 class ArrowTip extends VMobject {
-  constructor(tipPoint: number[], tipLeft: number[], tipRight: number[], color: string) {
+  constructor(delta: number[], tipLength: number, tipWidth: number, color: string) {
     super();
     this.color = color;
     this.fillOpacity = 1;
     this.strokeWidth = 0;
 
-    const addLineSegment = (points: number[][], p0: number[], p1: number[], isFirst: boolean) => {
-      const dx = p1[0] - p0[0];
-      const dy = p1[1] - p0[1];
-      const dz = p1[2] - p0[2];
+    const [dx, dy, dz] = delta;
+    const len = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (len === 0) {
+      this.setPoints3D([
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+      ]);
+      return;
+    }
 
-      if (isFirst) {
-        points.push([...p0]);
-      }
-      points.push([p0[0] + dx / 3, p0[1] + dy / 3, p0[2] + dz / 3]);
-      points.push([p0[0] + (2 * dx) / 3, p0[1] + (2 * dy) / 3, p0[2] + (2 * dz) / 3]);
+    const dirX = dx / len;
+    const dirY = dy / len;
+    const dirZ = dz / len;
+    const [perpX, perpY, perpZ] = perpendicularFromDirection(dirX, dirY, dirZ);
+
+    const baseCenter: Vector3Tuple = [-dirX * tipLength, -dirY * tipLength, -dirZ * tipLength];
+    const widthOffset = tipWidth;
+    const tipPoint: Vector3Tuple = [0, 0, 0];
+    const tipLeft: Vector3Tuple = [
+      baseCenter[0] + perpX * widthOffset,
+      baseCenter[1] + perpY * widthOffset,
+      baseCenter[2] + perpZ * widthOffset,
+    ];
+    const tipRight: Vector3Tuple = [
+      baseCenter[0] - perpX * widthOffset,
+      baseCenter[1] - perpY * widthOffset,
+      baseCenter[2] - perpZ * widthOffset,
+    ];
+
+    const addLineSegment = (points: number[][], p0: number[], p1: number[], isFirst: boolean) => {
+      const sdx = p1[0] - p0[0];
+      const sdy = p1[1] - p0[1];
+      const sdz = p1[2] - p0[2];
+
+      if (isFirst) points.push([...p0]);
+      points.push([p0[0] + sdx / 3, p0[1] + sdy / 3, p0[2] + sdz / 3]);
+      points.push([p0[0] + (2 * sdx) / 3, p0[1] + (2 * sdy) / 3, p0[2] + (2 * sdz) / 3]);
       points.push([...p1]);
     };
 
@@ -81,10 +151,57 @@ class ArrowTip extends VMobject {
   }
 
   override copy(): ArrowTip {
-    const copy = new ArrowTip([0, 0, 0], [0, 0, 0], [0, 0, 0], this.color);
+    const copy = new ArrowTip([1, 0, 0], 0.3, 0.1, this.color);
     this._copyBaseAttributesInto(copy, { copyChildren: false, copyPosition: false });
     return copy;
   }
+
+  /**
+   * Center of the tip along its own spine: the midpoint between the base center
+   * and the apex, mapped to world.
+   *
+   * VMobject.getCenter() takes the bbox of the *world* points, which drifts off
+   * the triangle once the tip is rotated. The tip's local geometry is fixed
+   * (see ArrowTip's addLineSegment order): index 3 is the apex, indices 0 and 6
+   * are the two base corners. Averaging the apex with the base-corner midpoint
+   * gives the spine midpoint, which we then map through the world matrix so the
+   * center stays rigidly attached to the geometry under rotation.
+   *
+   * @post this.rotation === 0 && uniform scale => result === midpoint(baseCenter, apex)
+   */
+  override getCenter(): Vector3Tuple {
+    const local = this.getLocalPoints();
+    if (local.length < 7) return super.getCenter();
+
+    const apex = local[3];
+    const leftBase = local[0];
+    const rightBase = local[6];
+    return this._localToWorld([
+      (apex[0] + (leftBase[0] + rightBase[0]) / 2) / 2,
+      (apex[1] + (leftBase[1] + rightBase[1]) / 2) / 2,
+      (apex[2] + (leftBase[2] + rightBase[2]) / 2) / 2,
+    ]);
+  }
+}
+
+function perpendicularFromDirection(dirX: number, dirY: number, dirZ: number): Vector3Tuple {
+  const ref: Vector3Tuple = Math.abs(dirZ) < 0.9 ? [0, 0, 1] : [1, 0, 0];
+
+  // ref × dir
+  let px = ref[1] * dirZ - ref[2] * dirY;
+  let py = ref[2] * dirX - ref[0] * dirZ;
+  let pz = ref[0] * dirY - ref[1] * dirX;
+
+  let len = Math.sqrt(px * px + py * py + pz * pz);
+  if (len < 1e-10) {
+    const alt: Vector3Tuple = [0, 1, 0];
+    px = alt[1] * dirZ - alt[2] * dirY;
+    py = alt[2] * dirX - alt[0] * dirZ;
+    pz = alt[0] * dirY - alt[1] * dirX;
+    len = Math.sqrt(px * px + py * py + pz * pz) || 1;
+  }
+
+  return [px / len, py / len, pz / len];
 }
 
 /**
@@ -109,14 +226,27 @@ class ArrowTip extends VMobject {
  * const bigTip = new Arrow({ tipLength: 0.4, tipWidth: 0.25 });
  * ```
  */
-export class Arrow extends Group {
-  private _start: Vector3Tuple;
-  private _end: Vector3Tuple;
+export class Arrow extends VGroup {
+  /** Configured triangle depth measured from apex back toward shaft. */
   private _tipLength: number;
+  /** Configured half-width from tip base-center to either side corner. */
   private _tipWidth: number;
+  /** Shaft stroke width used when regenerating parts. */
   private _strokeWidth: number;
+  /** Internal shaft child (always present after putStartAndEndOn, including zero-length). */
   private _shaft: ArrowShaft | null = null;
+  /** Internal tip child (always present after putStartAndEndOn, including zero-length). */
   private _tip: ArrowTip | null = null;
+  /**
+   * Endpoints in this group's LOCAL frame — the source of truth for the arrow's
+   * geometry. getStart()/getEnd() map these through _localToWorld(), and
+   * normalizeTransform() re-bakes them so they stay world-invariant when the
+   * group's deferred transform is folded into the children (cf. Circle folding
+   * scale into _radius). The shaft/tip children are pure rendering derived from
+   * these in putStartAndEndOn().
+   */
+  private _start: Vector3Tuple = [0, 0, 0];
+  private _end: Vector3Tuple = [0, 0, 0];
 
   constructor(options: ArrowOptions = {}) {
     super();
@@ -130,119 +260,179 @@ export class Arrow extends Group {
       tipWidth = 0.1,
     } = options;
 
-    this._start = [...start];
-    this._end = [...end];
     this._tipLength = tipLength;
     this._tipWidth = tipWidth;
     this._color = color;
     this._strokeWidth = strokeWidth;
 
-    this._generateParts();
+    this.putStartAndEndOn(start, end);
   }
 
   /**
-   * Generate the arrow parts (shaft line + tip triangle)
+   * Convert full arrow delta to shaft delta by removing tip length along direction.
+   *
+   * Convention: tip geometry is built from full `delta`, shaft geometry from
+   * `max(0, |delta| - tipLength)` in the same direction.
    */
-  private _generateParts(): void {
-    this.clear();
+  private _getShaftDelta(delta: Vector3Tuple): Vector3Tuple {
+    const [dx, dy, dz] = delta;
+    const length = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (length === 0) return [0, 0, 0];
 
-    const [x0, y0, z0] = this._start;
-    const [x1, y1, z1] = this._end;
+    const shaftLength = Math.max(0, length - this._tipLength);
+    const inv = 1 / length;
+    return [dx * inv * shaftLength, dy * inv * shaftLength, dz * inv * shaftLength];
+  }
 
-    const dx = x1 - x0;
-    const dy = y1 - y0;
-    const dz = z1 - z0;
+  /**
+   * Regenerate canonical children from endpoint delta.
+   *
+   * Conventions:
+   * - Always rebuilds children (no in-place geometry mutation).
+   * - Zero-length still yields canonical shaft+tip children.
+   * - Tip local geometry is centered via centerPointsAroundPosition(), so
+   *   `tip.getCenter() === tip.position` for the child object itself.
+   */
+  private _generateParts(delta: Vector3Tuple): void {
+    this.remove(...this.children);
+
+    const [dx, dy, dz] = delta;
     const length = Math.sqrt(dx * dx + dy * dy + dz * dz);
 
     if (length === 0) {
+      // Important invariant: putStartAndEndOn() must always leave Arrow with
+      // canonical children (shaft + tip), even for degenerate/zero-length input.
+      // Graphing vectors rely on this path and call endpoint helpers on zero vectors.
+      this._shaft = new ArrowShaft([0, 0, 0], this._color, this._strokeWidth);
+      this._tip = new ArrowTip([0, 0, 0], this._tipLength, this._tipWidth, this._color);
+      this._tip.centerPointsAroundPosition();
+      this.add(this._shaft);
+      this.add(this._tip);
       return;
     }
 
-    const dirX = dx / length;
-    const dirY = dy / length;
-    const dirZ = dz / length;
+    // Build the shaft from the FULL delta but trim only the tip end, so its
+    // geometry spans [start, end - tipLength*dir]. Placed with its carrier at
+    // the arrow center (see putStartAndEndOn) this leaves the near end exactly
+    // on getStart() — a symmetric shaftDelta-long line would instead sit
+    // tipLength/2 forward, gapping at the start and poking into the tip.
+    const endMargin = Math.min(this._tipLength, length);
+    this._shaft = new ArrowShaft(delta, this._color, this._strokeWidth, 0, endMargin);
+    this._tip = new ArrowTip(delta, this._tipLength, this._tipWidth, this._color);
+    this._tip.centerPointsAroundPosition();
 
-    let perpX: number, perpY: number, perpZ: number;
-    if (Math.abs(dirZ) > 0.99) {
-      perpX = 1;
-      perpY = 0;
-      perpZ = 0;
-    } else {
-      perpX = -dirY;
-      perpY = dirX;
-      perpZ = 0;
-      const perpLen = Math.sqrt(perpX * perpX + perpY * perpY);
-      perpX /= perpLen;
-      perpY /= perpLen;
-    }
-
-    const tipBaseX = x1 - dirX * this._tipLength;
-    const tipBaseY = y1 - dirY * this._tipLength;
-    const tipBaseZ = z1 - dirZ * this._tipLength;
-
-    const tipLeft = [
-      tipBaseX + perpX * this._tipWidth,
-      tipBaseY + perpY * this._tipWidth,
-      tipBaseZ + perpZ * this._tipWidth,
-    ];
-    const tipRight = [
-      tipBaseX - perpX * this._tipWidth,
-      tipBaseY - perpY * this._tipWidth,
-      tipBaseZ - perpZ * this._tipWidth,
-    ];
-
-    this._shaft = new ArrowShaft(
-      [x0, y0, z0],
-      [tipBaseX, tipBaseY, tipBaseZ],
-      this._color,
-      this._strokeWidth,
-    );
     this.add(this._shaft);
-
-    this._tip = new ArrowTip([x1, y1, z1], tipLeft, tipRight, this._color);
     this.add(this._tip);
   }
 
   /**
-   * Get the start point
+   * Get the start point in world coordinates.
+   * @post result === _localToWorld(_start)
    */
   getStart(): Vector3Tuple {
-    return [...this._start];
+    return this._localToWorld(this._start);
   }
 
   /**
-   * Set the start point
+   * Set both start and end points in one canonical operation.
+   *
+   * Conventions:
+   * - Regenerates shaft/tip from delta every call.
+   * - Does not mutate this VGroup's own position.
+   * - Places shaft carrier at geometric midpoint.
+   * - Places tip carrier at midpoint + shaftDelta/2 (forward along direction).
+   */
+  putStartAndEndOn(start: Vector3Tuple, end: Vector3Tuple): this {
+    const delta: Vector3Tuple = [end[0] - start[0], end[1] - start[1], end[2] - start[2]];
+    this._generateParts(delta);
+
+    // Endpoints are the source of truth; the shaft/tip layout below just renders them.
+    this._start = [...start];
+    this._end = [...end];
+
+    const center: Vector3Tuple = [
+      (start[0] + end[0]) / 2,
+      (start[1] + end[1]) / 2,
+      (start[2] + end[2]) / 2,
+    ];
+
+    const shaftDelta = this._getShaftDelta(delta);
+
+    // Seat the shaft CARRIER (not its bbox center) at the arrow center. The shaft
+    // geometry is laid out in the full-delta frame spanning [start, end - tipLength]
+    // (see _generateParts), so its local origin already corresponds to the arrow
+    // center; placing position there lands the near end exactly on `start`.
+    // moveTo() would instead align the shaft's bbox center, shifting the
+    // tip-trimmed shaft forward by tipLength/2 and offsetting getStart/getEnd.
+    this._shaft!.position.set(center[0], center[1], center[2]);
+    this._shaft!._markDirty();
+    this._tip!.moveTo([
+      center[0] + shaftDelta[0] / 2,
+      center[1] + shaftDelta[1] / 2,
+      center[2] + shaftDelta[2] / 2,
+    ]);
+
+    return this;
+  }
+
+  /**
+   * @deprecated Use putStartAndEndOn(start, end) for canonical endpoint updates.
    */
   setStart(point: Vector3Tuple): this {
-    this._start = [...point];
-    this._generateParts();
-    return this;
+    return this.putStartAndEndOn(point, this.getEnd());
   }
 
   /**
-   * Get the end point (tip of the arrow)
+   * Get the end point (tip of the arrow) in world coordinates.
+   * @post result === _localToWorld(_end)
    */
   getEnd(): Vector3Tuple {
-    return [...this._end];
+    return this._localToWorld(this._end);
   }
 
   /**
-   * Set the end point (tip of the arrow)
+   * @deprecated Use putStartAndEndOn(start, end) for canonical endpoint updates.
    */
   setEnd(point: Vector3Tuple): this {
-    this._end = [...point];
-    this._generateParts();
-    return this;
+    return this.putStartAndEndOn(this.getStart(), point);
   }
 
   /**
-   * Get the length of the arrow (including tip)
+   * Get the center point of the arrow in world coordinates.
+   *
+   * Delegates to the VGroup world-bounds center: the old shaft-position shortcut
+   * ignored this Arrow's own group transform, so a shifted/scaled Arrow reported
+   * a stale center.
+   */
+  override getCenter(): Vector3Tuple {
+    return super.getCenter();
+  }
+
+  /**
+   * Get the length of the arrow (including tip), in world space.
+   * @post result === dist(getStart(), getEnd())
    */
   getLength(): number {
-    const dx = this._end[0] - this._start[0];
-    const dy = this._end[1] - this._start[1];
-    const dz = this._end[2] - this._start[2];
-    return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    return segmentLength(this.getStart(), this.getEnd());
+  }
+
+  /**
+   * Re-express the endpoint cache so getStart()/getEnd() stay world-invariant
+   * when normalization folds this group's deferred transform into the children.
+   *
+   * _start/_end are in this group's local frame; capture their world positions
+   * before super bakes (and resets) the group transform, then map them back into
+   * the post-bake local frame. Mirrors Circle.normalizeTransform folding scale
+   * into _radius — without it, _start/_end would silently drift (as the old
+   * shaft-position/_originToStartLocal reconstruction did).
+   */
+  override normalizeTransform(): this {
+    const worldStart = this.getStart();
+    const worldEnd = this.getEnd();
+    super.normalizeTransform();
+    this._start = this._worldToLocal(worldStart);
+    this._end = this._worldToLocal(worldEnd);
+    return this;
   }
 
   /**
@@ -257,7 +447,7 @@ export class Arrow extends Group {
    */
   setTipLength(value: number): this {
     this._tipLength = value;
-    this._generateParts();
+    this.putStartAndEndOn(this.getStart(), this.getEnd());
     return this;
   }
 
@@ -273,36 +463,32 @@ export class Arrow extends Group {
    */
   setTipWidth(value: number): this {
     this._tipWidth = value;
-    this._generateParts();
+    this.putStartAndEndOn(this.getStart(), this.getEnd());
     return this;
   }
 
   /**
-   * Get the direction vector of the arrow (normalized)
+   * Get the direction vector of the arrow (normalized, world-space).
+   * @post result === normalize(getEnd() - getStart())
    */
   getDirection(): Vector3Tuple {
-    const length = this.getLength();
-    if (length === 0) {
-      return [1, 0, 0];
-    }
-    return [
-      (this._end[0] - this._start[0]) / length,
-      (this._end[1] - this._start[1]) / length,
-      (this._end[2] - this._start[2]) / length,
-    ];
+    return segmentDirection(this.getStart(), this.getEnd());
   }
 
   /**
-   * Get the angle of the arrow in the XY plane (in radians)
+   * Get the angle of the arrow in the XY plane (in radians, world-space).
    */
   getAngle(): number {
-    return Math.atan2(this._end[1] - this._start[1], this._end[0] - this._start[0]);
+    return segmentAngle(this.getStart(), this.getEnd());
   }
 
   /**
-   * Rebuild the tip triangle from the shaft's and tip's current (possibly transformed) points.
-   * Uses the tip's already-transformed apex so the arrow still points at the exact
-   * transformed coordinate, while restoring a clean isosceles triangle shape.
+   * Empty shell for {@link Mobject.copy}. The Arrow constructor eagerly builds
+   * shaft+tip, so we strip them: copy() clones the source's actual children
+   * (preserving per-child state like a recolored tip) and {@link copy} rebinds
+   * the _shaft/_tip pointers to them.
+   *
+   * @post result.children.length === 0
    */
   reconstructTip(): void {
     if (!this._shaft || !this._tip) return;
@@ -374,29 +560,58 @@ export class Arrow extends Group {
     this._end = [tipApex[0], tipApex[1], tipApex[2]];
   }
 
+  /**
+   * Copy this Arrow by cloning its actual shaft/tip children and rebinding the
+   * _shaft/_tip pointers to them, rather than rebuilding geometry from endpoint
+   * params via the constructor. This preserves per-child state (e.g. a recolored
+   * tip) that constructor params can't express.
+   *
+   * @post result.children.length === 2  // shaft, tip
+   * @post result.getStart() === this.getStart() && result.getEnd() === this.getEnd()
+   */
   override copy(): Arrow {
-    const copy = new Arrow({
-      start: this._start,
-      end: this._end,
+    this.normalizeTransform();
+
+    // Construct a shell carrying only the scalar config; strip the children the
+    // constructor eagerly built so we can rebind to clones of THIS arrow's parts.
+    const clone = new Arrow({
       tipLength: this._tipLength,
       tipWidth: this._tipWidth,
       color: this.color,
       strokeWidth: this.strokeWidth,
     });
-    this._copyBaseAttributesInto(copy, { copyChildren: false });
-    return copy;
+    clone.remove(...clone.children);
+
+    clone._shaft = this._shaft ? this._shaft.copy() : null;
+    clone._tip = this._tip ? this._tip.copy() : null;
+    if (clone._shaft) clone.add(clone._shaft);
+    if (clone._tip) clone.add(clone._tip);
+
+    // Endpoints are the source of truth; carry them over directly (children
+    // already encode the matching geometry).
+    clone._start = [...this._start];
+    clone._end = [...this._end];
+
+    this._copyBaseAttributesInto(clone, { copyChildren: false, copyPosition: false });
+    return clone;
   }
 }
 
 /**
  * DoubleArrow - An arrow with tips on both ends
  */
-export class DoubleArrow extends Group {
-  private _start: Vector3Tuple;
-  private _end: Vector3Tuple;
+export class DoubleArrow extends VGroup {
   private _tipLength: number;
   private _tipWidth: number;
   private _strokeWidth: number;
+  /**
+   * Endpoints in this group's LOCAL frame — the source of truth (see Arrow._start).
+   * getStart()/getEnd() map these through _localToWorld(); the shaft/tips are
+   * pure rendering laid out from them in putStartAndEndOn(). normalizeTransform()
+   * re-bakes them so they stay world-invariant under deferred group transforms.
+   */
+  private _start: Vector3Tuple = [0, 0, 0];
+  private _end: Vector3Tuple = [0, 0, 0];
 
   constructor(options: ArrowOptions = {}) {
     super();
@@ -410,228 +625,156 @@ export class DoubleArrow extends Group {
       tipWidth = 0.1,
     } = options;
 
-    this._start = [...start];
-    this._end = [...end];
     this._tipLength = tipLength;
     this._tipWidth = tipWidth;
     this._color = color;
     this._strokeWidth = strokeWidth;
 
-    this._generateParts();
+    this.putStartAndEndOn(start, end);
   }
 
-  private _generateParts(): void {
-    this.clear();
+  private _generateParts(delta: Vector3Tuple): void {
+    this.remove(...this.children);
 
-    const [x0, y0, z0] = this._start;
-    const [x1, y1, z1] = this._end;
-
-    const dx = x1 - x0;
-    const dy = y1 - y0;
-    const dz = z1 - z0;
+    const [dx, dy, dz] = delta;
     const length = Math.sqrt(dx * dx + dy * dy + dz * dz);
-
-    if (length === 0) {
-      return;
-    }
+    if (length === 0) return;
 
     const dirX = dx / length;
     const dirY = dy / length;
     const dirZ = dz / length;
 
-    let perpX: number, perpY: number, perpZ: number;
-    if (Math.abs(dirZ) > 0.99) {
-      perpX = 1;
-      perpY = 0;
-      perpZ = 0;
-    } else {
-      perpX = -dirY;
-      perpY = dirX;
-      perpZ = 0;
-      const perpLen = Math.sqrt(perpX * perpX + perpY * perpY);
-      perpX /= perpLen;
-      perpY /= perpLen;
-    }
+    const shaftLength = length - 2 * this._tipLength;
+    const shaftDelta: Vector3Tuple = [dirX * shaftLength, dirY * shaftLength, dirZ * shaftLength];
 
-    const endTipBaseX = x1 - dirX * this._tipLength;
-    const endTipBaseY = y1 - dirY * this._tipLength;
-    const endTipBaseZ = z1 - dirZ * this._tipLength;
+    const shaft = new ArrowShaft(shaftDelta, this._color, this._strokeWidth);
+    const endTip = new ArrowTip(delta, this._tipLength, this._tipWidth, this._color);
+    const startTip = new ArrowTip([-dx, -dy, -dz], this._tipLength, this._tipWidth, this._color);
 
-    const startTipBaseX = x0 + dirX * this._tipLength;
-    const startTipBaseY = y0 + dirY * this._tipLength;
-    const startTipBaseZ = z0 + dirZ * this._tipLength;
-
-    const endTipLeft = [
-      endTipBaseX + perpX * this._tipWidth,
-      endTipBaseY + perpY * this._tipWidth,
-      endTipBaseZ + perpZ * this._tipWidth,
-    ];
-    const endTipRight = [
-      endTipBaseX - perpX * this._tipWidth,
-      endTipBaseY - perpY * this._tipWidth,
-      endTipBaseZ - perpZ * this._tipWidth,
-    ];
-    const startTipLeft = [
-      startTipBaseX + perpX * this._tipWidth,
-      startTipBaseY + perpY * this._tipWidth,
-      startTipBaseZ + perpZ * this._tipWidth,
-    ];
-    const startTipRight = [
-      startTipBaseX - perpX * this._tipWidth,
-      startTipBaseY - perpY * this._tipWidth,
-      startTipBaseZ - perpZ * this._tipWidth,
-    ];
-
-    const shaft = new ArrowShaft(
-      [startTipBaseX, startTipBaseY, startTipBaseZ],
-      [endTipBaseX, endTipBaseY, endTipBaseZ],
-      this._color,
-      this._strokeWidth,
-    );
     this.add(shaft);
-
-    const endTip = new ArrowTip([x1, y1, z1], endTipLeft, endTipRight, this._color);
     this.add(endTip);
-
-    const startTip = new ArrowTip([x0, y0, z0], startTipRight, startTipLeft, this._color);
     this.add(startTip);
   }
 
+  /**
+   * Get the start point in world coordinates.
+   * @post result === _localToWorld(_start)
+   */
   getStart(): Vector3Tuple {
-    return [...this._start];
+    return this._localToWorld(this._start);
   }
 
-  setStart(point: Vector3Tuple): this {
-    this._start = [...point];
-    this._generateParts();
+  putStartAndEndOn(start: Vector3Tuple, end: Vector3Tuple): this {
+    const delta: Vector3Tuple = [end[0] - start[0], end[1] - start[1], end[2] - start[2]];
+    this._generateParts(delta);
+
+    // Endpoints are the source of truth; the shaft/tip layout below just renders them.
+    this._start = [...start];
+    this._end = [...end];
+
+    const length = Math.sqrt(delta[0] * delta[0] + delta[1] * delta[1] + delta[2] * delta[2]);
+    if (length === 0) return this;
+
+    const dirX = delta[0] / length;
+    const dirY = delta[1] / length;
+    const dirZ = delta[2] / length;
+
+    const shaftStart: Vector3Tuple = [
+      start[0] + dirX * this._tipLength,
+      start[1] + dirY * this._tipLength,
+      start[2] + dirZ * this._tipLength,
+    ];
+
+    (this.children[0] as ArrowShaft).moveTo(shaftStart);
+    (this.children[1] as ArrowTip).moveTo(end);
+    (this.children[2] as ArrowTip).moveTo(start);
     return this;
   }
 
-  getEnd(): Vector3Tuple {
-    return [...this._end];
-  }
-
-  setEnd(point: Vector3Tuple): this {
-    this._end = [...point];
-    this._generateParts();
+  setTipLength(value: number): this {
+    this._tipLength = value;
+    this.putStartAndEndOn(this.getStart(), this.getEnd());
     return this;
   }
 
-  getLength(): number {
-    const dx = this._end[0] - this._start[0];
-    const dy = this._end[1] - this._start[1];
-    const dz = this._end[2] - this._start[2];
-    return Math.sqrt(dx * dx + dy * dy + dz * dz);
+  getTipLength(): number {
+    return this._tipLength;
+  }
+
+  setTipWidth(value: number): this {
+    this._tipWidth = value;
+    this.putStartAndEndOn(this.getStart(), this.getEnd());
+    return this;
+  }
+
+  getTipWidth(): number {
+    return this._tipWidth;
   }
 
   /**
-   * Rebuild both tip triangles from the shaft's current transformed endpoints.
+   * @deprecated Use putStartAndEndOn(start, end) for canonical endpoint updates.
    */
-  reconstructTips(): void {
-    // DoubleArrow has children: [shaft, endTip, startTip]
-    const kids = this.children;
-    if (kids.length < 3) return;
-
-    const shaft = kids[0];
-    const endTipMob = kids[1];
-    const startTipMob = kids[2];
-
-    // Duck-type check
-    type VMobLike = { getLocalPoints(): number[][]; setPoints(p: number[][]): void };
-    const asVMob = (m: unknown): VMobLike | null => {
-      const o = m as Record<string, unknown>;
-      return typeof o.getLocalPoints === 'function' && typeof o.setPoints === 'function'
-        ? (o as unknown as VMobLike)
-        : null;
-    };
-    const shaftVM = asVMob(shaft);
-    const endTipVM = asVMob(endTipMob);
-    const startTipVM = asVMob(startTipMob);
-    if (!shaftVM || !endTipVM || !startTipVM) return;
-
-    const shaftPts = shaftVM.getLocalPoints();
-    if (shaftPts.length < 4) return;
-
-    const endTipCurPts = endTipVM.getLocalPoints();
-    const startTipCurPts = startTipVM.getLocalPoints();
-    if (endTipCurPts.length < 4 || startTipCurPts.length < 4) return;
-
-    const shaftStart = shaftPts[0];
-    const shaftEnd = shaftPts[shaftPts.length - 1];
-
-    // Use already-transformed apex positions (Bezier index 3) so tips
-    // land on the exact transformed coordinates
-    const endApex = endTipCurPts[3];
-    const startApex = startTipCurPts[3];
-
-    const halfW = this._tipWidth;
-    const addSeg = (pts: number[][], p0: number[], p1: number[], first: boolean) => {
-      const sdx = p1[0] - p0[0],
-        sdy = p1[1] - p0[1],
-        sdz = p1[2] - p0[2];
-      if (first) pts.push([...p0]);
-      pts.push([p0[0] + sdx / 3, p0[1] + sdy / 3, p0[2] + sdz / 3]);
-      pts.push([p0[0] + (2 * sdx) / 3, p0[1] + (2 * sdy) / 3, p0[2] + (2 * sdz) / 3]);
-      pts.push([...p1]);
-    };
-
-    const rebuildTip = (base: number[], apex: number[], vm: VMobLike, reverse: boolean) => {
-      const dx = apex[0] - base[0];
-      const dy = apex[1] - base[1];
-      const dz = apex[2] - base[2];
-      const len = Math.sqrt(dx * dx + dy * dy + dz * dz);
-      if (len === 0) return;
-      const dxn = dx / len,
-        dyn = dy / len,
-        dzn = dz / len;
-
-      let perpX: number, perpY: number, perpZ: number;
-      if (Math.abs(dzn) > 0.99) {
-        perpX = 1;
-        perpY = 0;
-        perpZ = 0;
-      } else {
-        perpX = -dyn;
-        perpY = dxn;
-        perpZ = 0;
-        const pl = Math.sqrt(perpX * perpX + perpY * perpY);
-        perpX /= pl;
-        perpY /= pl;
-      }
-
-      const left = [base[0] + perpX * halfW, base[1] + perpY * halfW, base[2] + perpZ * halfW];
-      const right = [base[0] - perpX * halfW, base[1] - perpY * halfW, base[2] - perpZ * halfW];
-      const pts: number[][] = [];
-      if (reverse) {
-        addSeg(pts, right, apex, true);
-        addSeg(pts, apex, left, false);
-        addSeg(pts, left, right, false);
-      } else {
-        addSeg(pts, left, apex, true);
-        addSeg(pts, apex, right, false);
-        addSeg(pts, right, left, false);
-      }
-      vm.setPoints(pts);
-    };
-
-    rebuildTip(shaftEnd, endApex, endTipVM, false);
-    rebuildTip(shaftStart, startApex, startTipVM, true);
-
-    this._start = [startApex[0], startApex[1], startApex[2]];
-    this._end = [endApex[0], endApex[1], endApex[2]];
+  setStart(point: Vector3Tuple): this {
+    return this.putStartAndEndOn(point, this.getEnd());
   }
 
+  /**
+   * Get the end point in world coordinates.
+   * @post result === _localToWorld(_end)
+   */
+  getEnd(): Vector3Tuple {
+    return this._localToWorld(this._end);
+  }
+
+  /**
+   * @deprecated Use putStartAndEndOn(start, end) for canonical endpoint updates.
+   */
+  setEnd(point: Vector3Tuple): this {
+    return this.putStartAndEndOn(this.getStart(), point);
+  }
+
+  /**
+   * Get the length of the arrow in world space.
+   * @post result === dist(getStart(), getEnd())
+   */
+  getLength(): number {
+    return segmentLength(this.getStart(), this.getEnd());
+  }
+
+  /**
+   * Re-express the endpoint cache so getStart()/getEnd() stay world-invariant
+   * when normalization folds this group's deferred transform into the children.
+   * See Arrow.normalizeTransform.
+   */
+  override normalizeTransform(): this {
+    const worldStart = this.getStart();
+    const worldEnd = this.getEnd();
+    super.normalizeTransform();
+    this._start = this._worldToLocal(worldStart);
+    this._end = this._worldToLocal(worldEnd);
+    return this;
+  }
+
+  /**
+   * Empty shell for {@link Mobject.copy}. The constructor eagerly builds
+   * shaft+endTip+startTip, so we strip them and let copy() clone the source's
+   * actual children. DoubleArrow reads its parts by child index (no cached
+   * pointers), so no rebind override is needed.
+   *
+   * @post result.children.length === 0
+   */
   override copy(): DoubleArrow {
-    const copy = new DoubleArrow({
-      start: this._start,
-      end: this._end,
+    this.normalizeTransform();
+    const clone = new DoubleArrow({
+      start: this.getStart(),
+      end: this.getEnd(),
       tipLength: this._tipLength,
       tipWidth: this._tipWidth,
       color: this._color,
       strokeWidth: this._strokeWidth,
     });
-    this._copyBaseAttributesInto(copy, { copyChildren: false });
-    return copy;
+    this._copyBaseAttributesInto(clone, { copyPosition: false });
+    return clone;
   }
 }
 

--- a/src/mobjects/geometry/DashedLine.ts
+++ b/src/mobjects/geometry/DashedLine.ts
@@ -254,8 +254,13 @@ export class DashedLine extends VMobject {
     return this;
   }
 
+  /**
+   * Copy this DashedLine, rebuilding dashes from endpoint params.
+   * @post result.children.length === this.children.length  // dashes rebuilt by constructor
+   */
   override copy(): DashedLine {
-    const copy = new DashedLine({
+    this.normalizeTransform();
+    const clone = new DashedLine({
       start: this._start,
       end: this._end,
       dashLength: this._dashLength,
@@ -263,7 +268,8 @@ export class DashedLine extends VMobject {
       color: this.color,
       strokeWidth: this.strokeWidth,
     });
-    this._copyBaseAttributesInto(copy, { copyChildren: false });
-    return copy;
+    this._copyBaseAttributesInto(clone, { copyPosition: false });
+    clone._dashes = clone.children.slice() as Line[];
+    return clone;
   }
 }

--- a/src/mobjects/geometry/Line.ts
+++ b/src/mobjects/geometry/Line.ts
@@ -2,6 +2,13 @@ import * as THREE from 'three';
 import { VMobject } from '../../core/VMobject';
 import { Vector3Tuple } from '../../core/Mobject';
 import { WHITE } from '../../constants';
+import {
+  segmentLength,
+  segmentMidpoint,
+  segmentDirection,
+  segmentAngle,
+  segmentPointAt,
+} from './segment';
 
 /**
  * Options for creating a Line
@@ -120,12 +127,7 @@ export class Line extends VMobject {
    * @post result === dist(getStart(), getEnd())
    */
   getLength(): number {
-    const s = this.getStart();
-    const e = this.getEnd();
-    const dx = e[0] - s[0];
-    const dy = e[1] - s[1];
-    const dz = e[2] - s[2];
-    return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    return segmentLength(this.getStart(), this.getEnd());
   }
 
   /**
@@ -133,9 +135,7 @@ export class Line extends VMobject {
    * @post result === (getStart() + getEnd()) / 2
    */
   getMidpoint(): Vector3Tuple {
-    const s = this.getStart();
-    const e = this.getEnd();
-    return [(s[0] + e[0]) / 2, (s[1] + e[1]) / 2, (s[2] + e[2]) / 2];
+    return segmentMidpoint(this.getStart(), this.getEnd());
   }
 
   /**
@@ -143,22 +143,14 @@ export class Line extends VMobject {
    * @post result === normalize(getEnd() - getStart())
    */
   getDirection(): Vector3Tuple {
-    const s = this.getStart();
-    const e = this.getEnd();
-    const length = this.getLength();
-    if (length === 0) {
-      return [1, 0, 0];
-    }
-    return [(e[0] - s[0]) / length, (e[1] - s[1]) / length, (e[2] - s[2]) / length];
+    return segmentDirection(this.getStart(), this.getEnd());
   }
 
   /**
    * Get the angle of the line in the XY plane (in radians, world-space).
    */
   getAngle(): number {
-    const s = this.getStart();
-    const e = this.getEnd();
-    return Math.atan2(e[1] - s[1], e[0] - s[0]);
+    return segmentAngle(this.getStart(), this.getEnd());
   }
 
   /**
@@ -166,19 +158,21 @@ export class Line extends VMobject {
    * @post pointAlongPath(0) === getStart() && pointAlongPath(1) === getEnd()
    */
   pointAlongPath(t: number): Vector3Tuple {
-    const s = this.getStart();
-    const e = this.getEnd();
-    return [s[0] + (e[0] - s[0]) * t, s[1] + (e[1] - s[1]) * t, s[2] + (e[2] - s[2]) * t];
+    return segmentPointAt(this.getStart(), this.getEnd(), t);
   }
 
+  /**
+   * Copy this Line.
+   */
   override copy(): Line {
-    const copy = new Line({
-      start: this._start,
-      end: this._end,
+    this.normalizeTransform();
+    const clone = new Line({
+      start: this.getStart(),
+      end: this.getEnd(),
       color: this.color,
       strokeWidth: this.strokeWidth,
     });
-    this._copyBaseAttributesInto(copy, { copyChildren: false });
-    return copy;
+    this._copyBaseAttributesInto(clone, { copyPosition: false });
+    return clone;
   }
 }

--- a/src/mobjects/geometry/geometry-arrow.test.ts
+++ b/src/mobjects/geometry/geometry-arrow.test.ts
@@ -64,13 +64,6 @@ describe('Arrow.reconstructTip', () => {
   });
 });
 
-describe('DoubleArrow.reconstructTips', () => {
-  it('exists and can be called without error', () => {
-    const da = new DoubleArrow({ start: [0, 0, 0], end: [3, 0, 0] });
-    expect(() => da.reconstructTips()).not.toThrow();
-  });
-});
-
 // ── ApplyMatrix on Arrow ────────────────────────────────────────────────────
 
 describe('ApplyMatrix on Arrow with non-uniform matrix', () => {

--- a/src/mobjects/geometry/scale-after-normalize.test.ts
+++ b/src/mobjects/geometry/scale-after-normalize.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { Square } from './Rectangle';
+
+/**
+ * MRE: scale() pivots about `position`, not the visual center.
+ *
+ * normalizeTransform() bakes a node's transform into its points and resets the
+ * carrier position to the origin. That makes `position` diverge from the visual
+ * center for ANY mobject (not just Arrow). scale() then pivots about `position`
+ * (== origin here) instead of the center, so the shape drifts.
+ */
+describe('scale after normalizeTransform (MRE)', () => {
+  it('keeps the visual center fixed when scaling (manim semantics)', () => {
+    const sq = new Square(); // sideLength 2, centered at origin
+
+    sq.shift([3, 0, 0]);
+    expect(sq.getCenter()).toEqual([3, 0, 0]); // sanity: center followed the shift
+
+    sq.normalizeTransform(); // bakes [3,0,0] into points; position resets to origin
+    expect(sq.getCenter()).toEqual([3, 0, 0]); // center unchanged by normalization
+    expect([sq.position.x, sq.position.y, sq.position.z]).toEqual([0, 0, 0]); // ...but position is now origin
+
+    sq.scale(2); // manim: scale about center -> center stays [3,0,0]
+
+    // BUG: current code pivots about position ([0,0,0]) -> center jumps to [6,0,0]
+    expect(sq.getCenter()).toEqual([3, 0, 0]);
+  });
+});

--- a/src/mobjects/geometry/segment.ts
+++ b/src/mobjects/geometry/segment.ts
@@ -1,0 +1,48 @@
+import { Vector3Tuple } from '../../core/Mobject';
+
+/**
+ * Pure endpoint geometry shared by Line, Arrow and DoubleArrow.
+ *
+ * Every function takes the two endpoints already resolved to the SAME frame
+ * (in practice the caller's world-space `getStart()` / `getEnd()`), so the
+ * results stay correct under any group transform. This is the single source of
+ * truth for segment-derived quantities; callers must not recompute them from
+ * cached/local endpoints, which go stale under rotation/scale.
+ */
+
+/** Euclidean length of the segment. */
+export function segmentLength(start: Vector3Tuple, end: Vector3Tuple): number {
+  const dx = end[0] - start[0];
+  const dy = end[1] - start[1];
+  const dz = end[2] - start[2];
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+/**
+ * Unit direction from start to end. Returns [1, 0, 0] for a zero-length
+ * segment (matching the historical Line/Arrow fallback).
+ */
+export function segmentDirection(start: Vector3Tuple, end: Vector3Tuple): Vector3Tuple {
+  const length = segmentLength(start, end);
+  if (length === 0) return [1, 0, 0];
+  return [(end[0] - start[0]) / length, (end[1] - start[1]) / length, (end[2] - start[2]) / length];
+}
+
+/** Angle of the segment in the XY plane, in radians. */
+export function segmentAngle(start: Vector3Tuple, end: Vector3Tuple): number {
+  return Math.atan2(end[1] - start[1], end[0] - start[0]);
+}
+
+/** Midpoint of the segment. */
+export function segmentMidpoint(start: Vector3Tuple, end: Vector3Tuple): Vector3Tuple {
+  return [(start[0] + end[0]) / 2, (start[1] + end[1]) / 2, (start[2] + end[2]) / 2];
+}
+
+/** Point at parameter t along the segment (0 = start, 1 = end). */
+export function segmentPointAt(start: Vector3Tuple, end: Vector3Tuple, t: number): Vector3Tuple {
+  return [
+    start[0] + (end[0] - start[0]) * t,
+    start[1] + (end[1] - start[1]) * t,
+    start[2] + (end[2] - start[2]) * t,
+  ];
+}


### PR DESCRIPTION
## Summary

# Summary                                                                                                                                                                                   
                                                                                                                                                                                           
 1. Refactor Arrow/DoubleArrow endpoint handling to use geometry-derived start/end via putStartAndEndOn() instead of stored _start/_end state.                                             
 2. Simplify GrowArrow to child-based growth (not group transform): child scale interpolation (~0 -> 1) plus anchor-based child position interpolation.                                    
                                                                                                                                                                                           
 This makes endpoint behavior more deterministic under transforms/regeneration, removes duplicated state, and keeps GrowArrow aligned with the intended growth contract.                   
 As a result, animation end state is simpler to reason about, tests now lock in those invariants directly, and it also solves the animation being wrong for a shifted arrow.             

The same contract is used for `Line`, to share code related to `putStartAndEndOn`

Also added examples to illustrate behaviour

## Changes

- `geometry/Arrow.ts`, `Arrow`/`DoubleArrow`: endpoints derived from geometry via `putStartAndEndOn()` (drop stored `_start`/`_end`)
- `geometry/segment.ts` (new): pure segment math shared by `Line`, `Arrow`, `DoubleArrow` — single source of truth, stays correct under group transforms
- `geometry/Line.ts`, `geometry/DashedLine.ts`: adopt the same `segment` contract
- `animation/growing/index.ts`: `GrowArrow` reworked to child scale + anchor-based position interpolation
- `examples/arrow-dance.{html,ts}` (new) + tests locking the endpoint/growth invariants


## Testing
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Types check (`npm run typecheck`)

## Related Issues
Closes #339

## Illustration


https://github.com/user-attachments/assets/6af754f7-e358-4487-90a0-495d4b5fd14b

