### PR TITLE
fix(transform): correct corner tangents when resampling with resamplePointList3D

### DIFF
--- a/src/core/VMobjectTransformAlignment.ts
+++ b/src/core/VMobjectTransformAlignment.ts
@@ -228,6 +228,20 @@ function locateOnChain(info: ChainArcInfo, arc: number): { curveIdx: number; t: 
   return { curveIdx, t: tForArcLength(info.tables[curveIdx], localArc) };
 }
 
+/**
+ * Like locateOnChain but snaps t≈1 to {curveIdx+1, t:0}.
+ * Used to obtain the *outgoing* tangent at a curve boundary: the tangent on
+ * the arriving side of the next curve rather than the departing side of the
+ * previous one.
+ */
+function locateOnChainSnapped(info: ChainArcInfo, arc: number): { curveIdx: number; t: number } {
+  const loc = locateOnChain(info, arc);
+  if (loc.t > 1 - 1e-9 && loc.curveIdx < info.curves.length - 1) {
+    return { curveIdx: loc.curveIdx + 1, t: 0 };
+  }
+  return loc;
+}
+
 /** Build a degenerate cubic chain consisting of `newCurveCount` zero-length pieces. */
 function makeDegenerateChain(point: number[], newCurveCount: number): number[][] {
   const out: number[][] = [[...point]];
@@ -286,27 +300,37 @@ function arcLengthResampleCubicChain(points: number[][], newCurveCount: number):
   const info = buildChainArcInfo(points);
   if (info.totalLen <= 0) return makeDegenerateChain(points[0], newCurveCount);
 
-  // Anchor positions and unit tangents at each new arc-length-uniform anchor.
+  // For each new anchor compute:
+  //   - its position on the original chain
+  //   - its *outgoing* tangent (used as h1 of the sub-cubic that departs from it)
+  //   - its *incoming* tangent (used as h2 of the sub-cubic that arrives at it)
+  // At smooth points these are equal.  At a sharp corner (e.g. a square vertex)
+  // they differ: the outgoing tangent is the direction of the arriving edge while
+  // the incoming tangent is the direction of the departing edge.  Using the wrong
+  // one produces handles that bulge outside the shape.
   const anchors: number[][] = [];
-  const tangents: number[][] = [];
+  const outgoingTangents: number[][] = []; // h1 of sub-cubic i  (departure direction)
+  const incomingTangents: number[][] = []; // h2 of sub-cubic i-1 (arrival direction)
   for (let i = 0; i <= newCurveCount; i++) {
     const arcAt = (i / newCurveCount) * info.totalLen;
-    const loc = locateOnChain(info, arcAt);
-    const c = info.curves[loc.curveIdx];
-    anchors.push(evalCubicBezier(c[0], c[1], c[2], c[3], loc.t));
-    tangents.push(unitTangentAt(c, loc.t));
+    const locIn = locateOnChain(info, arcAt); // t≈1 stays on current curve → incoming
+    const locOut = locateOnChainSnapped(info, arcAt); // t≈1 snaps to next curve  → outgoing
+    const c = info.curves[locOut.curveIdx];
+    anchors.push(evalCubicBezier(c[0], c[1], c[2], c[3], locOut.t));
+    outgoingTangents.push(unitTangentAt(info.curves[locOut.curveIdx], locOut.t));
+    incomingTangents.push(unitTangentAt(info.curves[locIn.curveIdx], locIn.t));
   }
 
   const out: number[][] = [[...anchors[0]]];
   for (let i = 0; i < newCurveCount; i++) {
-    const sLoc = locateOnChain(info, (i / newCurveCount) * info.totalLen);
-    const eLoc = locateOnChain(info, ((i + 1) / newCurveCount) * info.totalLen);
+    const sLoc = locateOnChainSnapped(info, (i / newCurveCount) * info.totalLen);
+    const eLoc = locateOnChainSnapped(info, ((i + 1) / newCurveCount) * info.totalLen);
     const { h1, h2 } = buildSubCubic(
       info,
       anchors[i],
       anchors[i + 1],
-      tangents[i],
-      tangents[i + 1],
+      outgoingTangents[i], // outgoing direction at start anchor
+      incomingTangents[i + 1], // incoming direction at end anchor
       sLoc,
       eLoc,
     );

--- a/src/core/vmobject.test.ts
+++ b/src/core/vmobject.test.ts
@@ -1254,6 +1254,60 @@ describe('VMobject._interpolatePointList3D (via alignPoints)', () => {
   });
 });
 
