### PR TITLE
ci: raise Node heap for Docusaurus builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,5 +104,9 @@ jobs:
       - name: Build Docusaurus site
         run: npm run build
         working-directory: docs
+        env:
+          # typedoc over the full src tree pushes the build past Node's
+          # default old-space limit on runners (OOM, exit 134)
+          NODE_OPTIONS: --max-old-space-size=6144
       - name: Assert typia transform applied in docs bundle
         run: bash scripts/assert-docs-typia-transform.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,10 @@ jobs:
       - name: Build Docusaurus site
         run: npm run build
         working-directory: docs
+        env:
+          # typedoc over the full src tree pushes the build past Node's
+          # default old-space limit on runners (OOM, exit 134)
+          NODE_OPTIONS: --max-old-space-size=6144
 
       - name: Assert typia transform applied in docs bundle
         run: bash scripts/assert-docs-typia-transform.sh


### PR DESCRIPTION
## Summary

Post-merge `Deploy Docs` run on main ([27405807458](https://github.com/maloyan/manim-web/actions/runs/27405807458)) failed with exit 134:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

The identical docs build passed in PR #450's CI (12m47s), so the typedoc-over-`src/` Docusaurus build is sitting right at Node's default old-space ceiling and fails nondeterministically.

## Fix

Set `NODE_OPTIONS: --max-old-space-size=6144` on the "Build Docusaurus site" step in both `docs.yml` (Deploy Docs) and `ci.yml` (Docs build check). Runners have 16 GB; 6 GB of heap gives comfortable headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
