### PR TITLE
feat(examples): add Clickable example showcasing click vs drag (#430)

### DIFF
--- a/docs/docs/examples/new.mdx
+++ b/docs/docs/examples/new.mdx
@@ -5,6 +5,7 @@ sidebar_label: New Features
 
 import DraggableObjectsExample from '@site/src/components/examples/DraggableObjectsExample';
 import DraggableObjects3DExample from '@site/src/components/examples/DraggableObjects3DExample';
+import ClickableObjectsExample from '@site/src/components/examples/ClickableObjectsExample';
 import MatrixHelpersExample from '@site/src/components/examples/MatrixHelpersExample';
 import ConvexHull3DExample from '@site/src/components/examples/ConvexHull3DExample';
 import TipableVMobjectExample from '@site/src/components/examples/TipableVMobjectExample';
@@ -91,6 +92,88 @@ makeDraggable(dot, scene);
 ```
 
 </details>
+
+---
+
+## Clickable Objects
+
+`Clickable` adds discrete click / double-click / tap detection to a mobject. The callback fires when you click *on* the object, but the object itself doesn't move — making it the tool for buttons, toggles, and actions. Click the circle below to cycle its color and bump the counter; double-click it to reset. The square next to it is `Draggable` instead: a plain click does nothing, you have to drag it.
+
+<ClickableObjectsExample />
+
+### `Clickable` vs `Draggable`
+
+| | `Clickable` / `makeClickable` | `Draggable` / `makeDraggable` |
+|---|---|---|
+| **Trigger** | discrete `click` / `dblclick` / tap | `mousedown` → move → `mouseup` (a drag gesture) |
+| **Moves the mobject?** | **No** — fires a callback, the object stays put | **Yes** — repositions the mobject as you drag |
+| **Callbacks** | `onClick`, `onDoubleClick` | `onDragStart`, `onDrag`, `onDragEnd` |
+| **Extra options** | — | `constrainX` / `constrainY` / `constrainZ`, `snapToGrid` |
+| **Reach for it when…** | buttons, toggles, selecting, triggering an action | letting users reposition objects |
+
+Both return a handle with `enable()`, `disable()`, and `dispose()` — call `dispose()` to remove the underlying event listeners when you're done. (`Hoverable` / `makeHoverable` is the third sibling, for hover feedback like scaling or recoloring.)
+
+<details>
+<summary>Source Code</summary>
+
+```typescript
+import { Circle, Square, Text, makeClickable, makeDraggable, BLUE, GREEN, YELLOW, RED, PURPLE, ORANGE, TEAL, PINK, WHITE } from 'manim-web';
+
+const PALETTE = [BLUE, GREEN, YELLOW, RED, PURPLE, ORANGE, TEAL, PINK];
+
+// Clickable: a discrete tap action — the circle never moves
+let colorIndex = 0;
+let clickCount = 0;
+const circle = new Circle({ radius: 0.7, color: BLUE, fillOpacity: 0.9 });
+circle.moveTo([-2.5, 0.3, 0]);
+const counter = new Text({ text: 'Clicks: 0', fontSize: 22, color: WHITE });
+counter.moveTo([-2.5, -1.6, 0]);
+
+// Draggable: a continuous gesture that repositions the square
+const square = new Square({ sideLength: 1.3, color: GREEN, fillOpacity: 0.9 });
+square.moveTo([2.5, 0.3, 0]);
+const posLabel = new Text({ text: 'Square: (2.5, 0.3)', fontSize: 22, color: WHITE });
+posLabel.moveTo([2.5, -1.6, 0]);
+
+scene.add(circle, counter, square, posLabel);
+
+// This scene has no animation loop, so the callbacks call scene.render()
+// to repaint after mutating a mobject.
+
+// Click cycles color + counts; double-click resets (reset is idempotent)
+const clickable = makeClickable(circle, scene, {
+  onClick: () => {
+    clickCount += 1;
+    colorIndex = (colorIndex + 1) % PALETTE.length;
+    circle.setColor(PALETTE[colorIndex]);
+    counter.setText(`Clicks: ${clickCount}`);
+    scene.render();
+  },
+  onDoubleClick: () => {
+    clickCount = 0;
+    colorIndex = 0;
+    circle.setColor(BLUE);
+    counter.setText('Clicks: 0');
+    scene.render();
+  },
+});
+
+// Drag repositions the square and reports its live position
+const draggable = makeDraggable(square, scene, {
+  onDrag: (_mobject, position) => {
+    posLabel.setText(`Square: (${position[0].toFixed(1)}, ${position[1].toFixed(1)})`);
+    scene.render();
+  },
+});
+
+// Remove the event listeners when finished
+// clickable.dispose();
+// draggable.dispose();
+```
+
+</details>
+
+**Learn More:** [**Clickable**](/api/classes/Clickable) · [**makeClickable**](/api/functions/makeClickable) · [**Draggable**](/api/classes/Draggable) · [**makeDraggable**](/api/functions/makeDraggable)
 
 ---
 

--- a/docs/src/components/examples/ClickableObjectsExample.tsx
+++ b/docs/src/components/examples/ClickableObjectsExample.tsx
@@ -1,0 +1,95 @@
+// Hand-written companion to examples/clickable_objects.ts (not generated).
+import React from 'react';
+import ManimExample from '../ManimExample';
+
+async function animate(scene: any) {
+  const {
+    Circle,
+    Square,
+    Text,
+    makeClickable,
+    makeDraggable,
+    BLUE,
+    GREEN,
+    YELLOW,
+    RED,
+    PURPLE,
+    ORANGE,
+    TEAL,
+    PINK,
+    WHITE,
+  } = await import('manim-web');
+
+  const PALETTE = [BLUE, GREEN, YELLOW, RED, PURPLE, ORANGE, TEAL, PINK];
+
+  const title = new Text({
+    text: 'Click the circle  •  Drag the square',
+    fontSize: 26,
+    color: WHITE,
+  });
+  title.moveTo([0, 2.8, 0]);
+
+  // Clickable: a discrete tap action — the circle never moves.
+  let colorIndex = 0;
+  let clickCount = 0;
+  const circle = new Circle({ radius: 0.7, color: BLUE, fillOpacity: 0.9 });
+  circle.moveTo([-2.5, 0.3, 0]);
+  const counter = new Text({ text: 'Clicks: 0', fontSize: 22, color: WHITE });
+  counter.moveTo([-2.5, -1.6, 0]);
+
+  // Draggable: a continuous gesture that repositions the square.
+  const square = new Square({ sideLength: 1.3, color: GREEN, fillOpacity: 0.9 });
+  square.moveTo([2.5, 0.3, 0]);
+  const posLabel = new Text({ text: 'Square: (2.5, 0.3)', fontSize: 22, color: WHITE });
+  posLabel.moveTo([2.5, -1.6, 0]);
+
+  const hint = new Text({
+    text: 'Double-click the circle to reset',
+    fontSize: 18,
+    color: '#888888',
+  });
+  hint.moveTo([0, -2.8, 0]);
+
+  scene.add(title, circle, counter, square, posLabel, hint);
+
+  // Click cycles color + bumps the counter; double-click resets (idempotent
+  // because browsers fire `click` before `dblclick`).
+  // This scene has no animation loop, so interaction callbacks must call
+  // scene.render() to repaint after they mutate a mobject.
+  const clickable = makeClickable(circle, scene, {
+    onClick: () => {
+      clickCount += 1;
+      colorIndex = (colorIndex + 1) % PALETTE.length;
+      circle.setColor(PALETTE[colorIndex]);
+      counter.setText(`Clicks: ${clickCount}`);
+      scene.render();
+    },
+    onDoubleClick: () => {
+      clickCount = 0;
+      colorIndex = 0;
+      circle.setColor(BLUE);
+      counter.setText('Clicks: 0');
+      scene.render();
+    },
+  });
+
+  const draggable = makeDraggable(square, scene, {
+    onDrag: (_mobject: any, position: [number, number, number]) => {
+      posLabel.setText(`Square: (${position[0].toFixed(1)}, ${position[1].toFixed(1)})`);
+      scene.render();
+    },
+  });
+
+  try {
+    // Keep the demo interactive for a while before the loop replays.
+    await scene.wait(60);
+  } finally {
+    // Dispose handles so canvas/window listeners don't accumulate across loops.
+    clickable.dispose();
+    draggable.dispose();
+  }
+}
+
+export default function ClickableObjectsExample() {
+  return <ManimExample animationFn={animate} />;
+}

--- a/examples/clickable_objects.html
+++ b/examples/clickable_objects.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script>if(new URLSearchParams(location.search).has('embed'))document.documentElement.classList.add('embed')</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ManimWeb - Clickable Objects</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    body {
+      background: #1a1a2e;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+    }
+    #container {
+      border: 2px solid #333;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .controls {
+      margin-top: 20px;
+      display: flex;
+      gap: 10px;
+    }
+    button {
+      padding: 10px 20px;
+      background: #e94560;
+      border: none;
+      border-radius: 4px;
+      color: white;
+      cursor: pointer;
+      font-size: 14px;
+    }
+    button:hover { background: #ff6b6b; }
+    button:disabled { background: #666; cursor: not-allowed; }
+    html.embed, html.embed body { margin:0!important;padding:0!important;overflow:hidden;background:#000!important;width:100%;height:100%; }
+    html.embed body { display:flex;justify-content:center;align-items:center; }
+    html.embed .controls, html.embed .buttons, html.embed h1, html.embed #status { display:none!important; }
+    html.embed #container { border:none!important;border-radius:0!important;width:100vw;height:100vh;display:flex;justify-content:center;align-items:center; }
+  </style>
+</head>
+<body>
+  <div id="container"></div>
+  <div class="controls">
+    <button id="playBtn">Start Demo</button>
+    <button id="resetBtn">Reset</button>
+  </div>
+
+  <script type="module" src="./clickable_objects.ts"></script>
+</body>
+</html>

--- a/examples/clickable_objects.ts
+++ b/examples/clickable_objects.ts
@@ -1,0 +1,148 @@
+import {
+  Scene,
+  Circle,
+  Square,
+  Text,
+  makeClickable,
+  makeDraggable,
+  type Vector3Tuple,
+  BLUE,
+  GREEN,
+  YELLOW,
+  RED,
+  PURPLE,
+  ORANGE,
+  TEAL,
+  PINK,
+  WHITE,
+} from '../src/index.ts';
+
+const container = document.getElementById('container');
+const scene = new Scene(container, {
+  width: 800,
+  height: 450,
+  backgroundColor: '#000000',
+});
+
+// Colors the clickable circle cycles through on each click.
+const PALETTE = [BLUE, GREEN, YELLOW, RED, PURPLE, ORANGE, TEAL, PINK];
+
+// Interaction handles are disposed before each replay so their canvas/window
+// event listeners don't accumulate across runs.
+let handles: Array<{ dispose: () => void }> = [];
+
+function disposeHandles(): void {
+  handles.forEach((h) => h.dispose());
+  handles = [];
+}
+
+let isAnimating = false;
+
+document.getElementById('playBtn').addEventListener('click', async () => {
+  if (isAnimating) return;
+  isAnimating = true;
+  document.getElementById('playBtn').disabled = true;
+
+  try {
+    disposeHandles();
+    scene.clear();
+
+    const title = new Text({
+      text: 'Click the circle  •  Drag the square',
+      fontSize: 26,
+      color: WHITE,
+    });
+    title.moveTo([0, 2.8, 0]);
+
+    // --- Clickable: a discrete tap action. The circle never moves. ---
+    let colorIndex = 0;
+    let clickCount = 0;
+
+    const circle = new Circle({ radius: 0.7, color: BLUE, fillOpacity: 0.9 });
+    circle.moveTo([-2.5, 0.3, 0]);
+
+    const counter = new Text({ text: 'Clicks: 0', fontSize: 22, color: WHITE });
+    counter.moveTo([-2.5, -1.6, 0]);
+
+    // --- Draggable: a continuous gesture that repositions the square. ---
+    const square = new Square({ sideLength: 1.3, color: GREEN, fillOpacity: 0.9 });
+    square.moveTo([2.5, 0.3, 0]);
+
+    const posLabel = new Text({ text: 'Square: (2.5, 0.3)', fontSize: 22, color: WHITE });
+    posLabel.moveTo([2.5, -1.6, 0]);
+
+    const hint = new Text({
+      text: 'Double-click the circle to reset',
+      fontSize: 18,
+      color: '#888888',
+    });
+    hint.moveTo([0, -2.8, 0]);
+
+    scene.add(title, circle, counter, square, posLabel, hint);
+    scene.render();
+
+    // Click → cycle color and bump the counter (the object stays put).
+    // Double-click → reset to the initial state. Reset is idempotent because
+    // browsers fire `click` events before `dblclick`.
+    // This scene has no animation loop, so interaction callbacks must call
+    // scene.render() to repaint after they mutate a mobject.
+    handles.push(
+      makeClickable(circle, scene, {
+        onClick: () => {
+          clickCount += 1;
+          colorIndex = (colorIndex + 1) % PALETTE.length;
+          circle.setColor(PALETTE[colorIndex]);
+          counter.setText(`Clicks: ${clickCount}`);
+          scene.render();
+        },
+        onDoubleClick: () => {
+          clickCount = 0;
+          colorIndex = 0;
+          circle.setColor(BLUE);
+          counter.setText('Clicks: 0');
+          scene.render();
+        },
+      }),
+    );
+
+    // Drag → reposition the square and reflect its live position in the label.
+    handles.push(
+      makeDraggable(square, scene, {
+        onDrag: (_mobject, position: Vector3Tuple) => {
+          posLabel.setText(`Square: (${position[0].toFixed(1)}, ${position[1].toFixed(1)})`);
+          scene.render();
+        },
+      }),
+    );
+  } catch (e) {
+    console.error('ERROR:', e.message, e.stack);
+  }
+
+  isAnimating = false;
+  document.getElementById('playBtn').disabled = false;
+});
+
+document.getElementById('resetBtn').addEventListener('click', () => {
+  disposeHandles();
+  scene.clear();
+});
+
+// Embed mode: hide controls, auto-play, loop
+if (new URLSearchParams(window.location.search).has('embed')) {
+  document
+    .querySelectorAll('.controls, .buttons, h1, #status')
+    .forEach((el) => ((el as HTMLElement).style.display = 'none'));
+  document.documentElement.style.cssText =
+    'margin:0;padding:0;width:100%;height:100%;overflow:hidden;background:#000';
+  document.body.style.cssText =
+    'margin:0;padding:0;width:100%;height:100%;overflow:hidden;background:#000;display:flex;justify-content:center;align-items:center';
+  const cont = document.getElementById('container');
+  if (cont) {
+    cont.style.cssText =
+      'border:none;border-radius:0;width:100vw;height:100vh;display:flex;justify-content:center;align-items:center';
+  }
+  const playBtn = document.getElementById('playBtn');
+  if (playBtn) {
+    setTimeout(() => (playBtn as HTMLButtonElement).click(), 500);
+  }
+}

--- a/src/interaction/interaction.test.ts
+++ b/src/interaction/interaction.test.ts
@@ -252,6 +252,17 @@ describe('Clickable', () => {
     c.dispose();
   });
 
+  // MIGRATION: example-based regression for issue #430 (Clickable example).
+  // Intent: the defining difference from Draggable is that clicking triggers a
+  // callback WITHOUT repositioning the mobject. Guards the contrast the example
+  // teaches — click = action, drag = move.
+  it('clicking a Clickable fires the callback but never moves the mobject', () => {
+    const canvas = scene.getCanvas();
+    fireMouseEvent(canvas, 'click', { clientX: 400, clientY: 300 });
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(mob.moveTo).not.toHaveBeenCalled();
+  });
+
   it('dispose removes event listeners (no errors on subsequent clicks)', () => {
     clickable.dispose();
     const canvas = scene.getCanvas();


### PR DESCRIPTION
## Summary

Closes #430 — adds an example showcasing the `Clickable` behavior and how it differs from `makeDraggable`.

- **`examples/clickable_objects.{ts,html}`** — a runnable demo: click the circle to cycle its color and a click counter (double-click resets, idempotently); drag the square to reposition it with a live coordinate label. Clicking never moves the circle; dragging never affects the circle — making the *click = action, drag = move* distinction obvious side-by-side.
- **Docs** — a "Clickable Objects" section in `docs/docs/examples/new.mdx` with an interactive `ClickableObjectsExample` component and a `Clickable` vs `Draggable` comparison table.
- **Test** — one regression test asserting a `Clickable` fires its callback without moving the mobject.

## Note on `scene.render()`

A static `Scene` (no updaters/animation) renders once and does **not** run a continuous loop — `Scene.wait()` only loops when `_needsPerFrameRendering()` is true. So `setColor`/`setText` from interaction callbacks won't repaint on their own. The callbacks therefore call `scene.render()` explicitly. (The existing draggable demo only repaints because its line `addUpdater` keeps the loop alive.)

## Testing

- `npx vitest run` → **6119 passed** (incl. the new test); `npm run typecheck` clean; `npx eslint src/ --max-warnings 0` clean.
- `npm run build` and the Docusaurus docs build both succeed.
- Verified live in a browser: clicks cycle color + counter, double-click resets, drag repositions the square + updates its label, and the circle stays put across drags.

## Review

Plan and implementation both reviewed with codex; findings folded in (explicit listener `dispose()`, symmetric contrast with a live position label, clearer button/heading copy, minimal non-redundant test).
