### PR TITLE
fix(geometry): sweep rounded-corner arcs clockwise to match path direction

### DIFF
--- a/examples/rounded_rectangle.html
+++ b/examples/rounded_rectangle.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ManimWeb - RoundedRectangle Example</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    body {
+      background: #1a1a2e;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      font-family: system-ui, sans-serif;
+    }
+    #container {
+      border: 2px solid #333;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+  </style>
+</head>
+<body>
+  <div id="container"></div>
+
+  <script type="module">
+    import {
+      Scene,
+      RoundedRectangle,
+      SurroundingRectangle,
+      Text,
+      BLUE,
+      GREEN,
+      RED,
+      YELLOW,
+      BLACK,
+    } from '../src/index.ts';
+
+    const container = document.getElementById('container');
+    const scene = new Scene(container, {
+      width: 800,
+      height: 450,
+      backgroundColor: BLACK,
+      backgroundOpacity: 1,
+    });
+
+    // The button from issue #434
+    const button = new RoundedRectangle({
+      width: 3,
+      height: 1,
+      cornerRadius: 0.15,
+      fillOpacity: 1,
+      strokeWidth: 0,
+      center: [-2.5, 1.5, 0],
+    });
+    button.fillColor = BLUE;
+
+    // Larger corner radius
+    const card = new RoundedRectangle({
+      width: 3,
+      height: 2,
+      cornerRadius: 0.5,
+      color: GREEN,
+      fillOpacity: 0.3,
+      center: [2.5, 1, 0],
+    });
+
+    // Pill shape (corner radius = half height)
+    const pill = new RoundedRectangle({
+      width: 4,
+      height: 1,
+      cornerRadius: 0.5,
+      color: RED,
+      fillOpacity: 0.5,
+      center: [-2, -1.5, 0],
+    });
+
+    // SurroundingRectangle with rounded corners
+    const label = new Text({ text: 'manim-web', fontSize: 36 });
+    label.shift([2.5, -1.5, 0]);
+    const frame = new SurroundingRectangle(label, {
+      buff: 0.25,
+      cornerRadius: 0.2,
+      color: YELLOW,
+    });
+
+    scene.add(button, card, pill, label, frame);
+    scene.render();
+  </script>
+</body>
+</html>