+describe('resamplePointList3D – corner-tangent regression', () => {
+  // A square in 3n+1 cubic-bezier format (4 straight-line segments, sideLength=2).
+  // Resampling it to 25 pts (ratio 2:1) places new anchors exactly on the original
+  // curve boundaries (the corners).  The bug: buildSubCubic used the wrong tangent
+  // at those boundaries, producing handles that bulge outside the square.
+  //
+  // For every straight-line segment the handles must lie on the segment itself,
+  // i.e. h1 = anchor_start + 1/3*(anchor_end - anchor_start) and similarly h2.
+  // We verify that every handle in the 25-pt result is collinear with its two
+  // surrounding anchors (within floating-point tolerance).
+
+  it('resampling a square 13→25 keeps all handles collinear with their anchors', () => {
+    const TL = [-1, 1, 0],
+      TR = [1, 1, 0],
+      BR = [1, -1, 0],
+      BL = [-1, -1, 0];
+    function seg(p0: number[], p1: number[]): number[][] {
+      return [
+        [p0[0] + (p1[0] - p0[0]) / 3, p0[1] + (p1[1] - p0[1]) / 3, 0],
+        [p0[0] + (2 * (p1[0] - p0[0])) / 3, p0[1] + (2 * (p1[1] - p0[1])) / 3, 0],
+        [...p1],
+      ];
+    }
+    const sq13 = [TL, ...seg(TL, TR), ...seg(TR, BR), ...seg(BR, BL), ...seg(BL, TL)];
+    expect(sq13.length).toBe(13);
+
+    const v1 = new VMobject();
+    v1.setPoints(sq13);
+    const v2 = new VMobject();
+    // 25-pt target to force resample (same count as a Python Circle with 8 arcs)
+    v2.setPoints(Array.from({ length: 25 }, (_, i) => [i, 0, 0]));
+
+    v1.alignPoints(v2);
+    const pts = v1.getLocalPoints();
+    expect(pts.length).toBe(25);
+
+    // Every triplet [anchor, h1, h2, anchor] must be collinear.
+    // Cross product of (h-anchor_start) × (anchor_end - anchor_start) must be ~0.
+    for (let i = 0; i + 3 < pts.length; i += 3) {
+      const a0 = pts[i],
+        h1 = pts[i + 1],
+        h2 = pts[i + 2],
+        a1 = pts[i + 3];
+      const edgeX = a1[0] - a0[0],
+        edgeY = a1[1] - a0[1];
+      // cross product z-component: edge × (h - a0)
+      const cross1 = edgeX * (h1[1] - a0[1]) - edgeY * (h1[0] - a0[0]);
+      const cross2 = edgeX * (h2[1] - a0[1]) - edgeY * (h2[0] - a0[0]);
+      expect(Math.abs(cross1)).toBeCloseTo(0, 10);
+      expect(Math.abs(cross2)).toBeCloseTo(0, 10);
+    }
+  });
+});
+
 describe('VMobject style optimization (no-op dirty checks)', () => {
   it('setStrokeOpacity does not mark dirty if value unchanged', () => {
     const v = new VMobject();


### PR DESCRIPTION
## Summary

Fix the resampling logic that was wrong for sharp turns like square.

## Changes
- src/core/VMobjectTransformAlignment.ts : handle start and end control points
- src/core/vmobject.test.ts : add non-regression test

## Testing
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Types check (`npm run typecheck`)

## Related Issues
Closes #445 

State after change:

<img width="936" height="417" alt="image" src="https://github.com/user-attachments/assets/e1b86d50-6c31-4666-8fae-a84381e04e56" />