--- a/src/mobjects/geometry/PolygonExtensions.ts
+++ b/src/mobjects/geometry/PolygonExtensions.ts
@@ -84,25 +84,23 @@ export class RoundedRectangle extends VMobject {
     const kappa = (4 / 3) * Math.tan(Math.PI / 8);
 
     // Helper to add a line segment as cubic Bezier
-    const addLineSegment = (p0: number[], p1: number[], isFirst: boolean) => {
+    // (the segment's start anchor is the previous segment's end point)
+    const addLineSegment = (p0: number[], p1: number[]) => {
       const dx = p1[0] - p0[0];
       const dy = p1[1] - p0[1];
       const dz = p1[2] - p0[2];
 
-      if (isFirst) {
-        points.push([...p0]);
-      }
       points.push([p0[0] + dx / 3, p0[1] + dy / 3, p0[2] + dz / 3]);
       points.push([p0[0] + (2 * dx) / 3, p0[1] + (2 * dy) / 3, p0[2] + (2 * dz) / 3]);
       points.push([...p1]);
     };
 
-    // Helper to add a 90-degree arc at a corner
-    // arcCenter: center of the arc circle
-    // startAngle: starting angle in radians
+    // Helper to add a 90-degree arc at a corner.
+    // The path traverses the rectangle clockwise, so each arc sweeps
+    // clockwise from startAngle to startAngle - PI/2.
     const addCornerArc = (arcCenterX: number, arcCenterY: number, startAngle: number) => {
       const theta1 = startAngle;
-      const theta2 = startAngle + Math.PI / 2;
+      const theta2 = startAngle - Math.PI / 2;
 
       // Start point
       const x0 = arcCenterX + r * Math.cos(theta1);
@@ -112,16 +110,13 @@ export class RoundedRectangle extends VMobject {
       const x3 = arcCenterX + r * Math.cos(theta2);
       const y3 = arcCenterY + r * Math.sin(theta2);
 
-      // Control points using kappa
-      const dx1 = -Math.sin(theta1);
-      const dy1 = Math.cos(theta1);
-      const x1 = x0 + kappa * r * dx1;
-      const y1 = y0 + kappa * r * dy1;
+      // Control points using kappa; the unit tangent in the direction of
+      // (clockwise) travel at angle theta is (sin theta, -cos theta)
+      const x1 = x0 + kappa * r * Math.sin(theta1);
+      const y1 = y0 - kappa * r * Math.cos(theta1);
 
-      const dx2 = -Math.sin(theta2);
-      const dy2 = Math.cos(theta2);
-      const x2 = x3 - kappa * r * dx2;
-      const y2 = y3 - kappa * r * dy2;
+      const x2 = x3 - kappa * r * Math.sin(theta2);
+      const y2 = y3 + kappa * r * Math.cos(theta2);
 
       // Arc doesn't need first point (connected from previous segment)
       points.push([x1, y1, cz]);
@@ -129,7 +124,6 @@ export class RoundedRectangle extends VMobject {
       points.push([x3, y3, cz]);
     };
 
-    // Start from top edge (after top-left corner arc ends)
     // Top-left corner arc center
     const tlX = cx - halfWidth + r;
     const tlY = cy + halfHeight - r;
@@ -146,15 +140,15 @@ export class RoundedRectangle extends VMobject {
     const blX = cx - halfWidth + r;
     const blY = cy - halfHeight + r;
 
-    // Start at top-left corner (end of top-left arc = top of left edge)
+    // Start at the top of the left edge (start of the top-left arc)
     const startX = cx - halfWidth;
     const startY = cy + halfHeight - r;
 
     // Build path: top-left arc -> top edge -> top-right arc -> right edge ->
     // bottom-right arc -> bottom edge -> bottom-left arc -> left edge (close)
 
-    // Top-left corner arc (starts at left, goes to top) - 180 to 270 degrees (or PI to 3PI/2)
-    // Actually starts from left side going up: angle PI to PI/2
+    // Top-left corner arc starts from the left side going up:
+    // angle PI sweeping clockwise to PI/2
     const arcStart = Math.PI;
 
     // First point (start of top-left arc)
@@ -164,25 +158,25 @@ export class RoundedRectangle extends VMobject {
     addCornerArc(tlX, tlY, arcStart);
 
     // Top edge (from top-left corner end to top-right corner start)
-    addLineSegment([tlX, cy + halfHeight, cz], [trX, cy + halfHeight, cz], false);
+    addLineSegment([tlX, cy + halfHeight, cz], [trX, cy + halfHeight, cz]);
 
     // Top-right corner arc (from top going to right)
     addCornerArc(trX, trY, Math.PI / 2);
 
     // Right edge
-    addLineSegment([cx + halfWidth, trY, cz], [cx + halfWidth, brY, cz], false);
+    addLineSegment([cx + halfWidth, trY, cz], [cx + halfWidth, brY, cz]);
 
     // Bottom-right corner arc (from right going to bottom)
     addCornerArc(brX, brY, 0);
 
     // Bottom edge
-    addLineSegment([brX, cy - halfHeight, cz], [blX, cy - halfHeight, cz], false);
+    addLineSegment([brX, cy - halfHeight, cz], [blX, cy - halfHeight, cz]);
 
     // Bottom-left corner arc (from bottom going to left)
     addCornerArc(blX, blY, -Math.PI / 2);
 
     // Left edge (closes the shape)
-    addLineSegment([cx - halfWidth, blY, cz], [cx - halfWidth, tlY, cz], false);
+    addLineSegment([cx - halfWidth, blY, cz], [cx - halfWidth, tlY, cz]);
 
     this.setPoints3D(points);
   }

--- a/src/mobjects/geometry/ShapeMatchers.ts
+++ b/src/mobjects/geometry/ShapeMatchers.ts
@@ -289,7 +289,6 @@ export class SurroundingRectangle extends VMobject {
     // Magic number for approximating circular arc with cubic Bezier
     const k = 0.5522847498;
 
-    // Start at top-left corner, after the curve
     // Top-left corner arc center
     const tlCx = cx - halfWidth + r;
     const tlCy = cy + halfHeight - r;
@@ -306,24 +305,24 @@ export class SurroundingRectangle extends VMobject {
     const blCx = cx - halfWidth + r;
     const blCy = cy - halfHeight + r;
 
-    // Helper to add arc from angle1 to angle2
-    const addArc = (arcCx: number, arcCy: number, startAngle: number, isFirst: boolean) => {
-      // Each corner is a 90-degree arc
+    // Helper to add a 90-degree corner arc. The path traverses the
+    // rectangle clockwise, so each arc sweeps clockwise from startAngle
+    // to startAngle - PI/2.
+    const addArc = (arcCx: number, arcCy: number, startAngle: number) => {
+      const endAngle = startAngle - Math.PI / 2;
       const cosStart = Math.cos(startAngle);
       const sinStart = Math.sin(startAngle);
-      const cosEnd = Math.cos(startAngle + Math.PI / 2);
-      const sinEnd = Math.sin(startAngle + Math.PI / 2);
+      const cosEnd = Math.cos(endAngle);
+      const sinEnd = Math.sin(endAngle);
 
       const p0: number[] = [arcCx + r * cosStart, arcCy + r * sinStart, cz];
       const p3: number[] = [arcCx + r * cosEnd, arcCy + r * sinEnd, cz];
 
-      // Control points for quarter circle
-      const p1: number[] = [p0[0] - k * r * sinStart, p0[1] + k * r * cosStart, cz];
-      const p2: number[] = [p3[0] + k * r * sinEnd, p3[1] - k * r * cosEnd, cz];
+      // Control points for quarter circle; the unit tangent in the
+      // direction of (clockwise) travel at angle theta is (sin theta, -cos theta)
+      const p1: number[] = [p0[0] + k * r * sinStart, p0[1] - k * r * cosStart, cz];
+      const p2: number[] = [p3[0] - k * r * sinEnd, p3[1] + k * r * cosEnd, cz];
 
-      if (isFirst) {
-        points.push([...p0]);
-      }
       points.push([...p1], [...p2], [...p3]);
     };
 
@@ -338,26 +337,31 @@ export class SurroundingRectangle extends VMobject {
       points.push([...p1]);
     };
 
-    // Top-left arc (starts pointing up, 90 degrees)
-    addArc(tlCx, tlCy, Math.PI / 2, true);
+    // Clockwise path starting at the top of the left edge:
+    // TL arc, top edge, TR arc, right edge, BR arc, bottom edge,
+    // BL arc, left edge (closing)
+    points.push([cx - halfWidth, tlCy, cz]);
+
+    // Top-left arc (from left side going to top: PI -> PI/2)
+    addArc(tlCx, tlCy, Math.PI);
 
     // Top edge
     addLine([tlCx, cy + halfHeight, cz], [trCx, cy + halfHeight, cz]);
 
-    // Top-right arc (starts pointing right, 0 degrees)
-    addArc(trCx, trCy, 0, false);
+    // Top-right arc (from top going to right: PI/2 -> 0)
+    addArc(trCx, trCy, Math.PI / 2);
 
     // Right edge
     addLine([cx + halfWidth, trCy, cz], [cx + halfWidth, brCy, cz]);
 
-    // Bottom-right arc (starts pointing down, -90 degrees)
-    addArc(brCx, brCy, -Math.PI / 2, false);
+    // Bottom-right arc (from right going to bottom: 0 -> -PI/2)
+    addArc(brCx, brCy, 0);
 
     // Bottom edge
     addLine([brCx, cy - halfHeight, cz], [blCx, cy - halfHeight, cz]);
 
-    // Bottom-left arc (starts pointing left, 180 degrees)
-    addArc(blCx, blCy, Math.PI, false);
+    // Bottom-left arc (from bottom going to left: -PI/2 -> -PI)
+    addArc(blCx, blCy, -Math.PI / 2);
 
     // Left edge (closing)
     addLine([cx - halfWidth, blCy, cz], [cx - halfWidth, tlCy, cz]);

--- a/src/mobjects/geometry/geometry-algorithms.test.ts
+++ b/src/mobjects/geometry/geometry-algorithms.test.ts
@@ -332,6 +332,85 @@ describe('SurroundingRectangle', () => {
     expect(rounded.getLocalPoints().length).toBeGreaterThan(sharp.getLocalPoints().length);
   });
 
+  // Regression test for the same corner-arc sweep bug as issue #434:
+  // arcs swept counterclockwise while the path runs clockwise.
+  it('rounded corner anchors land on the edge tangent points (issue #434)', () => {
+    const target = new Rectangle({ width: 4, height: 2 });
+    // Outer rect: 4.5 x 2.5 centered at origin, r = 0.3
+    const sr = new SurroundingRectangle(target, { buff: 0.25, cornerRadius: 0.3 });
+    const pts = sr.getLocalPoints();
+    const anchors: number[][] = [];
+    for (let i = 0; i < pts.length; i += 3) anchors.push(pts[i]);
+
+    const expected = [
+      [-2.25, 0.95],
+      [-1.95, 1.25],
+      [1.95, 1.25],
+      [2.25, 0.95],
+      [2.25, -0.95],
+      [1.95, -1.25],
+      [-1.95, -1.25],
+      [-2.25, -0.95],
+      [-2.25, 0.95],
+    ];
+    expect(anchors.length).toBe(expected.length);
+    expected.forEach(([x, y], i) => {
+      expect(anchors[i][0]).toBeCloseTo(x, 10);
+      expect(anchors[i][1]).toBeCloseTo(y, 10);
+    });
+
+    // No point may leave the surrounding rectangle's bounds
+    for (const p of pts) {
+      expect(Math.abs(p[0])).toBeLessThanOrEqual(2.25 + 1e-9);
+      expect(Math.abs(p[1])).toBeLessThanOrEqual(1.25 + 1e-9);
+    }
+  });
+
+  it('rounded corner arcs bulge outward and are tangent to the edges (issue #434)', () => {
+    const r = 0.3;
+    const target = new Rectangle({ width: 4, height: 2 });
+    const sr = new SurroundingRectangle(target, { buff: 0.25, cornerRadius: r });
+    const pts = sr.getLocalPoints();
+
+    const bezier = (p0: number[], p1: number[], p2: number[], p3: number[], t: number) => {
+      const u = 1 - t;
+      return [0, 1].map(
+        (k) =>
+          u * u * u * p0[k] + 3 * u * u * t * p1[k] + 3 * u * t * t * p2[k] + t * t * t * p3[k],
+      );
+    };
+    const unit = (from: number[], to: number[]) => {
+      const dx = to[0] - from[0];
+      const dy = to[1] - from[1];
+      const len = Math.hypot(dx, dy);
+      return [dx / len, dy / len];
+    };
+
+    const d = Math.SQRT1_2;
+    // [segment start index, arc center, outward 45° direction, in-tangent, out-tangent]
+    const arcs: [number, number[], number[], number[], number[]][] = [
+      [0, [-1.95, 0.95], [-d, d], [0, 1], [1, 0]], // top-left
+      [6, [1.95, 0.95], [d, d], [1, 0], [0, -1]], // top-right
+      [12, [1.95, -0.95], [d, -d], [0, -1], [-1, 0]], // bottom-right
+      [18, [-1.95, -0.95], [-d, -d], [-1, 0], [0, 1]], // bottom-left
+    ];
+
+    for (const [s, center, dir, tIn, tOut] of arcs) {
+      // Arc midpoint sits on the corner circle at 45° outward
+      const mid = bezier(pts[s], pts[s + 1], pts[s + 2], pts[s + 3], 0.5);
+      expect(mid[0]).toBeCloseTo(center[0] + r * dir[0], 4);
+      expect(mid[1]).toBeCloseTo(center[1] + r * dir[1], 4);
+
+      // Control points pin the tangent directions to the adjacent edges
+      const startTangent = unit(pts[s], pts[s + 1]);
+      const endTangent = unit(pts[s + 2], pts[s + 3]);
+      expect(startTangent[0]).toBeCloseTo(tIn[0], 10);
+      expect(startTangent[1]).toBeCloseTo(tIn[1], 10);
+      expect(endTangent[0]).toBeCloseTo(tOut[0], 10);
+      expect(endTangent[1]).toBeCloseTo(tOut[1], 10);
+    }
+  });
+
   it('respects custom color and works with Circle target', () => {
     const rect = new Rectangle({ width: 2, height: 2 });
     expect(new SurroundingRectangle(rect, { color: '#ff0000' }).color.toLowerCase()).toBe(

--- a/src/mobjects/geometry/geometry-polygons.test.ts
+++ b/src/mobjects/geometry/geometry-polygons.test.ts
@@ -329,6 +329,152 @@ describe('RoundedRectangle', () => {
     const rr = new RoundedRectangle();
     expect(rr.numPoints).toBeGreaterThan(0);
   });
+
+  // Regression tests for issue #434: corners rendered as "curved spikes"
+  // because the corner arcs swept counterclockwise while the path
+  // traverses the rectangle clockwise.
+  describe('corner geometry (issue #434)', () => {
+    // Evaluate a cubic Bezier segment at parameter t
+    const bezier = (p0: number[], p1: number[], p2: number[], p3: number[], t: number) => {
+      const u = 1 - t;
+      return [0, 1].map(
+        (k) =>
+          u * u * u * p0[k] + 3 * u * u * t * p1[k] + 3 * u * t * t * p2[k] + t * t * t * p3[k],
+      );
+    };
+
+    it('anchor points land on the edge tangent points of all 4 corners', () => {
+      const rr = new RoundedRectangle({ width: 3, height: 1, cornerRadius: 0.15 });
+      const pts = rr.getLocalPoints();
+      const anchors: number[][] = [];
+      for (let i = 0; i < pts.length; i += 3) anchors.push(pts[i]);
+
+      // Clockwise path: TL arc, top edge, TR arc, right edge,
+      // BR arc, bottom edge, BL arc, left edge (close)
+      const expected = [
+        [-1.5, 0.35],
+        [-1.35, 0.5],
+        [1.35, 0.5],
+        [1.5, 0.35],
+        [1.5, -0.35],
+        [1.35, -0.5],
+        [-1.35, -0.5],
+        [-1.5, -0.35],
+        [-1.5, 0.35],
+      ];
+      expect(anchors.length).toBe(expected.length);
+      expected.forEach(([x, y], i) => {
+        expect(anchors[i][0]).toBeCloseTo(x, 10);
+        expect(anchors[i][1]).toBeCloseTo(y, 10);
+      });
+    });
+
+    it('all points (anchors and controls) stay within the rectangle bounds', () => {
+      const rr = new RoundedRectangle({ width: 3, height: 1, cornerRadius: 0.15 });
+      for (const p of rr.getLocalPoints()) {
+        expect(Math.abs(p[0])).toBeLessThanOrEqual(1.5 + 1e-9);
+        expect(Math.abs(p[1])).toBeLessThanOrEqual(0.5 + 1e-9);
+      }
+    });
+
+    it('corner arc midpoints bulge outward at 45 degrees from the arc centers', () => {
+      const r = 0.15;
+      const rr = new RoundedRectangle({ width: 3, height: 1, cornerRadius: r });
+      const pts = rr.getLocalPoints();
+      const d = Math.SQRT1_2; // cos(45°) = sin(45°)
+
+      // [segment start index, arc center, outward 45° direction]
+      const arcs: [number, number[], number[]][] = [
+        [0, [-1.35, 0.35], [-d, d]], // top-left
+        [6, [1.35, 0.35], [d, d]], // top-right
+        [12, [1.35, -0.35], [d, -d]], // bottom-right
+        [18, [-1.35, -0.35], [-d, -d]], // bottom-left
+      ];
+
+      for (const [s, center, dir] of arcs) {
+        const mid = bezier(pts[s], pts[s + 1], pts[s + 2], pts[s + 3], 0.5);
+        expect(mid[0]).toBeCloseTo(center[0] + r * dir[0], 4);
+        expect(mid[1]).toBeCloseTo(center[1] + r * dir[1], 4);
+      }
+    });
+
+    it('corner arcs are tangent to the adjacent edges', () => {
+      // The Bezier midpoint is symmetric in the two control points, so it
+      // cannot detect swapped or inward-bowing controls. Pin the start/end
+      // tangent directions instead: each arc must leave its start anchor
+      // along the incoming edge and reach its end anchor along the outgoing
+      // edge of the clockwise path.
+      const rr = new RoundedRectangle({ width: 3, height: 1, cornerRadius: 0.15 });
+      const pts = rr.getLocalPoints();
+
+      const unit = (from: number[], to: number[]) => {
+        const dx = to[0] - from[0];
+        const dy = to[1] - from[1];
+        const len = Math.hypot(dx, dy);
+        return [dx / len, dy / len];
+      };
+
+      // [segment start index, in-tangent, out-tangent] for the clockwise path
+      const arcs: [number, number[], number[]][] = [
+        [0, [0, 1], [1, 0]], // top-left: up the left edge, out along top edge
+        [6, [1, 0], [0, -1]], // top-right
+        [12, [0, -1], [-1, 0]], // bottom-right
+        [18, [-1, 0], [0, 1]], // bottom-left
+      ];
+
+      for (const [s, tIn, tOut] of arcs) {
+        const startTangent = unit(pts[s], pts[s + 1]);
+        const endTangent = unit(pts[s + 2], pts[s + 3]);
+        expect(startTangent[0]).toBeCloseTo(tIn[0], 10);
+        expect(startTangent[1]).toBeCloseTo(tIn[1], 10);
+        expect(endTangent[0]).toBeCloseTo(tOut[0], 10);
+        expect(endTangent[1]).toBeCloseTo(tOut[1], 10);
+      }
+    });
+
+    it('path is closed', () => {
+      const rr = new RoundedRectangle({ width: 3, height: 1, cornerRadius: 0.15 });
+      const pts = rr.getLocalPoints();
+      const first = pts[0];
+      const last = pts[pts.length - 1];
+      expect(last[0]).toBeCloseTo(first[0], 10);
+      expect(last[1]).toBeCloseTo(first[1], 10);
+    });
+
+    it('cornerRadius 0 degenerates to sharp corners at the rectangle vertices', () => {
+      const rr = new RoundedRectangle({ width: 3, height: 1, cornerRadius: 0 });
+      const corners = [
+        [-1.5, 0.5],
+        [1.5, 0.5],
+        [1.5, -0.5],
+        [-1.5, -0.5],
+      ];
+      for (let i = 0; i < rr.getLocalPoints().length; i += 3) {
+        const a = rr.getLocalPoints()[i];
+        const onCorner = corners.some(
+          ([x, y]) => Math.abs(a[0] - x) < 1e-9 && Math.abs(a[1] - y) < 1e-9,
+        );
+        expect(onCorner).toBe(true);
+      }
+    });
+
+    it('pill shape (radius = half height) reaches the left/right extremes at y=0', () => {
+      const rr = new RoundedRectangle({ width: 4, height: 1, cornerRadius: 0.5 });
+      const anchors: number[][] = [];
+      const pts = rr.getLocalPoints();
+      for (let i = 0; i < pts.length; i += 3) anchors.push(pts[i]);
+
+      const hasLeft = anchors.some((a) => Math.abs(a[0] + 2) < 1e-9 && Math.abs(a[1]) < 1e-9);
+      const hasRight = anchors.some((a) => Math.abs(a[0] - 2) < 1e-9 && Math.abs(a[1]) < 1e-9);
+      expect(hasLeft).toBe(true);
+      expect(hasRight).toBe(true);
+
+      for (const p of pts) {
+        expect(Math.abs(p[0])).toBeLessThanOrEqual(2 + 1e-9);
+        expect(Math.abs(p[1])).toBeLessThanOrEqual(0.5 + 1e-9);
+      }
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #434 — `RoundedRectangle` corners rendered as "curved spikes" instead of rounded arcs.

**Root cause:** both `RoundedRectangle` (`PolygonExtensions.ts`) and `SurroundingRectangle` (`ShapeMatchers.ts`) build their outline paths **clockwise** (left edge up → top edge right → …), but the corner-arc helpers swept each 90° arc **counterclockwise** (`theta2 = startAngle + PI/2`). Every arc ended 90° on the wrong side of its start point, so the cubic-Bezier chain anchors mismatched the edge segments' control points — producing the spikes in the issue screenshot.

**Fix:** arcs now sweep clockwise (`theta2 = startAngle - PI/2`) with control points along the travel-direction tangent `T(θ) = (sin θ, −cos θ)`. `SurroundingRectangle`'s rounded path was restructured to start at the top of the left edge, matching `RoundedRectangle`.

## Behavior note

`SurroundingRectangle`'s rounded-path first anchor moves from the top of the top-left corner to the left side of that corner. Audited all in-repo consumers (hit testing, `DiceFace`, examples, docs) — none depend on the previous start point, and `Transform` resamples with winding/rotation matching so cross-shape transforms degrade gracefully.

## Tests

Previous tests only asserted point counts, which is how this slipped through. New regression tests pin:

- exact anchor coordinates at all 4 corner/edge tangent points (both classes)
- bounding-box containment of all points
- 45° arc midpoints on the corner circles
- arc start/end tangent directions matching the adjacent edges (the midpoint alone is symmetric in the control points and misses swapped or inward-bowing controls)
- closed path, `cornerRadius: 0`, and pill-shape clamping

All four hand-applied mutants (CCW sweep, CCW tangents, swapped controls in either class) now fail the suite; full suite is green (6134 tests).

## Visual result

`examples/rounded_rectangle.html` (new) renders the issue's button plus a card, pill, and rounded `SurroundingRectangle`:

| Before | After |
|---|---|
| curved-spike corners (see issue screenshot) | properly rounded corners |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
